### PR TITLE
Lock spend proposal inputs while operations are in flight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ be considered breaking changes.
 
 ### Added
 
+- Note locking: while a spend operation (`z_sendmany`, `z_shieldcoinbase`) is
+  in flight, the notes and UTXOs it selected are locked so that a concurrent
+  operation on the same account cannot select (and double-spend) them during
+  the selection-to-broadcast window. Each operation locks under its own random
+  owner token; locks are released when the operation's transactions are stored
+  for broadcast, released explicitly when it fails, and expire on their own
+  once the chain advances past the lock height, so a crashed operation
+  self-heals without intervention.
+  - New `builder.note_lock_blocks` config option: the number of blocks a
+    proposal's input locks last (default 40, roughly 50 minutes of block time,
+    comfortably above worst-case build-and-prove time; 0 disables locking).
+  - A lock conflict surfaces as a retryable "Account is busy" RPC error.
+  - New `z_clearlockedoutputs` RPC method: releases every note lock held for
+    an account, as recovery after the wallet loses track of an in-flight
+    operation. Only safe when no in-flight proposal or PCZT for the account
+    remains.
+  - `z_getbalanceforaccount` reports a per-pool `lockedZat` field alongside
+    the spendable `valueZat`, and `z_getbalances` now populates its `locked`
+    bucket: value locked by in-flight operations, excluded from the spendable
+    balance but still owned by the account. A pool whose entire balance is
+    locked stays visible; `lockedZat` is omitted when zero.
 - RPC methods:
   - `z_exportviewingkey`. In addition to the `zcashd` behaviour (exporting the
     Sapling extended full viewing key for a Sapling address), it accepts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
 ]
@@ -5749,7 +5749,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5762,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5812,7 +5812,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "hex",
@@ -5902,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5948,7 +5948,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "getset",
@@ -5991,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6021,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6056,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "document-features",
@@ -6119,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bip32",
  "bs58",
@@ -6298,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,7 +1304,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1339,7 +1339,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3008,8 +3008,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",
@@ -5750,7 +5749,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5763,7 +5762,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5813,7 +5812,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5850,6 +5849,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys 0.15.0",
+ "zcash_pool_migration_backend",
  "zcash_primitives 0.29.0",
  "zcash_protocol 0.10.0",
  "zcash_script",
@@ -5861,7 +5861,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "corez",
  "hex",
@@ -5902,7 +5902,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5946,6 +5946,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+dependencies = [
+ "corez",
+ "getset",
+ "libm",
+ "rand_core 0.6.4",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5978,7 +5991,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6008,7 +6021,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6043,7 +6056,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "corez",
  "document-features",
@@ -6106,7 +6119,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bip32",
  "bs58",
@@ -6285,7 +6298,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,23 +166,22 @@ tonic = "0.14"
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
 #
-# TEMPORARY PIN: the current rev is on the `danny/note-locking-testing` branch
-# of librustzcash (PR #2726), which carries the owner-keyed note-locking API
-# (`LockOwner`/`LockRequest` on the propose_* functions, the `WalletWrite` lock
-# methods, `Balance::locked_value`). Move back to a main-branch rev (or the
-# released crates) once PR #2726 merges.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+# TEMPORARY PIN: the current rev is librustzcash main (note locking merged in
+# PR #2716, including the owner-keyed `LockOwner`/`LockRequest` API on the
+# propose_* functions, the `WalletWrite` lock methods, `Balance::locked_value`,
+# and `LockFilter`-based selection). Replace with the next crates.io release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
 # The pinned librustzcash rev builds against the git `orchard` (the ZIP 374 /
 # NU6.3 deferred-anchor builder API: `Builder::new_with_anchor_deferred`,
 # `add_spend_unwitnessed`), not the crates.io release; patch it to the same rev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,18 +165,29 @@ tonic = "0.14"
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+#
+# TEMPORARY PIN: the current rev is on the `danny/note-locking-testing` branch
+# of librustzcash (PR #2726), which carries the owner-keyed note-locking API
+# (`LockOwner`/`LockRequest` on the propose_* functions, the `WalletWrite` lock
+# methods, `Balance::locked_value`). Move back to a main-branch rev (or the
+# released crates) once PR #2726 merges.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+# The pinned librustzcash rev builds against the git `orchard` (the ZIP 374 /
+# NU6.3 deferred-anchor builder API: `Builder::new_with_anchor_deferred`,
+# `add_spend_unwitnessed`), not the crates.io release; patch it to the same rev
+# librustzcash pins. Drop alongside the librustzcash pin above.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
 ]
@@ -7013,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7026,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7076,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "hex",
@@ -7177,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7223,7 +7223,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "getset",
@@ -7266,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7296,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7331,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "document-features",
@@ -7394,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bip32",
  "bs58",
@@ -7848,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,7 +1523,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1559,7 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3545,8 +3545,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",
@@ -7014,7 +7013,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7027,7 +7026,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7077,7 +7076,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7114,6 +7113,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys 0.15.0",
+ "zcash_pool_migration_backend",
  "zcash_primitives 0.29.0",
  "zcash_protocol 0.10.0",
  "zcash_script",
@@ -7125,7 +7125,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "corez",
  "hex",
@@ -7177,7 +7177,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7221,6 +7221,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+dependencies = [
+ "corez",
+ "getset",
+ "libm",
+ "rand_core 0.6.4",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7253,7 +7266,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7283,7 +7296,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7318,7 +7331,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "corez",
  "document-features",
@@ -7381,7 +7394,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bip32",
  "bs58",
@@ -7835,7 +7848,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -73,18 +73,22 @@ tempfile = "3"
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+# The pinned librustzcash rev builds against the git `orchard` (the ZIP 374
+# deferred-anchor builder API), not the crates.io release; patch it to the same
+# rev librustzcash pins. Drop alongside the librustzcash pin above.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 # TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
 # which surfaces the Ironwood (NU6.3) note commitment treestate from

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -73,18 +73,18 @@ tempfile = "3"
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
 # The pinned librustzcash rev builds against the git `orchard` (the ZIP 374
 # deferred-anchor builder API), not the crates.io release; patch it to the same
 # rev librustzcash pins. Drop alongside the librustzcash pin above.

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3351,8 +3351,7 @@ dependencies = [
 [[package]]
 name = "orchard"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+source = "git+https://github.com/zcash/orchard.git?rev=3bd2b736d1273226595773265313fc3f3428af16#3bd2b736d1273226595773265313fc3f3428af16"
 dependencies = [
  "aes",
  "bitvec",
@@ -6593,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6606,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6656,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6693,6 +6692,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_encoding",
  "zcash_keys 0.15.0",
+ "zcash_pool_migration_backend",
  "zcash_primitives 0.29.0",
  "zcash_protocol 0.10.0",
  "zcash_script",
@@ -6704,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "corez",
  "hex",
@@ -6756,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6800,6 +6800,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "zcash_pool_migration_backend"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+dependencies = [
+ "corez",
+ "getset",
+ "libm",
+ "rand_core 0.6.4",
+ "zcash_primitives 0.29.0",
+ "zcash_protocol 0.10.0",
+]
+
+[[package]]
 name = "zcash_primitives"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6832,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6862,7 +6875,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6897,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "corez",
  "document-features",
@@ -6960,7 +6973,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "bip32",
  "bs58",
@@ -7414,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,7 +1466,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
 ]
@@ -6592,7 +6592,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6605,7 +6605,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6655,7 +6655,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6704,7 +6704,7 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "hex",
@@ -6756,7 +6756,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6802,7 +6802,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration_backend"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "getset",
@@ -6845,7 +6845,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6875,7 +6875,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6910,7 +6910,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "corez",
  "document-features",
@@ -6973,7 +6973,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "bip32",
  "bs58",
@@ -7427,7 +7427,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=2e140f402cc72f0f483d686d46b5f18e07971fcd#2e140f402cc72f0f483d686d46b5f18e07971fcd"
+source = "git+https://github.com/zcash/librustzcash.git?rev=beec9b595f1e2b12c51eb19beb6d222ffd6f2088#beec9b595f1e2b12c51eb19beb6d222ffd6f2088"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -76,18 +76,22 @@ tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+# The pinned librustzcash rev builds against the git `orchard` (the ZIP 374
+# deferred-anchor builder API), not the crates.io release; patch it to the same
+# rev librustzcash pins. Drop alongside the librustzcash pin above.
+orchard = { git = "https://github.com/zcash/orchard.git", rev = "3bd2b736d1273226595773265313fc3f3428af16" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -76,18 +76,18 @@ tokio-console = ["zallet-core/tokio-console"]
 
 [patch.crates-io]
 # Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "2e140f402cc72f0f483d686d46b5f18e07971fcd" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "beec9b595f1e2b12c51eb19beb6d222ffd6f2088" }
 # The pinned librustzcash rev builds against the git `orchard` (the ZIP 374
 # deferred-anchor builder API), not the crates.io release; patch it to the same
 # rev librustzcash pins. Drop alongside the librustzcash pin above.

--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -69,6 +69,19 @@
 # Values smaller than `trusted_confirmations` are ignored.
 #untrusted_confirmations = 10
 
+# The number of blocks for which the inputs selected by a spend proposal are locked.
+#
+# While a spend operation (e.g. `z_sendmany`, `z_shieldcoinbase`) is in flight, the
+# notes and UTXOs it selected are locked so that a concurrent operation on the same
+# account cannot select (and double-spend) them. The lock is released when the
+# operation's transactions are stored for broadcast, released explicitly if the
+# operation fails, and expires on its own once the chain advances this many blocks
+# past the operation's target height (self-healing if the wallet crashes while an
+# operation is in flight).
+#
+# Set to `0` to disable input locking entirely.
+#note_lock_blocks = 40
+
 
 #
 # Configurable limits on transaction builder operation (to prevent e.g. memory

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -119,6 +119,35 @@ that require the availability of private keys, such as sending funds.
 Issuing the `walletpassphrase` command while the wallet is already unlocked will
 set a new unlock time that overrides the old one.
 
+## `z_clearlockedoutputs`
+
+*Only available in wallet builds of Zallet.*
+
+Releases every note lock held for the given account.
+
+While a spend operation (`z_sendmany`, `z_shieldcoinbase`) is in flight, the notes
+and UTXOs it selected are locked so that no concurrent operation can select them;
+the locks are released when the operation completes or fails, and otherwise expire
+on their own once the chain advances past their lock height (the
+`builder.note_lock_blocks` config option, 40 blocks by default).
+
+This method is a recovery mechanism for the case where the wallet has lost track of
+an in-flight operation (for example, the process was killed between creating a
+proposal and building its transactions) and its locks would otherwise make the
+account's funds unspendable until they expire.
+
+#### Warning
+
+This releases every lock for the account, including locks held by operations that
+are still legitimately in flight; their inputs immediately become selectable by new
+operations, re-creating the double-spend conflict that locking exists to prevent.
+Only call this when no in-flight operation (spend, shielding, proposal, or PCZT)
+for the account remains. When in doubt, wait: locks expire on their own.
+
+#### Arguments
+- `account` (string or numeric, required): Either the UUID or the ZIP 32 account
+  index of the account, as returned by `z_getnewaccount`.
+
 ## `z_converttex`
 
 Converts a transparent P2PKH Zcash address to a TEX address.

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -15,12 +15,15 @@ use zcash_client_backend::{
         SAPLING_SHARD_HEIGHT, TargetValue, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
         WalletWrite, Zip32Derivation,
         chain::ChainState,
-        error::{FindAccountForAddressError, RewindError},
+        error::{FindAccountForAddressError, LockError, RewindError},
         wallet::{ConfirmationsPolicy, TargetHeight},
     },
     fees::StandardFeeRule,
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
-    wallet::{Note, ReceivedNote, TransparentAddressMetadata, WalletTransparentOutput},
+    wallet::{
+        LockOwner, Note, OutputRef, ReceivedNote, TransparentAddressMetadata,
+        WalletTransparentOutput,
+    },
 };
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
@@ -441,8 +444,11 @@ impl InputSource for DbConnection {
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
+        include_locked: bool,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
-        self.with(|db_data| db_data.get_spendable_note(txid, protocol, index, target_height))
+        self.with(|db_data| {
+            db_data.get_spendable_note(txid, protocol, index, target_height, include_locked)
+        })
     }
 
     fn select_spendable_notes(
@@ -453,6 +459,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
+        include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         self.with(|db_data| {
             db_data.select_spendable_notes(
@@ -462,6 +469,7 @@ impl InputSource for DbConnection {
                 target_height,
                 confirmations_policy,
                 exclude,
+                include_locked,
             )
         })
     }
@@ -472,16 +480,22 @@ impl InputSource for DbConnection {
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        include_locked: bool,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
-        self.with(|db_data| db_data.select_unspent_notes(account, sources, target_height, exclude))
+        self.with(|db_data| {
+            db_data.select_unspent_notes(account, sources, target_height, exclude, include_locked)
+        })
     }
 
     fn get_unspent_transparent_output(
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
+        include_locked: bool,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
-        self.with(|db_data| db_data.get_unspent_transparent_output(outpoint, target_height))
+        self.with(|db_data| {
+            db_data.get_unspent_transparent_output(outpoint, target_height, include_locked)
+        })
     }
 
     fn get_spendable_transparent_outputs(
@@ -490,6 +504,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.get_spendable_transparent_outputs(
@@ -497,6 +512,7 @@ impl InputSource for DbConnection {
                 target_height,
                 confirmations_policy,
                 output_filter,
+                include_locked,
             )
         })
     }
@@ -512,6 +528,7 @@ impl InputSource for DbConnection {
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
+        include_locked: bool,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.select_spendable_transparent_outputs(
@@ -523,6 +540,7 @@ impl InputSource for DbConnection {
                 target_value,
                 max_inputs,
                 fee_rule,
+                include_locked,
             )
         })
     }
@@ -533,8 +551,11 @@ impl InputSource for DbConnection {
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        include_locked: bool,
     ) -> Result<AccountMeta, Self::Error> {
-        self.with(|db_data| db_data.get_account_metadata(account, selector, target_height, exclude))
+        self.with(|db_data| {
+            db_data.get_account_metadata(account, selector, target_height, exclude, include_locked)
+        })
     }
 }
 
@@ -734,6 +755,23 @@ impl WalletWrite for DbConnection {
         exposures: &[(TransparentAddress, BlockHeight)],
     ) -> Result<(), Self::Error> {
         self.with_mut(|mut db_data| db_data.mark_transparent_addresses_exposed(exposures))
+    }
+
+    fn lock_outputs(
+        &mut self,
+        outputs: &[OutputRef],
+        owner: LockOwner,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>> {
+        self.with_mut(|mut db_data| db_data.lock_outputs(outputs, owner, lock_expiry_height))
+    }
+
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error> {
+        self.with_mut(|mut db_data| db_data.unlock_output(output, owner))
+    }
+
+    fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
+        self.with_mut(|mut db_data| db_data.clear_locked_outputs(account))
     }
 }
 

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -16,7 +16,7 @@ use zcash_client_backend::{
         WalletWrite, Zip32Derivation,
         chain::ChainState,
         error::{FindAccountForAddressError, LockError, RewindError},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     fees::StandardFeeRule,
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
@@ -444,10 +444,10 @@ impl InputSource for DbConnection {
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
         self.with(|db_data| {
-            db_data.get_spendable_note(txid, protocol, index, target_height, include_locked)
+            db_data.get_spendable_note(txid, protocol, index, target_height, lock_filter)
         })
     }
 
@@ -459,7 +459,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         self.with(|db_data| {
             db_data.select_spendable_notes(
@@ -469,7 +469,7 @@ impl InputSource for DbConnection {
                 target_height,
                 confirmations_policy,
                 exclude,
-                include_locked,
+                lock_filter,
             )
         })
     }
@@ -480,10 +480,10 @@ impl InputSource for DbConnection {
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         self.with(|db_data| {
-            db_data.select_unspent_notes(account, sources, target_height, exclude, include_locked)
+            db_data.select_unspent_notes(account, sources, target_height, exclude, lock_filter)
         })
     }
 
@@ -491,11 +491,8 @@ impl InputSource for DbConnection {
         &self,
         outpoint: &OutPoint,
         target_height: TargetHeight,
-        include_locked: bool,
     ) -> Result<Option<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
-        self.with(|db_data| {
-            db_data.get_unspent_transparent_output(outpoint, target_height, include_locked)
-        })
+        self.with(|db_data| db_data.get_unspent_transparent_output(outpoint, target_height))
     }
 
     fn get_spendable_transparent_outputs(
@@ -504,7 +501,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.get_spendable_transparent_outputs(
@@ -512,7 +509,7 @@ impl InputSource for DbConnection {
                 target_height,
                 confirmations_policy,
                 output_filter,
-                include_locked,
+                lock_filter,
             )
         })
     }
@@ -528,7 +525,7 @@ impl InputSource for DbConnection {
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.select_spendable_transparent_outputs(
@@ -540,7 +537,7 @@ impl InputSource for DbConnection {
                 target_value,
                 max_inputs,
                 fee_rule,
-                include_locked,
+                lock_filter,
             )
         })
     }
@@ -551,10 +548,10 @@ impl InputSource for DbConnection {
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
-        include_locked: bool,
+        lock_filter: LockFilter<'_>,
     ) -> Result<AccountMeta, Self::Error> {
         self.with(|db_data| {
-            db_data.get_account_metadata(account, selector, target_height, exclude, include_locked)
+            db_data.get_account_metadata(account, selector, target_height, exclude, lock_filter)
         })
     }
 }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -19,6 +19,8 @@ use {
     tokio::sync::RwLock,
 };
 
+#[cfg(zallet_build = "wallet")]
+mod clear_locked_outputs;
 mod convert_tex;
 mod decode_raw_transaction;
 mod decode_script;
@@ -437,6 +439,33 @@ pub(crate) trait WalletRpc {
         account: JsonValue,
         minconf: Option<u32>,
     ) -> z_get_balance_for_account::Response;
+
+    /// Releases every note lock held for the given account.
+    ///
+    /// While a spend operation (`z_sendmany`, `z_shieldcoinbase`) is in flight, the notes
+    /// and UTXOs it selected are locked so that no concurrent operation can select them;
+    /// the locks are released when the operation completes or fails, and otherwise expire
+    /// on their own once the chain advances past their lock height (the
+    /// `builder.note_lock_blocks` config option, 40 blocks by default).
+    ///
+    /// This method is a recovery mechanism for the case where the wallet has lost track of
+    /// an in-flight operation (for example, the process was killed between creating a
+    /// proposal and building its transactions) and its locks would otherwise make the
+    /// account's funds unspendable until they expire.
+    ///
+    /// # Warning
+    ///
+    /// This releases every lock for the account, including locks held by operations that
+    /// are still legitimately in flight; their inputs immediately become selectable by new
+    /// operations, re-creating the double-spend conflict that locking exists to prevent.
+    /// Only call this when no in-flight operation (spend, shielding, proposal, or PCZT)
+    /// for the account remains. When in doubt, wait: locks expire on their own.
+    ///
+    /// # Arguments
+    /// - `account` (string or numeric, required): Either the UUID or the ZIP 32 account
+    ///   index of the account, as returned by `z_getnewaccount`.
+    #[method(name = "z_clearlockedoutputs")]
+    async fn clear_locked_outputs(&self, account: JsonValue) -> clear_locked_outputs::Response;
 
     /// Imports a transparent address into the wallet for a given account.
     ///
@@ -1029,6 +1058,10 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             minconf,
         )
         .await
+    }
+
+    async fn clear_locked_outputs(&self, account: JsonValue) -> clear_locked_outputs::Response {
+        clear_locked_outputs::call(self.wallet().await?.as_mut(), &self.keystore, account).await
     }
 
     async fn import_address(

--- a/zallet-core/src/components/json_rpc/methods/clear_locked_outputs.rs
+++ b/zallet-core/src/components/json_rpc/methods/clear_locked_outputs.rs
@@ -1,0 +1,47 @@
+//! `z_clearlockedoutputs`: release every note lock held for an account.
+
+use documented::Documented;
+use jsonrpsee::core::{JsonValue, RpcResult};
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_client_backend::data_api::WalletWrite;
+
+use crate::components::{
+    database::DbConnection,
+    json_rpc::{server::LegacyCode, utils::parse_account_parameter},
+    keystore::KeyStore,
+};
+
+/// Response to a `z_clearlockedoutputs` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+pub(crate) type ResultType = ClearLockedOutputs;
+
+/// The result of releasing an account's note locks.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct ClearLockedOutputs {
+    /// The UUID of the account whose locks were released.
+    account_uuid: String,
+
+    /// The number of outputs that were unlocked.
+    cleared: u64,
+}
+
+pub(super) const PARAM_ACCOUNT_DESC: &str =
+    "Either the UUID or ZIP 32 account index of the account whose locks to release.";
+
+pub(crate) async fn call(
+    wallet: &mut DbConnection,
+    keystore: &KeyStore,
+    account: JsonValue,
+) -> Response {
+    let account_id = parse_account_parameter(wallet, keystore, &account).await?;
+
+    let cleared = wallet
+        .clear_locked_outputs(account_id)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    Ok(ClearLockedOutputs {
+        account_uuid: account_id.expose_uuid().to_string(),
+        cleared: cleared as u64,
+    })
+}

--- a/zallet-core/src/components/json_rpc/methods/get_balances.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_balances.rs
@@ -118,9 +118,9 @@ struct Balance {
     /// Balance that is spendable at the requested number of confirmations, but currently
     /// locked by some other spend operation.
     ///
-    /// Omitted if zero.
-    // TODO: Support locked outputs.
-    // https://github.com/zcash/librustzcash/issues/2161
+    /// Locked value is excluded from `spendable` while the operation that locked it is in
+    /// flight, and returns to `spendable` when the operation completes, fails, or its
+    /// lock expires. Omitted if zero.
     #[serde(skip_serializing_if = "Option::is_none")]
     locked: Option<Value>,
 
@@ -237,6 +237,9 @@ fn balance_from(b: &zcash_client_backend::data_api::AccountBalance) -> RpcResult
             LegacyCode::Database
                 .with_static("Wallet database is corrupt: storing more than MAX_MONEY"),
         )?,
+        // `AccountBalance::locked_value` covers every pool (shielded and both
+        // transparent buckets), so it must be used exactly once here.
+        b.locked_value(),
         // `AccountBalance::change_pending_confirmation` and
         // `AccountBalance::value_pending_spendability` cover the shielded pools only.
         // Immature transparent coinbase funds are reported by the coinbase bucket's
@@ -260,6 +263,7 @@ fn balance_from(b: &zcash_client_backend::data_api::AccountBalance) -> RpcResult
 fn opt_balance_from(b: &zcash_client_backend::data_api::Balance) -> RpcResult<Option<Balance>> {
     Ok(opt_balance(
         b.spendable_value(),
+        b.locked_value(),
         (b.change_pending_confirmation() + b.value_pending_spendability()).ok_or(
             LegacyCode::Database
                 .with_static("Wallet database is corrupt: storing more than MAX_MONEY"),
@@ -268,21 +272,28 @@ fn opt_balance_from(b: &zcash_client_backend::data_api::Balance) -> RpcResult<Op
     ))
 }
 
-fn balance(spendable: Zatoshis, pending: Zatoshis, dust: Zatoshis) -> Balance {
+fn balance(spendable: Zatoshis, locked: Zatoshis, pending: Zatoshis, dust: Zatoshis) -> Balance {
     Balance {
         spendable: value(spendable),
-        locked: None,
+        locked: opt_value(locked),
         pending: opt_value(pending),
         dust: opt_value(dust),
     }
 }
 
-fn opt_balance(spendable: Zatoshis, pending: Zatoshis, dust: Zatoshis) -> Option<Balance> {
-    (!(spendable.is_zero() && pending.is_zero() && dust.is_zero())).then(|| Balance {
-        spendable: value(spendable),
-        locked: None,
-        pending: opt_value(pending),
-        dust: opt_value(dust),
+fn opt_balance(
+    spendable: Zatoshis,
+    locked: Zatoshis,
+    pending: Zatoshis,
+    dust: Zatoshis,
+) -> Option<Balance> {
+    (!(spendable.is_zero() && locked.is_zero() && pending.is_zero() && dust.is_zero())).then(|| {
+        Balance {
+            spendable: value(spendable),
+            locked: opt_value(locked),
+            pending: opt_value(pending),
+            dust: opt_value(dust),
+        }
     })
 }
 

--- a/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
@@ -2,7 +2,10 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_client_backend::data_api::{InputSource, NoteFilter, WalletRead, wallet::TargetHeight};
+use zcash_client_backend::data_api::{
+    InputSource, NoteFilter, WalletRead,
+    wallet::{TargetHeight, input_selection::LockFilter},
+};
 use zcash_protocol::{ShieldedPool, value::Zatoshis};
 
 use crate::components::{
@@ -66,10 +69,11 @@ pub(crate) fn call(
         .get_account_ids()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
     {
-        // Locked notes are still unspent notes held by the wallet, so they are counted.
-        let include_locked = true;
+        // Locked notes are still unspent notes held by the wallet, so they are counted:
+        // the query ignores lock state entirely (a retrieval path, not input selection).
+        let lock_filter = LockFilter::Unfiltered;
         let account_metadata = wallet
-            .get_account_metadata(account_id, &selector, target_height, &[], include_locked)
+            .get_account_metadata(account_id, &selector, target_height, &[], lock_filter)
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
         if let Some(note_count) = account_metadata.note_count(ShieldedPool::Sapling) {

--- a/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
@@ -66,8 +66,10 @@ pub(crate) fn call(
         .get_account_ids()
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
     {
+        // Locked notes are still unspent notes held by the wallet, so they are counted.
+        let include_locked = true;
         let account_metadata = wallet
-            .get_account_metadata(account_id, &selector, target_height, &[])
+            .get_account_metadata(account_id, &selector, target_height, &[], include_locked)
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
         if let Some(note_count) = account_metadata.note_count(ShieldedPool::Sapling) {

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -186,6 +186,10 @@ pub(crate) fn call(
 
         let is_watch_only = !matches!(account.purpose(), AccountPurpose::Spending { .. });
 
+        // `z_listunspent` reports unspent outputs and notes; a lock defers selection but
+        // does not spend, so locked entries are listed.
+        let include_locked = true;
+
         let utxos = wallet
             .get_transparent_receivers(account_id, true, true)
             .map_err(|e| {
@@ -212,6 +216,7 @@ pub(crate) fn call(
                             target_height,
                             confirmations_policy,
                             coinbase_filter,
+                            include_locked,
                         )
                         .map_err(|e| {
                             RpcError::owned(
@@ -265,6 +270,7 @@ pub(crate) fn call(
                 ],
                 target_height,
                 &[],
+                include_locked,
             )
             .map_err(|e| {
                 RpcError::owned(

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -13,7 +13,7 @@ use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
         Account, AccountPurpose, CoinbaseFilter, InputSource, WalletRead,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     encoding::AddressCodec,
     fees::{orchard::InputView as _, sapling::InputView as _},
@@ -187,8 +187,9 @@ pub(crate) fn call(
         let is_watch_only = !matches!(account.purpose(), AccountPurpose::Spending { .. });
 
         // `z_listunspent` reports unspent outputs and notes; a lock defers selection but
-        // does not spend, so locked entries are listed.
-        let include_locked = true;
+        // does not spend, so the queries ignore lock state entirely (retrieval paths, not
+        // input selection).
+        let lock_filter = LockFilter::Unfiltered;
 
         let utxos = wallet
             .get_transparent_receivers(account_id, true, true)
@@ -216,7 +217,7 @@ pub(crate) fn call(
                             target_height,
                             confirmations_policy,
                             coinbase_filter,
-                            include_locked,
+                            lock_filter,
                         )
                         .map_err(|e| {
                             RpcError::owned(
@@ -270,7 +271,7 @@ pub(crate) fn call(
                 ],
                 target_height,
                 &[],
-                include_locked,
+                lock_filter,
             )
             .map_err(|e| {
                 RpcError::owned(

--- a/zallet-core/src/components/json_rpc/methods/z_get_balance_for_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_get_balance_for_account.rs
@@ -60,9 +60,18 @@ struct Pools {
 
 #[derive(Clone, Debug, Serialize, JsonSchema)]
 struct PoolBalance {
-    /// The balance in zatoshis.
+    /// The spendable balance in zatoshis.
     #[serde(rename = "valueZat")]
     value_zat: u64,
+
+    /// The value (in zatoshis) currently locked by in-flight spend operations.
+    ///
+    /// Locked value is excluded from `valueZat` (it cannot be selected by a new spend
+    /// while the operation that locked it is in flight) but still belongs to the account;
+    /// it returns to `valueZat` when the operation completes, fails, or its lock expires.
+    /// Omitted if zero.
+    #[serde(rename = "lockedZat", skip_serializing_if = "Option::is_none")]
+    locked_zat: Option<u64>,
 }
 
 pub(super) const PARAM_ACCOUNT_DESC: &str =
@@ -102,28 +111,42 @@ pub(crate) async fn call(
 
 /// Builds the response from an account's balance.
 ///
-/// Reports each value pool's spendable balance, omitting pools whose balance is
-/// zero, and echoes the effective `minconf` (defaulting to 1, as in zcashd).
+/// Reports each value pool's spendable balance alongside any value locked by in-flight
+/// spend operations, omitting pools with neither, and echoes the effective `minconf`
+/// (defaulting to 1, as in zcashd).
 fn response_for_balance(
     account_balance: &AccountBalance,
     minconf: Option<u32>,
 ) -> BalanceForAccount {
+    let unshielded = account_balance.unshielded_balance();
     BalanceForAccount {
         pools: Pools {
-            transparent: pool_balance(account_balance.unshielded_balance().spendable_value()),
-            sapling: pool_balance(account_balance.sapling_balance().spendable_value()),
-            orchard: pool_balance(account_balance.orchard_balance().spendable_value()),
-            ironwood: pool_balance(account_balance.ironwood_balance().spendable_value()),
+            transparent: pool_balance(unshielded.spendable_value(), unshielded.locked_value()),
+            sapling: pool_balance(
+                account_balance.sapling_balance().spendable_value(),
+                account_balance.sapling_balance().locked_value(),
+            ),
+            orchard: pool_balance(
+                account_balance.orchard_balance().spendable_value(),
+                account_balance.orchard_balance().locked_value(),
+            ),
+            ironwood: pool_balance(
+                account_balance.ironwood_balance().spendable_value(),
+                account_balance.ironwood_balance().locked_value(),
+            ),
         },
         minimum_confirmations: minconf.unwrap_or(1),
     }
 }
 
-/// Renders a pool's spendable balance, omitting pools with a zero balance to
-/// match the reference `z_getbalanceforaccount` behaviour.
-fn pool_balance(value: Zatoshis) -> Option<PoolBalance> {
-    (!value.is_zero()).then(|| PoolBalance {
+/// Renders a pool's spendable and locked balances, omitting pools with neither (matching
+/// the reference `z_getbalanceforaccount` behaviour of omitting zero-balance pools; a pool
+/// whose entire balance is locked is still shown, so an in-flight operation does not make
+/// funds appear to vanish).
+fn pool_balance(value: Zatoshis, locked: Zatoshis) -> Option<PoolBalance> {
+    (!(value.is_zero() && locked.is_zero())).then(|| PoolBalance {
         value_zat: value.into_u64(),
+        locked_zat: (!locked.is_zero()).then(|| locked.into_u64()),
     })
 }
 
@@ -281,6 +304,42 @@ mod tests {
                 "pools": {"transparent": {"valueZat": 5 * COIN}},
                 "minimum_confirmations": 1,
             }),
+        );
+    }
+
+    // A pool with locked value reports it under `lockedZat` alongside the spendable
+    // `valueZat`, and a pool whose ENTIRE balance is locked still appears (spendable 0),
+    // so an in-flight operation does not make the funds appear to vanish.
+    #[test]
+    fn locked_value_is_rendered_and_keeps_the_pool_visible() {
+        let zat = Zatoshis::const_from_u64;
+        let mut balance = account_balance(0, 2 * COIN, 0, 0);
+        balance
+            .with_sapling_balance_mut::<_, BalanceError>(|b| b.add_locked_value(zat(3 * COIN)))
+            .unwrap();
+        balance
+            .with_orchard_balance_mut::<_, BalanceError>(|b| b.add_locked_value(zat(COIN)))
+            .unwrap();
+
+        assert_eq!(
+            serde_json::to_value(response_for_balance(&balance, None)).unwrap(),
+            json!({
+                "pools": {
+                    "sapling": {"valueZat": 2 * COIN, "lockedZat": 3 * COIN},
+                    "orchard": {"valueZat": 0, "lockedZat": COIN},
+                },
+                "minimum_confirmations": 1,
+            }),
+        );
+    }
+
+    // A pool with no locked value renders exactly as before locking existed (`lockedZat`
+    // omitted), so existing consumers of the RPC output are unaffected.
+    #[test]
+    fn unlocked_pools_render_without_locked_field() {
+        assert_eq!(
+            rendered(0, 5 * COIN, 0, 0, None),
+            json!({"pools": {"sapling": {"valueZat": 5 * COIN}}, "minimum_confirmations": 1}),
         );
     }
 

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -34,6 +34,12 @@ use zcash_protocol::{
     value::{MAX_MONEY, Zatoshis},
 };
 
+use rand::rngs::OsRng;
+use zcash_client_backend::data_api::error::Error as WalletError;
+use zcash_client_backend::data_api::wallet::LockRequest;
+use zcash_client_backend::proposal::ProposalError;
+use zcash_client_backend::wallet::LockOwner;
+
 use crate::{
     components::{
         chain::Chain,
@@ -42,8 +48,9 @@ use crate::{
             asyncop::{ContextInfo, OperationId},
             payments::{
                 AmountParameter, IncompatiblePrivacyPolicy, PrivacyPolicy, SendResult,
-                build_request, enforce_privacy_policy, get_account_for_address,
-                get_legacy_pool_account, verify_and_broadcast_transactions,
+                account_busy_error, build_request, enforce_privacy_policy, get_account_for_address,
+                get_legacy_pool_account, unlock_proposal_inputs_after_failure,
+                verify_and_broadcast_transactions,
             },
             server::LegacyCode,
         },
@@ -304,6 +311,18 @@ pub(crate) async fn call<C: Chain>(
 
     let input_selector = GreedyInputSelector::new();
 
+    // Lock the proposal's inputs for the configured window so a concurrent operation on
+    // this account cannot select (and double-spend) them while this one is building. Each
+    // operation locks under its own fresh random owner token, so releasing this
+    // operation's locks can never disturb a concurrent operation's, and a conflict always
+    // means a different in-flight operation holds the input.
+    let lock_inputs = APP
+        .config()
+        .builder
+        .note_lock_blocks()
+        .map(|for_blocks| LockRequest::new(LockOwner::random(&mut OsRng), for_blocks));
+    let lock_owner = lock_inputs.as_ref().map(|request| request.owner());
+
     let proposal = propose_transfer::<_, _, _, _, Infallible>(
         wallet.as_mut(),
         &params,
@@ -313,88 +332,120 @@ pub(crate) async fn call<C: Chain>(
         request,
         confirmations_policy,
         &spend_policy,
+        lock_inputs,
         // Do not request a specific transaction version; building falls back to the version
         // implied by the target height.
         None,
     )
     // TODO: Map errors to `zcashd` shape.
-    .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?;
-
-    enforce_privacy_policy(&proposal, privacy_policy)?;
-
-    let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
-    for step in proposal.steps() {
-        let orchard_spends = step
-            .shielded_inputs()
-            .iter()
-            .flat_map(|inputs| inputs.notes())
-            .filter(|note| note.note().pool() == ShieldedPool::Orchard)
-            .count();
-
-        let orchard_outputs = step
-            .payment_pools()
-            .values()
-            .filter(|pool| pool == &&PoolType::ORCHARD)
-            .count()
-            + step
-                .balance()
-                .proposed_change()
-                .iter()
-                .filter(|change| change.output_pool() == PoolType::ORCHARD)
-                .count();
-
-        let orchard_actions = orchard_spends.max(orchard_outputs);
-
-        if orchard_actions > orchard_actions_limit {
-            let (count, kind) = if orchard_outputs <= orchard_actions_limit {
-                (orchard_spends, "inputs")
-            } else if orchard_spends <= orchard_actions_limit {
-                (orchard_outputs, "outputs")
-            } else {
-                (orchard_actions, "actions")
-            };
-
-            return Err(LegacyCode::Misc.with_message(fl!(
-                "err-excess-orchard-actions",
-                count = count,
-                kind = kind,
-                limit = orchard_actions_limit,
-                config = "-orchardactionlimit=N",
-                bound = format!("N >= %u"),
-            )));
-        }
-    }
-
-    let derivation = account.source().key_derivation().ok_or_else(|| {
-        LegacyCode::InvalidAddressOrKey
-            .with_static("Invalid from address, no payment source found for address.")
+    .map_err(|e| match &e {
+        // A lock conflict is transient: a concurrent operation holds one of the selected
+        // inputs. Surface it as a retryable "account busy" error rather than a failure.
+        WalletError::Proposal(ProposalError::InputsLocked(_)) => account_busy_error(),
+        _ => LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")),
     })?;
 
-    // Fetch spending key last, to avoid a keystore decryption if unnecessary.
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            // TODO: Improve internal error types.
-            //       https://github.com/zcash/zallet/issues/256
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+    // From here until `create_proposed_transactions` stores the built transactions, this
+    // function owns the proposal's input locks: every error on this path must release
+    // them, or the account's inputs would stay unspendable until the lock window expires.
+    let post_proposal = async {
+        enforce_privacy_policy(&proposal, privacy_policy)?;
+
+        let orchard_actions_limit = APP.config().builder.limits.orchard_actions().into();
+        for step in proposal.steps() {
+            let orchard_spends = step
+                .shielded_inputs()
+                .iter()
+                .flat_map(|inputs| inputs.notes())
+                .filter(|note| note.note().pool() == ShieldedPool::Orchard)
+                .count();
+
+            let orchard_outputs = step
+                .payment_pools()
+                .values()
+                .filter(|pool| pool == &&PoolType::ORCHARD)
+                .count()
+                + step
+                    .balance()
+                    .proposed_change()
+                    .iter()
+                    .filter(|change| change.output_pool() == PoolType::ORCHARD)
+                    .count();
+
+            let orchard_actions = orchard_spends.max(orchard_outputs);
+
+            if orchard_actions > orchard_actions_limit {
+                let (count, kind) = if orchard_outputs <= orchard_actions_limit {
+                    (orchard_spends, "inputs")
+                } else if orchard_spends <= orchard_actions_limit {
+                    (orchard_outputs, "outputs")
+                } else {
+                    (orchard_actions, "actions")
+                };
+
+                return Err(LegacyCode::Misc.with_message(fl!(
+                    "err-excess-orchard-actions",
+                    count = count,
+                    kind = kind,
+                    limit = orchard_actions_limit,
+                    config = "-orchardactionlimit=N",
+                    bound = format!("N >= %u"),
+                )));
             }
-            _ => LegacyCode::Database.with_message(e.to_string()),
+        }
+
+        let derivation = account.source().key_derivation().ok_or_else(|| {
+            LegacyCode::InvalidAddressOrKey
+                .with_static("Invalid from address, no payment source found for address.")
         })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
-    #[cfg(feature = "zcashd-import")]
-    let standalone_keys =
-        collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account.id(), &proposal)
-            .await?;
+        // Fetch spending key last, to avoid a keystore decryption if unnecessary.
+        let seed = keystore
+            .decrypt_seed(derivation.seed_fingerprint())
+            .await
+            .map_err(|e| match e.kind() {
+                // TODO: Improve internal error types.
+                //       https://github.com/zcash/zallet/issues/256
+                crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                    LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+                }
+                _ => LegacyCode::Database.with_message(e.to_string()),
+            })?;
+        let usk = UnifiedSpendingKey::from_seed(
+            wallet.params(),
+            seed.expose_secret(),
+            derivation.account_index(),
+        )
+        .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
 
-    // TODO: verify that the proposal satisfies the requested privacy policy
+        #[cfg(feature = "zcashd-import")]
+        let standalone_keys = collect_standalone_transparent_keys(
+            wallet.as_ref(),
+            &keystore,
+            account.id(),
+            &proposal,
+        )
+        .await?;
+
+        // TODO: verify that the proposal satisfies the requested privacy policy
+
+        Ok::<_, jsonrpsee::types::ErrorObjectOwned>((
+            usk.to_unified_full_viewing_key(),
+            #[cfg(feature = "zcashd-import")]
+            SpendingKeys::new(usk, standalone_keys),
+            #[cfg(not(feature = "zcashd-import"))]
+            SpendingKeys::from_unified_spending_key(usk),
+        ))
+    }
+    .await;
+
+    let (ufvk, spending_keys) = match post_proposal {
+        Ok(keys) => keys,
+        Err(e) => {
+            unlock_proposal_inputs_after_failure(wallet.as_mut(), &proposal, lock_owner);
+            return Err(e);
+        }
+    };
 
     Ok((
         Some(ContextInfo::new(
@@ -409,12 +460,10 @@ pub(crate) async fn call<C: Chain>(
             wallet,
             chain,
             account.id(),
-            usk.to_unified_full_viewing_key(),
+            ufvk,
             proposal,
-            #[cfg(feature = "zcashd-import")]
-            SpendingKeys::new(usk, standalone_keys),
-            #[cfg(not(feature = "zcashd-import"))]
-            SpendingKeys::from_unified_spending_key(usk),
+            spending_keys,
+            lock_owner,
         ),
     ))
 }
@@ -430,8 +479,11 @@ pub(crate) async fn call<C: Chain>(
 /// 1. #1159 Currently there is no limit set on the number of elements, which could
 ///    make the tx too large.
 /// 2. #1360 Note selection is not optimal.
-/// 3. #1277 Spendable notes are not locked, so an operation running in parallel
-///    could also try to use them.
+///
+/// `lock_owner` is the owner token the proposal locked its inputs under when it was
+/// created (#1277), or `None` when locking is disabled: when building fails, that owner's
+/// locks are explicitly released; when it succeeds, `store_transactions_to_be_sent`
+/// releases them atomically as it marks the inputs spent.
 async fn run<C: Chain>(
     mut wallet: DbHandle,
     chain: C,
@@ -439,27 +491,44 @@ async fn run<C: Chain>(
     ufvk: UnifiedFullViewingKey,
     proposal: Proposal<StandardFeeRule, ReceivedNoteId>,
     spending_keys: SpendingKeys,
+    lock_owner: Option<LockOwner>,
 ) -> RpcResult<SendResult> {
     let prover = LocalTxProver::bundled();
-    let (wallet, proposal, txids) = crate::spawn_blocking!("z_sendmany prover", move || {
-        let params = *wallet.params();
-        create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-            wallet.as_mut(),
-            &params,
-            &prover,
-            &prover,
-            &spending_keys,
-            OvkPolicy::Sender,
-            &proposal,
-            // No expiry-height override; each transaction keeps its builder-derived expiry.
-            None,
-        )
-        .map(|txids| (wallet, proposal, txids))
-    })
-    .await
-    // TODO: Map errors to `zcashd` shape.
-    .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?
-    .map_err(|e| LegacyCode::Wallet.with_message(format!("Failed to propose transaction: {e}")))?;
+    // The closure returns the wallet and proposal in BOTH outcomes so that the failure
+    // path can release the proposal's input locks. (If the closure panics, the wallet
+    // handle is lost and the locks self-expire at the lock expiry height.)
+    let (mut wallet, proposal, build_result) =
+        crate::spawn_blocking!("z_sendmany prover", move || {
+            let params = *wallet.params();
+            let result = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                wallet.as_mut(),
+                &params,
+                &prover,
+                &prover,
+                &spending_keys,
+                OvkPolicy::Sender,
+                &proposal,
+                // No expiry-height override; each transaction keeps its builder-derived expiry.
+                None,
+            );
+            (wallet, proposal, result)
+        })
+        .await
+        // TODO: Map errors to `zcashd` shape.
+        .map_err(|e| {
+            LegacyCode::Wallet.with_message(format!("Failed to build transaction: {e}"))
+        })?;
+
+    let txids = match build_result {
+        Ok(txids) => txids,
+        Err(e) => {
+            unlock_proposal_inputs_after_failure(wallet.as_mut(), &proposal, lock_owner);
+            // TODO: Map errors to `zcashd` shape.
+            return Err(
+                LegacyCode::Wallet.with_message(format!("Failed to build transaction: {e}"))
+            );
+        }
+    };
 
     verify_and_broadcast_transactions(&wallet, chain, account_id, &ufvk, &proposal, txids.into())
         .await

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -19,7 +19,8 @@ use zcash_client_backend::{
         Account as _, CoinbaseFilter, InputSource, WalletRead,
         wallet::{
             ConfirmationsPolicy, LockRequest, SpendingKeys, TargetHeight,
-            create_proposed_transactions, input_selection::GreedyInputSelector,
+            create_proposed_transactions,
+            input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy},
             propose_shielding_coinbase,
         },
     },
@@ -550,8 +551,9 @@ fn enumerate_eligible(
     let mut total_utxos: u64 = 0;
     let mut total_value_zats = Zatoshis::ZERO;
     // "Eligible" mirrors what shielding selection can actually draw on, and selection
-    // excludes locked outputs.
-    let include_locked = false;
+    // excludes locked outputs (the default `LockedInputPolicy::Exclude`).
+    let locked_input_policy = LockedInputPolicy::Exclude;
+    let lock_filter = LockFilter::Policy(&locked_input_policy);
     for addr in from_addrs {
         let utxos = wallet
             .get_spendable_transparent_outputs(
@@ -559,7 +561,7 @@ fn enumerate_eligible(
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::CoinbaseOnly,
-                include_locked,
+                lock_filter,
             )
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
         total_utxos = total_utxos.saturating_add(utxos.len() as u64);

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -3,25 +3,29 @@
 use std::convert::Infallible;
 use std::future::Future;
 
+use abscissa_core::Application;
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
+use rand::rngs::OsRng;
 use schemars::JsonSchema;
 use secrecy::ExposeSecret;
 use serde::Serialize;
 use transparent::address::TransparentAddress;
 use uuid::Uuid;
 use zcash_address::ZcashAddress;
+use zcash_client_backend::{data_api::error::Error as WalletError, proposal::ProposalError};
 use zcash_client_backend::{
     data_api::{
         Account as _, CoinbaseFilter, InputSource, WalletRead,
         wallet::{
-            ConfirmationsPolicy, SpendingKeys, TargetHeight, create_proposed_transactions,
-            input_selection::GreedyInputSelector, propose_shielding_coinbase,
+            ConfirmationsPolicy, LockRequest, SpendingKeys, TargetHeight,
+            create_proposed_transactions, input_selection::GreedyInputSelector,
+            propose_shielding_coinbase,
         },
     },
     fees::StandardFeeRule,
     proposal::Proposal,
-    wallet::OvkPolicy,
+    wallet::{LockOwner, OvkPolicy},
 };
 use zcash_client_sqlite::AccountUuid;
 use zcash_keys::{
@@ -31,7 +35,9 @@ use zcash_keys::{
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::value::Zatoshis;
 
-use crate::components::json_rpc::payments::enforce_privacy_policy;
+use crate::components::json_rpc::payments::{
+    account_busy_error, enforce_privacy_policy, unlock_proposal_inputs_after_failure,
+};
 use crate::{
     components::{
         chain::Chain,
@@ -204,6 +210,19 @@ pub(crate) async fn call<C: Chain>(
     let params = *wallet.params();
     let input_selector = GreedyInputSelector::new();
 
+    // Lock the proposal's transparent inputs for the configured window, so a concurrent
+    // operation on the same UTXOs cannot select (and double-spend) them while this one
+    // builds. The operation locks under its own fresh random owner token, so releasing
+    // its locks can never disturb a concurrent operation's, and a conflict always means a
+    // different in-flight operation holds the input: the transient "account busy"
+    // condition, which the caller should retry.
+    let lock_inputs = APP
+        .config()
+        .builder
+        .note_lock_blocks()
+        .map(|for_blocks| LockRequest::new(LockOwner::random(&mut OsRng), for_blocks));
+    let lock_owner = lock_inputs.as_ref().map(|request| request.owner());
+
     // Create the shielding proposal. Uses Zatoshis::ZERO as the shielding
     // threshold to shield all available coinbase UTXOs (or all up to `limit`
     // when supplied). `propose_shielding_coinbase` hard-codes
@@ -221,92 +240,142 @@ pub(crate) async fn call<C: Chain>(
         to_zcash_address,
         memo,
         limit_usize,
+        lock_inputs,
     )
-    .map_err(|e| {
-        LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
+    .map_err(|e| match &e {
+        // A lock conflict is transient: a concurrent operation holds one of the selected
+        // inputs. Surface it as a retryable "account busy" error rather than a failure.
+        WalletError::Proposal(ProposalError::InputsLocked(_)) => account_busy_error(),
+        _ => {
+            LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
+        }
     })?;
 
     // Coinbase shielding always reveals the transparent sender(s); when the proposal selects
     // from multiple source addresses (an account UUID expanded to >1 receivers that all hold
     // eligible coinbase UTXOs) it also links those addresses on-chain. The privacy policy
     // parsed above bounds which of these leakages the caller is willing to accept;
-    // `enforce_privacy_policy` rejects the proposal if it requires more than the caller permitted.
-    enforce_privacy_policy(&proposal, privacy_policy)?;
-
-    // Pre-flight numerics. We compute `remaining_*` by enumerating all eligible coinbase UTXOs
-    // (`total_*`) and subtracting the ones the proposal selected (`shielding_*`). The
-    // enumeration is fragile (chain races; see the `checked_sub` errors below) and only exists
-    // because the wallet backend does not yet expose "give me only the unlocked outputs".
-    //
-    // TODO: once note/utxo locking lands upstream (blocked on
-    // https://github.com/zcash/librustzcash/issues/2161), drop the enumeration + subtraction
-    // and read `remaining_utxos`/`remaining_value` directly by querying the wallet for the
-    // outputs that the proposal left unlocked.
-    let (shielding_utxos, shielding_value_zats) = sum_selected_inputs(&proposal)?;
-    let target_height = proposal.min_target_height();
-    let (total_utxos, total_value_zats) =
-        enumerate_eligible(wallet.as_mut(), &from_addrs, target_height)?;
-
-    let remaining_utxos = total_utxos.checked_sub(shielding_utxos).ok_or_else(|| {
-        LegacyCode::Wallet.with_static(
-            "Internal accounting error: proposal selected more UTXOs than \
-             enumeration found (likely a chain race during shielding setup).",
-        )
-    })?;
-    let remaining_value_zats = (total_value_zats - shielding_value_zats).ok_or_else(|| {
-        LegacyCode::Wallet.with_static(
-            "Internal accounting error: proposal value exceeds enumerated total \
-             (likely a chain race during shielding setup).",
-        )
-    })?;
-
-    // Only warn when the caller did not constrain the batch themselves; if
-    // `limit` was supplied, the caller has already opted into a specific batch
-    // size and the warning is noise.
-    if limit.is_none() && shielding_utxos > COINBASE_INPUTS_WARN_THRESHOLD {
-        warn!(
-            "z_shieldcoinbase: proposal selected {} coinbase UTXOs, which exceeds the \
-             soft warning threshold of {}. The resulting transaction may exceed \
-             network/mempool size limits at broadcast time. If broadcast fails, retry \
-             with a `limit` parameter to shield in smaller batches.",
-            shielding_utxos, COINBASE_INPUTS_WARN_THRESHOLD,
-        );
+    // `enforce_privacy_policy` rejects the proposal if it requires more than the caller
+    // permitted. The proposal's inputs are already locked at this point, so a rejection
+    // must release them.
+    if let Err(e) = enforce_privacy_policy(&proposal, privacy_policy) {
+        unlock_proposal_inputs_after_failure(wallet.as_mut(), &proposal, lock_owner);
+        return Err(e.into());
     }
 
-    let preflight = Preflight {
-        remaining_utxos,
-        remaining_value: value_from_zatoshis(remaining_value_zats),
-        shielding_utxos,
-        shielding_value: value_from_zatoshis(shielding_value_zats),
-    };
+    // Whether the proposal's inputs were locked (the request was moved into the propose
+    // call; the retained owner token is the handle for releasing them).
+    let lock_inputs_taken = lock_owner.is_some();
 
-    // Derive the spending key for the source account.
-    let derivation = account.source().key_derivation().ok_or_else(|| {
-        LegacyCode::InvalidAddressOrKey.with_message(format!(
-            "No payment source found for account {}.",
-            account_id.expose_uuid(),
-        ))
-    })?;
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
+    // From here until `create_proposed_transactions` stores the built transaction, this
+    // function owns the proposal's input locks: every error on this path must release
+    // them, or the UTXOs would stay unspendable until the lock window expires.
+    let post_proposal = async {
+        // Pre-flight numerics. We compute `remaining_*` by enumerating all eligible coinbase
+        // UTXOs (`total_*`) and subtracting the ones the proposal selected (`shielding_*`).
+        // The enumeration excludes locked outputs, including the ones this proposal just
+        // locked, so the subtraction runs against the pre-lock view: `enumerate_eligible`
+        // adds the proposal's own (now locked) selection back by construction, because
+        // `total_*` is computed from `shielding_*` plus the remaining unlocked outputs.
+        let (shielding_utxos, shielding_value_zats) = sum_selected_inputs(&proposal)?;
+        let target_height = proposal.min_target_height();
+        let (unlocked_utxos, unlocked_value_zats) =
+            enumerate_eligible(wallet.as_mut(), &from_addrs, target_height)?;
+        let (total_utxos, total_value_zats) = if lock_inputs_taken {
+            // The proposal's own inputs were just locked, so the enumeration no longer
+            // sees them; the eligible total is the remaining unlocked outputs plus the
+            // proposal's selection.
+            (
+                unlocked_utxos.saturating_add(shielding_utxos),
+                (unlocked_value_zats + shielding_value_zats).ok_or_else(|| {
+                    LegacyCode::Wallet.with_static(
+                        "Internal error: total transparent value overflowed Zatoshis bounds.",
+                    )
+                })?,
+            )
+        } else {
+            (unlocked_utxos, unlocked_value_zats)
+        };
+
+        let remaining_utxos = total_utxos.checked_sub(shielding_utxos).ok_or_else(|| {
+            LegacyCode::Wallet.with_static(
+                "Internal accounting error: proposal selected more UTXOs than \
+                 enumeration found (likely a chain race during shielding setup).",
+            )
         })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+        let remaining_value_zats = (total_value_zats - shielding_value_zats).ok_or_else(|| {
+            LegacyCode::Wallet.with_static(
+                "Internal accounting error: proposal value exceeds enumerated total \
+                 (likely a chain race during shielding setup).",
+            )
+        })?;
 
-    #[cfg(feature = "zcashd-import")]
-    let standalone_keys =
-        collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account_id, &proposal)
-            .await?;
+        // Only warn when the caller did not constrain the batch themselves; if
+        // `limit` was supplied, the caller has already opted into a specific batch
+        // size and the warning is noise.
+        if limit.is_none() && shielding_utxos > COINBASE_INPUTS_WARN_THRESHOLD {
+            warn!(
+                "z_shieldcoinbase: proposal selected {} coinbase UTXOs, which exceeds the \
+                 soft warning threshold of {}. The resulting transaction may exceed \
+                 network/mempool size limits at broadcast time. If broadcast fails, retry \
+                 with a `limit` parameter to shield in smaller batches.",
+                shielding_utxos, COINBASE_INPUTS_WARN_THRESHOLD,
+            );
+        }
+
+        let preflight = Preflight {
+            remaining_utxos,
+            remaining_value: value_from_zatoshis(remaining_value_zats),
+            shielding_utxos,
+            shielding_value: value_from_zatoshis(shielding_value_zats),
+        };
+
+        // Derive the spending key for the source account.
+        let derivation = account.source().key_derivation().ok_or_else(|| {
+            LegacyCode::InvalidAddressOrKey.with_message(format!(
+                "No payment source found for account {}.",
+                account_id.expose_uuid(),
+            ))
+        })?;
+        let seed = keystore
+            .decrypt_seed(derivation.seed_fingerprint())
+            .await
+            .map_err(|e| match e.kind() {
+                crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                    LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+                }
+                _ => LegacyCode::Database.with_message(e.to_string()),
+            })?;
+        let usk = UnifiedSpendingKey::from_seed(
+            wallet.params(),
+            seed.expose_secret(),
+            derivation.account_index(),
+        )
+        .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+
+        #[cfg(feature = "zcashd-import")]
+        let standalone_keys =
+            collect_standalone_transparent_keys(wallet.as_ref(), &keystore, account_id, &proposal)
+                .await?;
+
+        Ok::<_, jsonrpsee::types::ErrorObjectOwned>((
+            preflight,
+            usk.to_unified_full_viewing_key(),
+            #[cfg(feature = "zcashd-import")]
+            SpendingKeys::new(usk, standalone_keys),
+            #[cfg(not(feature = "zcashd-import"))]
+            SpendingKeys::from_unified_spending_key(usk),
+        ))
+    }
+    .await;
+
+    let (preflight, ufvk, spending_keys) = match post_proposal {
+        Ok(parts) => parts,
+        Err(e) => {
+            unlock_proposal_inputs_after_failure(wallet.as_mut(), &proposal, lock_owner);
+            return Err(e);
+        }
+    };
 
     Ok((
         preflight,
@@ -322,12 +391,10 @@ pub(crate) async fn call<C: Chain>(
             wallet,
             chain,
             account_id,
-            usk.to_unified_full_viewing_key(),
+            ufvk,
             proposal,
-            #[cfg(feature = "zcashd-import")]
-            SpendingKeys::new(usk, standalone_keys),
-            #[cfg(not(feature = "zcashd-import"))]
-            SpendingKeys::from_unified_spending_key(usk),
+            spending_keys,
+            lock_owner,
         ),
     ))
 }
@@ -482,6 +549,9 @@ fn enumerate_eligible(
 ) -> RpcResult<(u64, Zatoshis)> {
     let mut total_utxos: u64 = 0;
     let mut total_value_zats = Zatoshis::ZERO;
+    // "Eligible" mirrors what shielding selection can actually draw on, and selection
+    // excludes locked outputs.
+    let include_locked = false;
     for addr in from_addrs {
         let utxos = wallet
             .get_spendable_transparent_outputs(
@@ -489,6 +559,7 @@ fn enumerate_eligible(
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::CoinbaseOnly,
+                include_locked,
             )
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
         total_utxos = total_utxos.saturating_add(utxos.len() as u64);
@@ -508,6 +579,10 @@ fn enumerate_eligible(
 /// `ufvk` must be derived from the wallet seed: the built transactions' transparent
 /// outputs are verified against it before broadcast, because their addresses come from
 /// wallet database records that are not integrity-protected.
+/// `lock_owner` is the owner token the proposal's transparent inputs were locked under
+/// when it was created, or `None` when locking is disabled: when building fails, that
+/// owner's locks are explicitly released; when it succeeds,
+/// `store_transactions_to_be_sent` releases them atomically as it marks the inputs spent.
 async fn run<C: Chain>(
     mut wallet: DbHandle,
     chain: C,
@@ -515,30 +590,41 @@ async fn run<C: Chain>(
     ufvk: UnifiedFullViewingKey,
     proposal: Proposal<StandardFeeRule, Infallible>,
     spending_keys: SpendingKeys,
+    lock_owner: Option<LockOwner>,
 ) -> RpcResult<SendResult> {
     let prover = LocalTxProver::bundled();
-    let (wallet, proposal, txids) = crate::spawn_blocking!("z_shieldcoinbase runner", move || {
-        let params = *wallet.params();
-        create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
-            wallet.as_mut(),
-            &params,
-            &prover,
-            &prover,
-            &spending_keys,
-            OvkPolicy::Sender,
-            &proposal,
-            // No expiry-height override; the transaction keeps its builder-derived expiry.
-            None,
-        )
-        .map(|txids| (wallet, proposal, txids))
-    })
-    .await
-    .map_err(|e| {
-        LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
-    })?
-    .map_err(|e| {
-        LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
-    })?;
+    // The closure returns the wallet and proposal in BOTH outcomes so that the failure
+    // path can release the proposal's input locks. (If the closure panics, the wallet
+    // handle is lost and the locks self-expire at the lock expiry height.)
+    let (mut wallet, proposal, build_result) =
+        crate::spawn_blocking!("z_shieldcoinbase runner", move || {
+            let params = *wallet.params();
+            let result = create_proposed_transactions::<_, _, Infallible, _, Infallible, _>(
+                wallet.as_mut(),
+                &params,
+                &prover,
+                &prover,
+                &spending_keys,
+                OvkPolicy::Sender,
+                &proposal,
+                // No expiry-height override; the transaction keeps its builder-derived expiry.
+                None,
+            );
+            (wallet, proposal, result)
+        })
+        .await
+        .map_err(|e| {
+            LegacyCode::Wallet.with_message(format!("Failed to build shielding transaction: {e}"))
+        })?;
+
+    let txids = match build_result {
+        Ok(txids) => txids,
+        Err(e) => {
+            unlock_proposal_inputs_after_failure(wallet.as_mut(), &proposal, lock_owner);
+            return Err(LegacyCode::Wallet
+                .with_message(format!("Failed to build shielding transaction: {e}")));
+        }
+    };
 
     verify_and_broadcast_transactions(&wallet, chain, account_id, &ufvk, &proposal, txids.into())
         .await

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 use transparent::{address::TransparentAddress, keys::AccountPubKey};
 use zcash_address::ZcashAddress;
 use zcash_client_backend::{
-    data_api::{Account as _, WalletRead},
+    data_api::{Account as _, WalletRead, wallet::unlock_proposal_inputs},
     proposal::Proposal,
-    wallet::TransparentAddressSource,
+    wallet::{LockOwner, TransparentAddressSource},
     zip321::{Payment, TransactionRequest},
 };
 use zcash_client_sqlite::{AccountUuid, wallet::Account};
@@ -63,6 +63,45 @@ impl AmountParameter {
 ///
 /// Rejects an empty array, duplicate recipient addresses, malformed addresses, and total
 /// output value overflow.
+/// The retryable error returned when a spend operation loses a note-lock conflict.
+///
+/// A lock conflict means a DIFFERENT lock owner (a concurrent operation, each of which
+/// locks under its own random `LockOwner` token) holds one of the inputs this operation
+/// selected; re-locking under the same owner is idempotent and never conflicts. The
+/// condition is transient: the caller should retry once the other operation completes,
+/// fails, or its locks expire.
+pub(super) fn account_busy_error() -> ErrorObjectOwned {
+    LegacyCode::Wallet.with_static(
+        "Account is busy: another in-flight transaction has locked one or more of the \
+         inputs selected by this operation. Retry shortly.",
+    )
+}
+
+/// Releases a locking proposal's input locks after a failure between proposal creation and
+/// the storage of its transactions.
+///
+/// Locks are otherwise released only when `store_transactions_to_be_sent` records the
+/// inputs as spent, or when the lock window expires; without this, a build/prove/sign
+/// failure would leave the account's inputs unspendable until expiry. `lock_owner` is the
+/// owner token the operation locked with; only that owner's locks are released, so a
+/// concurrent operation's locks on other outputs are never disturbed. A failure to unlock
+/// is logged rather than propagated (the original error is what the caller must see, and
+/// the locks self-expire), and `None` (locking disabled or not performed) is a no-op.
+pub(super) fn unlock_proposal_inputs_after_failure<FeeRuleT, NoteRef>(
+    wallet: &mut DbConnection,
+    proposal: &Proposal<FeeRuleT, NoteRef>,
+    lock_owner: Option<LockOwner>,
+) {
+    if let Some(owner) = lock_owner {
+        if let Err(e) = unlock_proposal_inputs(wallet, proposal, owner) {
+            tracing::warn!(
+                "Failed to release a failed operation's input locks (they will expire on \
+                 their own at the lock expiry height): {e}",
+            );
+        }
+    }
+}
+
 pub(super) fn build_request(amounts: &[AmountParameter]) -> RpcResult<TransactionRequest> {
     if amounts.is_empty() {
         return Err(

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -853,11 +853,15 @@ async fn service_address_request<V: ChainView>(
         .map_err(SyncError::Chain)?
         .into_iter()
         .collect();
+    // This enumerates the wallet's view of unspent outputs to compare against the chain;
+    // an in-flight proposal's lock must not hide an output from spent-detection.
+    let include_locked = true;
     let our_outputs = db_data.get_spendable_transparent_outputs(
         &address,
         TargetHeight::from(view_tip + 1),
         ConfirmationsPolicy::MIN,
         CoinbaseFilter::AllTransparentOutputs,
+        include_locked,
     )?;
     let any_spent = our_outputs.iter().any(|output| {
         let outpoint = output.outpoint();

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -48,7 +48,7 @@ use tokio::{sync::Notify, time};
 #[cfg(not(feature = "spend-index"))]
 use zcash_client_backend::data_api::{
     CoinbaseFilter, InputSource, TransactionsInvolvingAddress,
-    wallet::{ConfirmationsPolicy, TargetHeight},
+    wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
 };
 use zcash_client_backend::{
     data_api::{
@@ -854,14 +854,15 @@ async fn service_address_request<V: ChainView>(
         .into_iter()
         .collect();
     // This enumerates the wallet's view of unspent outputs to compare against the chain;
-    // an in-flight proposal's lock must not hide an output from spent-detection.
-    let include_locked = true;
+    // an in-flight proposal's lock must not hide an output from spent-detection, so the
+    // query ignores lock state entirely (a retrieval path, not input selection).
+    let lock_filter = LockFilter::Unfiltered;
     let our_outputs = db_data.get_spendable_transparent_outputs(
         &address,
         TargetHeight::from(view_tip + 1),
         ConfirmationsPolicy::MIN,
         CoinbaseFilter::AllTransparentOutputs,
-        include_locked,
+        lock_filter,
     )?;
     let any_spent = our_outputs.iter().any(|output| {
         let outpoint = output.outpoint();

--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -233,10 +233,33 @@ pub struct BuilderSection {
     /// Values smaller than `trusted_confirmations` are ignored.
     pub untrusted_confirmations: Option<u32>,
 
+    /// The number of blocks for which the inputs selected by a spend proposal are locked.
+    ///
+    /// While a spend operation (e.g. `z_sendmany`, `z_shieldcoinbase`) is in flight, the
+    /// notes and UTXOs it selected are locked so that a concurrent operation on the same
+    /// account cannot select (and double-spend) them. The lock is released when the
+    /// operation's transactions are stored for broadcast, released explicitly if the
+    /// operation fails, and expires on its own once the chain advances this many blocks
+    /// past the operation's target height (self-healing if the wallet crashes while an
+    /// operation is in flight).
+    ///
+    /// Set to `0` to disable input locking entirely.
+    pub note_lock_blocks: Option<u32>,
+
     /// Configurable limits on transaction builder operation (to prevent e.g. memory
     /// exhaustion).
     pub limits: BuilderLimitsSection,
 }
+
+/// The default number of blocks for which a spend proposal's inputs stay locked.
+///
+/// The lock must outlive the worst-case time between input selection and the transactions
+/// being stored for broadcast, which is dominated by proving (seconds to a few minutes per
+/// transaction, longer on constrained hardware or for multi-step proposals). 40 blocks is
+/// 50 minutes at a 75-second block target: comfortably above worst-case proving time, and
+/// the same window as the default `tx_expiry_delta`, so an in-flight transaction's inputs
+/// stay locked at least as long as the transaction itself could still be mined.
+const DEFAULT_NOTE_LOCK_BLOCKS: u32 = 40;
 
 impl BuilderSection {
     /// Whether to spend unconfirmed transparent change when sending transactions.
@@ -289,6 +312,24 @@ impl BuilderSection {
     /// Default is 10.
     pub fn untrusted_confirmations(&self) -> u32 {
         self.untrusted_confirmations.unwrap_or(10)
+    }
+
+    /// The number of blocks for which the inputs selected by a spend proposal are locked,
+    /// or `None` if input locking is disabled (a configured value of `0`).
+    ///
+    /// Default is 40 (about 50 minutes of block time): comfortably above the worst-case
+    /// build-and-prove time of a spend operation, and equal to the default
+    /// `tx_expiry_delta`. See `DEFAULT_NOTE_LOCK_BLOCKS` for the full rationale.
+    ///
+    /// Locks self-expire once the chain advances past the lock height, so a crashed
+    /// operation's inputs become spendable again without intervention; a lock window
+    /// shorter than the worst-case proving time re-opens the double-spend race that
+    /// locking exists to prevent.
+    pub fn note_lock_blocks(&self) -> Option<u32> {
+        match self.note_lock_blocks.unwrap_or(DEFAULT_NOTE_LOCK_BLOCKS) {
+            0 => None,
+            n => Some(n),
+        }
     }
 
     /// Returns the confirmations policy used for spending, based on number of trusted and
@@ -856,6 +897,7 @@ impl ZalletConfig {
                 "trusted_confirmations",
                 conf.builder.trusted_confirmations(),
             ),
+            builder("note_lock_blocks", conf.builder.note_lock_blocks()),
             builder("tx_expiry_delta", conf.builder.tx_expiry_delta()),
             builder(
                 "untrusted_confirmations",


### PR DESCRIPTION
Wires the librustzcash note-locking facility (zcash/librustzcash#2726, itself building on zcash/librustzcash#2716) into Zallet's spend paths, so that concurrent operations on one account cannot select the same inputs during the selection-to-broadcast window (the conflict described in the Zallet audit).

Based directly on `main`; independent of the pool-migration integration branches.

## What this adds

- **Input locking on every spend path.** `z_sendmany` and `z_shieldcoinbase` generate one `LockOwner` per operation and pass `LockRequest::new(owner, note_lock_blocks)` to `propose_transfer` / `propose_shielding_coinbase`, locking the proposal's inputs until `target_height + note_lock_blocks`. Locks are keyed by the owner token: a concurrent operation cannot release or steal them, while the owning operation's retry is an idempotent re-acquire.
- **Config**: `builder.note_lock_blocks` (default **40 blocks**, roughly 50 minutes at 75-second blocks; comfortably above worst-case build+prove time and equal to the default `tx_expiry_delta`, so locks outlive an unmined transaction's validity window; `0` disables locking).
- **Retryable busy error.** A lock conflict (`ProposalError::InputsLocked`) maps to a clear "account is busy, retry shortly" RPC error (LegacyCode -4). In practice a second overlapping operation usually surfaces as insufficient funds instead, because selection excludes locked inputs; the busy error fires only on a genuine check-then-lock race.
- **Unlock on failure.** Every failure between successful proposal creation and transaction storage (privacy-policy rejection, orchard-action limit, seed decryption, build/prove/sign) releases the operation's locks via `unlock_proposal_inputs` under its owner, without masking the original error. If the process dies instead, locks self-expire as the chain advances past the lock window.
- **Recovery**: new `z_clearlockedoutputs(account)` RPC wrapping `clear_locked_outputs`, documented as safe only when no in-flight operation for the account remains.
- **Balance visibility**: `z_getbalanceforaccount` reports per-pool `lockedZat`, and `z_getbalances` populates its `locked` bucket. Locked funds leave the spendable totals but remain part of the account total.

## Dependency pin (temporary)

Note locking has merged to librustzcash `main` (zcash/librustzcash#2716, including zcash/librustzcash#2726), and the librustzcash crates are now pinned by git rev to `main` (`beec9b59`) until the next crates.io release; the pin also mirrors main's git `orchard` entry in `[patch.crates-io]` (its `zcash_primitives` uses the ZIP 374 deferred-anchor builder API). Lockfiles regenerated via `utils/sync-lockfiles.sh`; the lockstep check passes. The pin should be replaced with released crate versions before merging.

## Testing

- `cargo fmt --check`, clippy with zero warnings, and full `cargo test --release` across all three workspaces (root, zebra backend, zaino backend); book RPC reference and example config regenerated.
- End-to-end coverage lives in zcash/integration-tests#180: ten note-locking scenarios across five `qa/rpc-tests` suites (locked-balance visibility, concurrent-send double-spend prevention, unlock-on-broadcast, expiry restoring funds, locks surviving a SIGKILL restart, `z_clearlockedoutputs` recovery, account isolation, all-notes-locked errors, shielding with locking, and the short-lock-window self-heal trade-off). All ten pass live against this branch: `ZALLET_BACKEND=zebra uv run ./qa/rpc-tests/wallet_note_locking.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

