### PR TITLE
config: Correct read_state_service rustdoc on per-backend non-best-chain reads

### DIFF
--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -612,9 +612,14 @@ pub struct IndexerSection {
     ///
     /// When this section is present, Zallet opens the running zebrad's state database
     /// as a read-only RocksDB secondary instance and follows the non-finalized chain
-    /// tip via zebrad's gRPC indexer interface. The JSON-RPC settings above are still
-    /// required: they are used for mempool access, transaction submission, and any
-    /// non-best-chain block reads.
+    /// tip via zebrad's gRPC indexer interface. The JSON-RPC `[indexer]` settings above
+    /// are still required, for the mempool and transaction submission.
+    ///
+    /// Handling of non-best-chain (side-chain) blocks depends on the backend. The
+    /// `zebra` backend serves them from the local state (it issues any-chain read
+    /// requests, which zebrad's state answers directly). The `zaino` backend serves
+    /// only the best chain from the local state and falls back to JSON-RPC for
+    /// non-best-chain blocks.
     pub read_state_service: Option<ReadStateServiceSection>,
 }
 


### PR DESCRIPTION
## Summary

Corrects the `IndexerSection::read_state_service` rustdoc, which claimed the JSON-RPC settings serve "any non-best-chain block reads" when the section is present. That is **wrong for the `zebra` backend and right for `zaino`** — the two genuinely differ, now confirmed against both backends' actual read paths:

- **`zebra` backend** (`backends/zebra/src/chain/reader.rs`): issues `ReadRequest::AnyChainBlock` / `AnyChainTransaction` (incl. `AnyTx::Side`), which zebrad's state answers **locally including side chains**, no JSON-RPC fallback.
- **`zaino` backend** (`zaino-state` `validator_connector.rs`, rev `8048bf8`): the `State` connector issues plain `ReadRequest::Block`; Zebra's `ReadStateService` doesn't serve non-best-chain blocks for that request, so on a `None` response it **falls back to the JSON-RPC `mempool_fetcher`** — per that file's own comment: *"Zebra's ReadStateService does not currently serve non-best chain blocks so we must fetch using the JsonRpcConnector."*

So the original wording described zaino's behavior. The doc now says JSON-RPC is used for the mempool and transaction submission, and that non-best-chain handling is backend-specific (zebra local, zaino JSON-RPC fallback).

**No fixture change:** this field doc doesn't flow into the generated `example-config` (that section is generated from `ReadStateServiceSection`'s own field docs, which are accurate). The correction surfaces in the published rustdoc. The book's setup guide was already fixed for the zebra case in #649.

Thanks to @Cosmos-Harry, whose review on #649 flagged that the comment looked like it described zaino — confirmed.

Closes #654.

## Test plan

- [x] `cargo fmt --all -- --check`, `cargo doc --no-deps -p zallet-core`, `cargo clippy -p zallet-core --all-targets` all clean
- [x] Confirmed `TRYCMD=overwrite … cli_tests` produces no fixture diff (field doc is not part of the generated config)
- [x] Verified both read paths in source: zallet `reader.rs` (any-chain, local) and zaino-state `validator_connector.rs` rev 8048bf8 (`ReadRequest::Block` → JSON-RPC fallback)

## AI disclosure

Prepared with AI assistance (Claude Opus 4.8, via Claude Code); `Co-Authored-By` metadata is on the commit. Reviewed by the PR author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
