### PR TITLE
ci: resolve zizmor high-severity findings

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         id: toolchain
       - run: rustup override set "${TOOLCHAIN}"
         env:

--- a/.github/workflows/binaries-and-deb-release.yml
+++ b/.github/workflows/binaries-and-deb-release.yml
@@ -178,7 +178,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust stable toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Install build tooling
         run: |
@@ -196,7 +196,7 @@ jobs:
             wget
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
         id: toolchain
       - run: rustup override set ${RUST_TOOLCHAIN}
         shell: bash
@@ -223,6 +223,10 @@ jobs:
           private-key: ${{ secrets.DISPATCH_APP_PRIVATE_KEY }}
           owner: zcash
           repositories: integration-tests
+          # Scope the installation token to the minimum needed to POST a
+          # repository_dispatch event (below), instead of inheriting the app's
+          # full installation permissions.
+          permission-contents: write
 
       - name: Get requested test branch, if any
         id: test-branch

--- a/.github/workflows/lints.yml
+++ b/.github/workflows/lints.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: dtolnay/rust-toolchain@beta
+      - uses: dtolnay/rust-toolchain@4711ae3e97dd6376c8d5d5d51c89566406abaefa # beta
         id: toolchain
         with:
           components: clippy

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,3 +2,15 @@ rules:
   secrets-outside-env:
     ignore:
       - ci.yml
+  superfluous-actions:
+    ignore:
+      # softprops/action-gh-release does create-or-update + generate_release_notes
+      # + append_body + clobber in a single declarative step. `gh` has no
+      # equivalent for the update path: `gh release edit` lacks --generate-notes
+      # and any append, so a script replacement would have to reimplement notes
+      # generation via the releases/generate-notes API plus manual body concat,
+      # and hand-roll the create-vs-update idempotency the re-release flow relies
+      # on. The action is already SHA-pinned and runs under a job-scoped
+      # contents:write token, so the supply-chain gain from dropping it is small
+      # relative to that added, lossier script. Keep the action.
+      - binaries-and-deb-release.yml:754


### PR DESCRIPTION
Resolves all high-severity findings reported by `uvx zizmor .` over the workflows in `.github/workflows/`.

## Changes

**Pin unpinned action references (`unpinned-uses`)** — pinned to commit SHAs with ref comments to satisfy the blanket pinning policy:
- `dtolnay/rust-toolchain@stable` → `@4cda84d… # stable` (`audits.yml`, `ci.yml`, `binaries-and-deb-release.yml`)
- `dtolnay/rust-toolchain@beta` → `@4711ae3… # beta` (`lints.yml`)
- `aws-actions/configure-aws-credentials@v4` → `@7474bc4… # v4.3.1` (`binaries-and-deb-release.yml`)

The `stable`/`beta` toolchain is still resolved at runtime by rustup, so pinning the action SHA freezes only the action code, not the Rust version.

**Scope the GitHub App token (`github-app`)** — added `permission-contents: write` to `create-github-app-token` in the `trigger-integration` job (`ci.yml`), limiting the installation token to the minimum needed to POST the `repository_dispatch` event instead of inheriting the app's blanket installation permissions.

**Suppress the `superfluous-actions` info finding** on `softprops/action-gh-release` (`.github/zizmor.yml`) with an explanatory comment. `gh release` has no equivalent for regenerating/appending release notes on an existing release (`gh release edit` lacks `--generate-notes`), so a script replacement would reimplement notes generation via the API plus manual body concat and hand-roll create-vs-update idempotency — while the action is already SHA-pinned and runs under a job-scoped `contents: write` token.

## Verification

`uvx zizmor .` now reports `0 high, 0 medium, 0 low` (the one remaining `template-injection` info finding is a low-confidence false positive on `${{ toJSON(needs) }}`, whose `.result` values are GitHub-controlled).

---
🤖 Opened with [Claude Code](https://claude.com/claude-code) assistance.