### PR TITLE
fix(rpc): rescan already-scanned range when z_importkey re-imports a known key with rescan=yes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- `z_importkey` with `rescan="yes"` now re-scans when the key is already known to
+  the wallet; previously it scanned nothing. The account's birthday is lowered to
+  `startHeight`, so the rescan reaches blocks below the wallet's previous earliest
+  birthday. This rewinds the **entire wallet** to `startHeight`: the note commitment
+  trees are shared, so every account re-scans from there.
+
 ## [0.1.0-beta.3] - 2026-08-24
 
 ### Added

--- a/zallet-core/src/components/json_rpc/methods/import_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_key.rs
@@ -124,11 +124,6 @@ pub(crate) async fn call<C: Chain>(
         //   historical blocks from that point.
         // - "no" → use the current chain tip so the sync engine only tracks new
         //   transactions going forward.
-        //
-        // TODO: When rescan is "yes" and the key already exists, zcashd would force a
-        // rescan from start_height. `WalletWrite::rewind_to_height` could now drive this,
-        // but it rewinds the *entire* wallet (every account) rather than just this key, so
-        // we defer wiring it up until that global side effect is the desired behaviour.
         let effective_height = match rescan {
             "yes" | "whenkeyisnew" => start_height,
             "no" => chain_tip.unwrap_or_else(|| {
@@ -161,6 +156,14 @@ pub(crate) async fn call<C: Chain>(
                 "sync engine has shut down; imported key won't be scanned until restart"
             );
         }
+    } else if rescan == "yes" {
+        // The key is already known but the caller requested a rescan: truncate to just before
+        // `start_height` so the sync engine re-scans `start_height..=tip`. Use `truncate_to_height`,
+        // not the account-scoped `rewind_to_chain_state` — the latter doesn't snap to a shared
+        // Sapling/Orchard checkpoint and corrupts the DB on a deep rewind (integration-tests #76).
+        wallet
+            .truncate_to_height(start_height.saturating_sub(1))
+            .map_err(|e| LegacyCode::Misc.with_message(format!("Rescan failed: {e}")))?;
     }
 
     Ok(ResultType {

--- a/zallet-core/src/components/json_rpc/methods/import_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_key.rs
@@ -1,8 +1,12 @@
+use std::collections::HashSet;
+
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_client_backend::data_api::{AccountPurpose, WalletRead, WalletWrite};
+use zcash_client_backend::data_api::{
+    Account, AccountPurpose, WalletRead, WalletWrite, error::RewindError,
+};
 use zcash_client_sqlite::error::SqliteClientError;
 use zcash_keys::{encoding::decode_extended_spending_key, keys::UnifiedFullViewingKey};
 use zcash_protocol::consensus::{BlockHeight, NetworkConstants};
@@ -44,6 +48,13 @@ fn validate_rescan(rescan: Option<&str>) -> RpcResult<&str> {
         Some(_) => Err(LegacyCode::InvalidParameter
             .with_static("Invalid rescan value. Must be \"yes\", \"no\", or \"whenkeyisnew\".")),
     }
+}
+
+/// Whether re-importing an already-known key should rewind the wallet to rescan.
+///
+/// A new key needs no rewind: its account import already queues the birthday range.
+fn should_rescan_existing_key(is_new_key: bool, rescan: &str) -> bool {
+    !is_new_key && rescan == "yes"
 }
 
 /// Decodes a Sapling extended spending key and derives the default payment address.
@@ -131,10 +142,10 @@ pub(crate) async fn call<C: Chain>(
         .map_err(|e| LegacyCode::Wallet.with_message(e.to_string()))?;
 
     // Check if the key is already known to the wallet.
-    let is_new_key = wallet
+    let existing_account = wallet
         .get_account_for_ufvk(&ufvk)
-        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-        .is_none();
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+    let is_new_key = existing_account.is_none();
 
     // For a new key, resolve its birthday before opening the transaction, since the birthday
     // fetch is async and may query the chain.
@@ -144,11 +155,6 @@ pub(crate) async fn call<C: Chain>(
         //   historical blocks from that point.
         // - "no" → use the current chain tip so the sync engine only tracks new
         //   transactions going forward.
-        //
-        // TODO: When rescan is "yes" and the key already exists, zcashd would force a
-        // rescan from start_height. `WalletWrite::rewind_to_height` could now drive this,
-        // but it rewinds the *entire* wallet (every account) rather than just this key, so
-        // we defer wiring it up until that global side effect is the desired behaviour.
         let effective_height = match rescan {
             "yes" | "whenkeyisnew" => start_height,
             "no" => chain_tip.unwrap_or_else(|| {
@@ -165,6 +171,16 @@ pub(crate) async fn call<C: Chain>(
             LegacyCode::Database.with_message(format!("Failed to obtain a chain snapshot: {e}"))
         })?;
         Some(fetch_account_birthday(&chain_view, effective_height, None).await?)
+    } else {
+        None
+    };
+
+    // Resolved before the transaction for the same reason as the birthday above: async.
+    let rewind_to = if should_rescan_existing_key(is_new_key, rescan) {
+        let chain_view = chain.snapshot().await.map_err(|e| {
+            LegacyCode::Database.with_message(format!("Failed to obtain a chain snapshot: {e}"))
+        })?;
+        Some(fetch_account_birthday(&chain_view, start_height, None).await?)
     } else {
         None
     };
@@ -204,6 +220,27 @@ pub(crate) async fn call<C: Chain>(
             ImportError::Database(e) => LegacyCode::Database.with_message(e.to_string()),
             ImportError::Keystore(e) => LegacyCode::Wallet.with_message(e.to_string()),
         })?;
+
+    // Rewind to just before `start_height` and lower this account's birthday to it, so the
+    // sync engine re-scans `start_height..=tip`. `truncate_to_height` cannot do this: scan
+    // ranges are floored at `MIN(birthday_height)` across all accounts. The commitment trees
+    // are shared, so every account re-scans; only this account's birthday moves.
+    if let (Some(account), Some(birthday)) = (&existing_account, &rewind_to) {
+        wallet
+            .rewind_to_chain_state(
+                birthday.prior_chain_state().clone(),
+                HashSet::from([account.id()]),
+            )
+            .map_err(|e| match e {
+                RewindError::RewindBeyondBirthdays(_) => LegacyCode::InvalidParameter
+                    .with_message(format!("Cannot rescan from height {start_height}.")),
+                RewindError::DataSource(e) => {
+                    LegacyCode::Database.with_message(format!("Rescan failed: {e}"))
+                }
+                // `RewindError` is `#[non_exhaustive]`; don't blame the caller for new variants.
+                _ => LegacyCode::Database.with_static("Rescan failed."),
+            })?;
+    }
 
     // Reload viewing keys so the key is scanned without a restart. Run this unconditionally:
     // a re-import must be able to repair an account the sync engine never loaded. Don't wait
@@ -260,6 +297,42 @@ mod tests {
         assert!(validate_rescan(Some("always")).is_err());
         assert!(validate_rescan(Some("")).is_err());
         assert!(validate_rescan(Some("true")).is_err());
+    }
+
+    // -- should_rescan_existing_key tests --
+
+    // The only combination that rewinds; the other arms keep the prior no-op behaviour.
+    #[test]
+    fn known_key_with_rescan_yes_rewinds() {
+        assert!(should_rescan_existing_key(false, "yes"));
+    }
+
+    #[test]
+    fn new_key_never_rewinds() {
+        for rescan in ["yes", "no", "whenkeyisnew"] {
+            assert!(
+                !should_rescan_existing_key(true, rescan),
+                "a new key must not rewind (rescan={rescan})",
+            );
+        }
+    }
+
+    #[test]
+    fn known_key_without_rescan_yes_does_not_rewind() {
+        assert!(!should_rescan_existing_key(false, "no"));
+        assert!(!should_rescan_existing_key(false, "whenkeyisnew"));
+    }
+
+    // Guards the matrix above against `validate_rescan` accepting a new value.
+    #[test]
+    fn every_validated_rescan_value_is_covered() {
+        for rescan in [None, Some("yes"), Some("no"), Some("whenkeyisnew")] {
+            let validated = validate_rescan(rescan).unwrap();
+            assert!(
+                ["yes", "no", "whenkeyisnew"].contains(&validated),
+                "unhandled rescan value {validated:?}",
+            );
+        }
     }
 
     // -- decode_key_and_address tests --


### PR DESCRIPTION
Closes #578.

Follow-up to #579 (merged), which made key imports scan **going forward** without a restart. #578 is the other half: re-importing an **already-known** key with `rescan="yes"` did nothing (`z_importkey` short-circuits on `is_new_key`). New keys are already covered by the account import queuing their birthday range; this wires up the existing-key path.

**What changed** (`import_key.rs`): when the key is already known and `rescan="yes"`, rewind to the chain state just before `startHeight` and reset *that account's* birthday to it, so the sync engine re-scans `startHeight..=tip` and finds notes in blocks that were scanned before this key was known. This reuses the same `fetch_account_birthday` → `rewind_to_chain_state` path the new-key import already goes through, rather than introducing a second mechanism.

**Why `rewind_to_chain_state` and not `truncate_to_height`.** An earlier revision of this PR used `truncate_to_height`, because at librustzcash `29c7fb2` `rewind_to_chain_state` did not snap its truncation target to a checkpoint shared by all pools — it asserted they matched and failed with *"Data DB is corrupted: Sapling and Orchard should have the same checkpoints"*. **That is fixed upstream.** At the currently pinned `1f6bb20` it computes a `window_floor` as the minimum over every active pool (Sapling / Orchard / Ironwood) of `min_checkpoint_id_at_or_above` (`zcash_client_sqlite/src/wallet.rs:4866-4884`), with dedicated tests for straddling and lagging pool checkpoints.

That matters because `truncate_to_height` **cannot lower an account's birthday**, and suggested scan ranges are floored at `MIN(birthday_height)` across *all* accounts (`wallet.rs:3240`, `wallet/scanning.rs:649`). That floor exists because account creation requires a tree frontier (`scanning.rs:645-648`). So a plain truncation below the wallet birthday is either clipped or rejected — which is exactly the case #578 leads with ("imported with an earlier birthday"). It also made the documented default `startHeight=0` fail with a bare `-1 "Rescan failed"`, since `select_truncation_height` needs a `blocks` row at or below the target and none exists at height 0.

**Behaviour notes:**
- This is a **wallet-wide** rewind: the note commitment trees are shared across accounts, so every account re-scans from `startHeight`. Only the re-imported account's birthday is lowered.
- A rewind that would land below every account's birthday without acknowledgement returns `RewindBeyondBirthdays`; that is mapped to `-8` (invalid parameter) rather than a generic failure.

**Testing.** `cargo check` / `fmt` / `clippy` clean; 388 unit tests pass, including 4 new ones covering the `(is_new_key, rescan)` decision matrix extracted as `should_rescan_existing_key`.

End-to-end against zcash/integration-tests#76 (`wallet_import_export_key.py`, branch `export-import-key-test`) on regtest with `zebrad 6.0.0-rc.0`: **this PR's scenario passes.** Instrumenting the run to print raw `z_getbalances`, the re-imported account reports `sapling.spendable.valueZat = 100000000` within ~20s of `z_importkey(key, "yes", funding_height)`, with `wallet_tip = fully_synced_height`, stable across repeated polls. The account birthday is correctly lowered (124 → 123) and the previously-missed note is attributed to it.

⚠️ **The full IT#76 run still fails, in a later phase, on #588 — not on this change.** After the fresh-import phase the wallet is left with `blocks` at 1..145 while the node is at 245, and a `Historic(144..245)` scan range that is never serviced: `recover_history` only handles ranges below the `tip - 100` boundary, and `steady_state` never consults the scan queue. **This reproduces identically with a build of this branch's previous `truncate_to_height` revision, and is unchanged at both a 450s and a 1200s timeout** (stuck, not slow) — so it is a pre-existing sync bug, not a regression from this PR. It matches #588, where a rewind-installed `Historic` range lands in a band that `recover_history` (bounded below `tip - 100`) will not service and that `steady_state` never looks at, because it follows an in-memory tip rather than the scan queue.

The practical consequence for this PR: any RPC-driven rescan currently leaves the `(tip - 100, tip]` band unscanned until #588 is fixed. `rescan="yes"` on a known key is still a strict improvement over the current behaviour of doing nothing at all.

_(Note: the previous revision of this description claimed IT#76 was fully green. That was measured against librustzcash `29c7fb2` before the pin moved, and no longer holds; it has been corrected above.)_

ZIT-Revision: export-import-key-test
