### PR TITLE
Bump librustzcash pin to include ZeWIF keypool-exposure fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
 ]
@@ -5750,7 +5750,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5763,7 +5763,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5813,7 +5813,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "corez",
  "hex",
@@ -5902,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5978,7 +5978,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6008,7 +6008,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6043,7 +6043,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "corez",
  "document-features",
@@ -6106,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bip32",
  "bs58",
@@ -6285,7 +6285,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,18 +165,18 @@ tonic = "0.14"
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7014,7 +7014,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7027,7 +7027,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7077,7 +7077,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "corez",
  "hex",
@@ -7177,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7253,7 +7253,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7283,7 +7283,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7318,7 +7318,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "corez",
  "document-features",
@@ -7381,7 +7381,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bip32",
  "bs58",
@@ -7835,7 +7835,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -73,18 +73,18 @@ tempfile = "3"
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
 # which surfaces the Ironwood (NU6.3) note commitment treestate from

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6593,7 +6593,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6606,7 +6606,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6656,7 +6656,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6704,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "corez",
  "hex",
@@ -6756,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6832,7 +6832,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6862,7 +6862,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6897,7 +6897,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "corez",
  "document-features",
@@ -6960,7 +6960,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "bip32",
  "bs58",
@@ -7414,7 +7414,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=f45d49b32392b9aed7ef017047b3995fe5fd6044#f45d49b32392b9aed7ef017047b3995fe5fd6044"
+source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -76,18 +76,18 @@ tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "f45d49b32392b9aed7ef017047b3995fe5fd6044" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [


### PR DESCRIPTION
Depends on https://github.com/zcash/librustzcash/pull/2666

Updates librustzcash pin to pull in fixes to the ZeWIF importer.

Closes https://github.com/zcash/zallet/issues/637
[COR-1588](https://linear.app/zodl/issue/COR-1588)