### PR TITLE
Update to librustzcash 0.30/0.10 cohort and zaino 0.5 backend

### DIFF
--- a/.github/workflows/audits.yml
+++ b/.github/workflows/audits.yml
@@ -39,7 +39,27 @@ jobs:
         env:
           TOOLCHAIN: ${{steps.toolchain.outputs.name}}
       - run: cargo install cargo-vet --version ~0.10
+      # cargo-vet decorates each `user-id` in audits.toml with a `# Name (login)`
+      # comment, but only for publishers it can resolve, and it resolves them
+      # solely from the current workspace's imports.lock -- which in turn only
+      # holds publishers of crates in that workspace's own graph. The shared
+      # audits.toml therefore has no single rendering that satisfies every
+      # workspace: entries trusting a publisher whose crates appear in only some
+      # of the graphs (e.g. the zebra-* and tower-* crates, absent from the root
+      # graph) get the comment from those workspaces and lose it from the others,
+      # and cargo-vet reports the mismatch as a store-format error. Normalise the
+      # store for this graph first so that purely cosmetic difference cannot fail
+      # the run; the audit facts themselves are unaffected, as the comments are
+      # regenerated decor that cargo-vet never reads back.
+      - run: cargo vet fmt
+        working-directory: ${{ matrix.workspace }}
       - run: cargo vet --locked
+        working-directory: ${{ matrix.workspace }}
+      # `cargo vet fmt` above would also mask a hand-edited config.toml or
+      # imports.lock, so keep enforcing formatting on the per-workspace files.
+      # Only the shared audits.toml is exempt.
+      - name: Check per-workspace store files are formatted
+        run: git diff --exit-code -- supply-chain/config.toml supply-chain/imports.lock
         working-directory: ${{ matrix.workspace }}
 
   cargo-deny:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -720,6 +720,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-link",
 ]
@@ -1098,6 +1099,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1304,7 +1339,8 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1339,7 +1375,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3007,9 +3044,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3134,6 +3171,35 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.3",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
+ "zcash_script",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
@@ -4131,6 +4197,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+dependencies = [
+ "base64 0.22.1",
+ "bs58",
+ "chrono",
+ "hex",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -5679,7 +5773,7 @@ dependencies = [
  "nix",
  "nonempty",
  "once_cell",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "phf",
  "proptest",
  "quote",
@@ -5720,14 +5814,14 @@ dependencies = [
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding",
- "zcash_keys 0.15.0",
+ "zcash_keys 0.16.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -5750,20 +5844,22 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.24.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5780,7 +5876,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -5800,20 +5896,21 @@ dependencies = [
  "which",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys 0.15.0",
+ "zcash_keys 0.16.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zip32",
  "zip321",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.22.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a496ad83b77e790bd0ea1013db14961b3ff825550097a2658837dc7e92a23d53"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5828,7 +5925,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -5849,11 +5946,12 @@ dependencies = [
  "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_keys 0.16.0",
+ "zcash_pool_migration",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zewif",
  "zip32",
 ]
@@ -5861,7 +5959,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -5901,8 +6000,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5916,7 +6016,7 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
@@ -5926,8 +6026,8 @@ dependencies = [
  "tracing",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_protocol 0.10.1",
+ "zcash_transparent 0.10.0",
  "zeroize",
  "zip32",
 ]
@@ -5943,6 +6043,26 @@ dependencies = [
  "cipher",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "zcash_pool_migration"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e4169a96a25de216d4a7265fe772003aaeea05ed2566b14cfc0b8146b1f99e"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.3",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
@@ -5977,8 +6097,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -5992,7 +6113,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -6000,15 +6121,16 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6024,7 +6146,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
 ]
 
 [[package]]
@@ -6042,8 +6164,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -6105,8 +6228,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -6121,7 +6245,7 @@ dependencies = [
  "subtle",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6285,13 +6409,14 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address 0.13.0",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,16 +120,16 @@ zcash_protocol = "0.10.0"
 # Zcash payment protocols
 orchard = "0.15.0"
 sapling = { package = "sapling-crypto", version = "0.7" }
-transparent = { package = "zcash_transparent", version = "0.9.0" }
+transparent = { package = "zcash_transparent", version = "0.10.0" }
 zcash_encoding = "0.4"
-zcash_keys = { version = "0.15.0", features = [
+zcash_keys = { version = "0.16.0", features = [
     "transparent-inputs",
     "sapling",
     "orchard",
     "transparent-key-encoding",
 ] }
-zcash_primitives = "0.29.0"
-zcash_proofs = "0.29.0"
+zcash_primitives = "0.30.0"
+zcash_proofs = "0.30.0"
 zcash_script = "0.4.3"
 zcash_spec = "0.2"
 secp256k1 = { version = "0.29", features = ["recovery"] }
@@ -148,8 +148,8 @@ schemerz-rusqlite = "0.370.0"
 shardtree = "0.7"
 time = "0.3"
 uuid = "1"
-zcash_client_backend = "0.24.0-rc.1"
-zcash_client_sqlite = "0.22.0-rc.1"
+zcash_client_backend = "0.24.0-rc.4"
+zcash_client_sqlite = "0.22.0-rc.4"
 zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
@@ -162,21 +162,6 @@ anyhow = "1.0"
 
 # lightwalletd (temporary)
 tonic = "0.14"
-
-[patch.crates-io]
-# Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
 
 [profile.release]
 debug = "line-tables-only"

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -37,7 +37,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -268,7 +268,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -454,7 +454,7 @@ version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cexpr",
  "clang-sys",
  "itertools 0.13.0",
@@ -463,7 +463,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex 1.3.0",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -504,9 +504,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitflags-serde-legacy"
@@ -514,7 +514,7 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b64e60c28b6d25ad92e8b367801ff9aa12b41d05fc8798055d296bace4a60cc"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "serde",
 ]
 
@@ -608,7 +608,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dc0086e469182132244e9b8d313a0742e1132da43a08c24b9dd3c18e0faf3a"
 dependencies = [
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -714,9 +714,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -818,7 +818,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -852,7 +852,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1088,9 +1088,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1173,7 +1173,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1206,7 +1206,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1217,7 +1217,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1303,7 +1303,7 @@ checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1335,7 +1335,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1389,7 +1389,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1409,7 +1409,7 @@ checksum = "ed6b3e31251e87acd1b74911aed84071c8364fc9087972748ade2f1094ccce34"
 dependencies = [
  "documented-macros",
  "phf",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1424,7 +1424,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1523,7 +1523,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1543,7 +1544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1559,7 +1560,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -1684,7 +1686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54f0d287c53ffd184d04d8677f590f4ac5379785529e5e08b1c8083acdd5c198"
 dependencies = [
  "memchr",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1766,7 +1768,7 @@ dependencies = [
  "rand_core 0.6.4",
  "serde",
  "serdect",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "visibility",
  "zeroize",
  "zeroize_derive",
@@ -1862,7 +1864,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1968,7 +1970,7 @@ checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1993,7 +1995,7 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "libc",
  "libgit2-sys",
  "log",
@@ -2458,7 +2460,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unic-langid",
 ]
 
@@ -2472,7 +2474,7 @@ dependencies = [
  "i18n-config",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2618,15 +2620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-codec"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d40b9d5e17727407e55028eafc22b2dc68781786e6d7eb8a21103f5058e3a14"
-dependencies = [
- "parity-scale-codec",
-]
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2634,7 +2627,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2724,7 +2717,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2804,7 +2797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2900,7 +2893,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3096,7 +3089,7 @@ checksum = "3f8ce05b56f3cbc65ec7d0908adb308ed91281e022f61c8c3a0c9388b5380b17"
 dependencies = [
  "bindgen",
  "cc",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tracing",
  "zcash_script",
 ]
@@ -3242,7 +3235,7 @@ checksum = "7c9303a7d70578b101a21b3043ade4ab825c59063bbcd89af1066729399b79c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3311,7 +3304,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3323,7 +3316,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3353,12 +3346,6 @@ name = "nonempty"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "549e471b99ccaf2f89101bec68f4d244457d5a95a9c3d0672e9564124397741d"
-
-[[package]]
-name = "nonempty"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9737e026353e5cd0736f98eddae28665118eb6f6600902a7f50db585621fecb6"
 
 [[package]]
 name = "nu-ansi-term"
@@ -3429,7 +3416,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -3477,10 +3464,10 @@ dependencies = [
  "documented",
  "jsonrpsee",
  "quote",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "serde_json",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3497,7 +3484,7 @@ checksum = "969ccca8ffc4fb105bd131a228107d5c9dd89d9d627edf3295cbe979156f9712"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3527,7 +3514,7 @@ dependencies = [
  "incrementalmerkletree",
  "lazy_static",
  "memuse",
- "nonempty 0.11.0",
+ "nonempty",
  "pasta_curves",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -3544,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3563,7 +3550,7 @@ dependencies = [
  "incrementalmerkletree",
  "lazy_static",
  "memuse",
- "nonempty 0.11.0",
+ "nonempty",
  "pasta_curves",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -3638,7 +3625,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3699,6 +3686,35 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.3",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
+ "zcash_script",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
@@ -3768,7 +3784,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3797,7 +3813,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3910,7 +3926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3929,19 +3945,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
 dependencies = [
  "fixed-hash",
- "impl-codec 0.6.0",
+ "impl-codec",
  "uint 0.9.5",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721a1da530b5a2633218dc9f75713394c983c352be88d2d7c9ee85e2c4c21794"
-dependencies = [
- "fixed-hash",
- "impl-codec 0.7.1",
- "uint 0.10.0",
 ]
 
 [[package]]
@@ -3950,7 +3955,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.12+spec-1.1.0",
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3972,7 +3977,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4011,7 +4016,7 @@ dependencies = [
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
 ]
 
@@ -4025,7 +4030,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4059,7 +4064,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "memchr",
  "unicase",
 ]
@@ -4110,7 +4115,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "web-time",
@@ -4131,7 +4136,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4148,14 +4153,14 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -4332,7 +4337,7 @@ dependencies = [
  "pasta_curves",
  "rand_core 0.6.4",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "zeroize",
 ]
 
@@ -4355,7 +4360,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
@@ -4366,7 +4371,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.17",
  "libredox",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -4386,7 +4391,7 @@ checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4583,7 +4588,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
  "hashlink",
@@ -4613,7 +4618,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rust-embed-utils",
- "syn 2.0.118",
+ "syn 2.0.119",
  "walkdir",
 ]
 
@@ -4674,11 +4679,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4737,7 +4742,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4844,9 +4849,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -4857,14 +4862,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4966,7 +4971,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -5035,18 +5040,18 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5105,7 +5110,7 @@ dependencies = [
  "indexmap 1.9.3",
  "indexmap 2.14.0",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -5121,7 +5126,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5205,7 +5210,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9cc96e9b6b1c307749019e7e2cf9dd29881b1928ce6866e3702a02a4800aa345"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "either",
  "incrementalmerkletree",
  "tracing",
@@ -5364,7 +5369,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5386,9 +5391,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5412,7 +5428,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5437,10 +5453,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5463,11 +5479,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.19",
 ]
 
 [[package]]
@@ -5478,18 +5494,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5585,7 +5601,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5702,14 +5718,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5718,7 +5734,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.3",
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5774,7 +5790,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5799,7 +5815,7 @@ dependencies = [
  "prost-build",
  "prost-types",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "tonic-build",
 ]
@@ -5856,9 +5872,9 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a49cdaf2b00c1150c93a8dbbb63cae193573903a3c9a07b5d4d61251b9e32f0"
+checksum = "58bb785abb0207bee98b1d7d874467bb1043d4e434f9a8c8a4714603563c762b"
 dependencies = [
  "futures",
  "futures-core",
@@ -5873,9 +5889,9 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.42"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "700cd6732c9c9e2c77501cc663708b2229abc9e8fa27d3deae15126330a1ed87"
+checksum = "c700b6ca0cca8b86ef35046dfc7bab9196b8271ab72e9d410f8f63d94857d14f"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -5889,7 +5905,7 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bytes",
  "futures-util",
  "http",
@@ -5933,7 +5949,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6221,7 +6237,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6384,7 +6400,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
@@ -6463,7 +6479,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6487,7 +6503,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6498,7 +6514,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6693,9 +6709,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6770,20 +6786,17 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zaino-common"
-version = "0.2.0"
-source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
+version = "0.4.0"
+source = "git+https://github.com/zodl-inc/zaino.git?rev=d2d06bdd#d2d06bdd6591f3b238a3829b8f1b973ae0ec40be"
 dependencies = [
- "hex",
- "nu-ansi-term",
  "rustls",
  "serde",
- "thiserror 2.0.18",
  "time",
  "tracing",
  "tracing-subscriber",
@@ -6793,8 +6806,8 @@ dependencies = [
 
 [[package]]
 name = "zaino-fetch"
-version = "0.2.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
+version = "0.4.0"
+source = "git+https://github.com/zodl-inc/zaino.git?rev=d2d06bdd#d2d06bdd6591f3b238a3829b8f1b973ae0ec40be"
 dependencies = [
  "base64 0.22.1",
  "derive_more",
@@ -6806,7 +6819,7 @@ dependencies = [
  "reqwest 0.13.1",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tonic",
  "tracing",
@@ -6819,8 +6832,8 @@ dependencies = [
 
 [[package]]
 name = "zaino-proto"
-version = "0.1.3"
-source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
+version = "0.2.0"
+source = "git+https://github.com/zodl-inc/zaino.git?rev=d2d06bdd#d2d06bdd6591f3b238a3829b8f1b973ae0ec40be"
 dependencies = [
  "prost",
  "tonic",
@@ -6833,33 +6846,28 @@ dependencies = [
 
 [[package]]
 name = "zaino-state"
-version = "0.3.1"
-source = "git+https://github.com/zingolabs/zaino.git?rev=8048bf8df61cd409af8c22518a16514bee02a0fb#8048bf8df61cd409af8c22518a16514bee02a0fb"
+version = "0.5.0"
+source = "git+https://github.com/zodl-inc/zaino.git?rev=d2d06bdd#d2d06bdd6591f3b238a3829b8f1b973ae0ec40be"
 dependencies = [
  "arc-swap",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "blake2",
- "bs58",
  "chrono",
  "corez",
  "dashmap",
- "derive_more",
  "futures",
  "hex",
  "incrementalmerkletree",
  "indexmap 2.14.0",
  "lmdb",
  "lmdb-sys",
- "nonempty 0.12.0",
- "primitive-types 0.14.0",
- "prost",
  "reqwest 0.13.1",
  "sapling-crypto",
  "serde",
  "serde_json",
  "sha2 0.10.9",
  "simple-mermaid",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6871,10 +6879,10 @@ dependencies = [
  "zaino-fetch",
  "zaino-proto",
  "zcash_address 0.13.0",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6916,8 +6924,8 @@ dependencies = [
  "jsonrpsee-http-client",
  "known-folders",
  "nix 0.29.0",
- "nonempty 0.11.0",
- "orchard 0.15.0",
+ "nonempty",
+ "orchard 0.15.3",
  "phf",
  "quote",
  "rand 0.8.7",
@@ -6926,7 +6934,7 @@ dependencies = [
  "rust-embed",
  "rust_decimal",
  "sapling-crypto",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "schemerz",
  "schemerz-rusqlite",
  "secp256k1",
@@ -6937,7 +6945,7 @@ dependencies = [
  "sha2 0.10.9",
  "shadow-rs",
  "shardtree",
- "syn 2.0.118",
+ "syn 2.0.119",
  "tempfile",
  "time",
  "tokio",
@@ -6955,14 +6963,14 @@ dependencies = [
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding",
- "zcash_keys 0.15.0",
+ "zcash_keys 0.16.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6979,7 +6987,7 @@ dependencies = [
  "incrementalmerkletree",
  "jsonrpsee",
  "once_cell",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "sapling-crypto",
  "tempfile",
  "tokio",
@@ -6988,10 +6996,10 @@ dependencies = [
  "zaino-state",
  "zallet-core",
  "zcash_client_backend",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -7014,20 +7022,22 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.24.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7043,8 +7053,8 @@ dependencies = [
  "hyper-util",
  "incrementalmerkletree",
  "memuse",
- "nonempty 0.11.0",
- "orchard 0.15.0",
+ "nonempty",
+ "orchard 0.15.3",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -7064,25 +7074,26 @@ dependencies = [
  "which",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys 0.15.0",
+ "zcash_keys 0.16.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zip32",
  "zip321",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.22.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a496ad83b77e790bd0ea1013db14961b3ff825550097a2658837dc7e92a23d53"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
  "bip32",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bs58",
  "byteorder",
  "document-features",
@@ -7091,8 +7102,8 @@ dependencies = [
  "incrementalmerkletree",
  "jubjub",
  "maybe-rayon",
- "nonempty 0.11.0",
- "orchard 0.15.0",
+ "nonempty",
+ "orchard 0.15.3",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -7113,11 +7124,12 @@ dependencies = [
  "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_keys 0.16.0",
+ "zcash_pool_migration",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zewif",
  "zip32",
 ]
@@ -7125,11 +7137,12 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
- "nonempty 0.11.0",
+ "nonempty",
 ]
 
 [[package]]
@@ -7140,7 +7153,7 @@ checksum = "69d2ed9a9fa7b466a7adedab1ad5a21f8330e4943756912fc776cf7f3beae32b"
 dependencies = [
  "blake2b_simd",
  "byteorder",
- "primitive-types 0.12.2",
+ "primitive-types",
 ]
 
 [[package]]
@@ -7159,7 +7172,7 @@ dependencies = [
  "document-features",
  "group",
  "memuse",
- "nonempty 0.11.0",
+ "nonempty",
  "orchard 0.14.0",
  "rand_core 0.6.4",
  "regex",
@@ -7176,8 +7189,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7190,8 +7204,8 @@ dependencies = [
  "document-features",
  "group",
  "memuse",
- "nonempty 0.11.0",
- "orchard 0.15.0",
+ "nonempty",
+ "orchard 0.15.3",
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
@@ -7201,8 +7215,8 @@ dependencies = [
  "tracing",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_protocol 0.10.1",
+ "zcash_transparent 0.10.0",
  "zeroize",
  "zip32",
 ]
@@ -7218,6 +7232,26 @@ dependencies = [
  "cipher",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "zcash_pool_migration"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e4169a96a25de216d4a7265fe772003aaeea05ed2566b14cfc0b8146b1f99e"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.3",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
@@ -7237,7 +7271,7 @@ dependencies = [
  "incrementalmerkletree",
  "jubjub",
  "memuse",
- "nonempty 0.11.0",
+ "nonempty",
  "orchard 0.14.0",
  "rand_core 0.6.4",
  "redjubjub",
@@ -7252,8 +7286,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7266,8 +7301,8 @@ dependencies = [
  "incrementalmerkletree",
  "jubjub",
  "memuse",
- "nonempty 0.11.0",
- "orchard 0.15.0",
+ "nonempty",
+ "orchard 0.15.3",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -7275,15 +7310,16 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7299,7 +7335,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
 ]
 
 [[package]]
@@ -7317,8 +7353,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -7334,14 +7371,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f872800287d118be71bdf6fe8c869c6a6ff6fb0a5762f68fb2af54c97edf0f2"
 dependencies = [
  "bip32",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bounded-vec",
  "hex",
  "ripemd 0.1.3",
  "secp256k1",
  "sha1",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7365,7 +7402,7 @@ dependencies = [
  "document-features",
  "getset",
  "hex",
- "nonempty 0.11.0",
+ "nonempty",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",
@@ -7380,8 +7417,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -7389,14 +7427,14 @@ dependencies = [
  "document-features",
  "getset",
  "hex",
- "nonempty 0.11.0",
+ "nonempty",
  "ripemd 0.1.3",
  "secp256k1",
  "sha2 0.10.9",
  "subtle",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7404,12 +7442,12 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "11.1.0"
+version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014adde138ea00b1cf6c873aaf56aacb5aa0d55b8e5451a3e3b1b06c461bd107"
+checksum = "825050a409c120d9dd0cffb36d99638a5e716e9cb092662009d087b4c227cc14"
 dependencies = [
  "bech32 0.11.1",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "bitflags-serde-legacy",
  "bitvec",
  "blake2b_simd",
@@ -7432,15 +7470,15 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.15.0",
- "primitive-types 0.12.2",
+ "orchard 0.15.3",
+ "primitive-types",
  "rand_core 0.6.4",
  "rayon",
  "reddsa",
  "redjubjub",
  "ripemd 0.1.3",
  "sapling-crypto",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "secp256k1",
  "serde",
  "serde-big-array",
@@ -7451,7 +7489,7 @@ dependencies = [
  "static_assertions",
  "strum",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tracing",
  "uint 0.10.0",
@@ -7460,17 +7498,17 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
 name = "zebra-consensus"
-version = "11.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4481ced3223226db18e33b9fb2e8eab7f7cefeae1681f4e8d8d7e3c2285a5c4d"
+checksum = "1f2a2f87471e58f9cedee3698ac4eeb6502ec60d059b054d67796eccfb896439"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7486,23 +7524,23 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "rand 0.8.7",
  "rayon",
  "sapling-crypto",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower 0.4.13",
  "tower-batch-control",
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7511,11 +7549,11 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "10.1.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a59dc9e9ac723c4c01d985a5ecf3ddd85c0f1681574457d52173c43263905f2"
+checksum = "4592281fa43e961048c4a2a4c153be1eacff481d64f0340bc70e1f9b84c53eca"
 dependencies = [
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -7533,10 +7571,10 @@ dependencies = [
  "rand 0.8.7",
  "rayon",
  "regex",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -7549,9 +7587,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "9.1.0"
+version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006992c62b9c4742a13a306f2e7443646fa0b5b884aac63a6fba5b0be273f864"
+checksum = "aee11bf0e45b764d09722f1e8f4c5a8d86ef021d9698b576bdf81d325c75b9b8"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7565,9 +7603,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "11.1.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d071b177740cdc1107f90dd50fac67e1b440a84c8509ae1529b3609fb6f801d"
+checksum = "761839b2ad7ff46c1836521f674d76458cd1c78f555e56d2259ead4cc9ddb170"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7586,12 +7624,12 @@ dependencies = [
  "metrics",
  "nix 0.30.1",
  "openrpsee",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "phf",
  "prost",
  "rand 0.8.7",
  "sapling-crypto",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "semver",
  "serde",
  "serde_json",
@@ -7599,7 +7637,7 @@ dependencies = [
  "strum",
  "strum_macros",
  "subtle",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
  "tonic",
@@ -7610,12 +7648,12 @@ dependencies = [
  "tracing",
  "which",
  "zcash_address 0.13.0",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7626,23 +7664,23 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "10.1.0"
+version = "10.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c967badb1bb99573dba430948c98fbca940daf23915f2e9736e1a1d2a166f3"
+checksum = "ad711c56bfe377e184a9dfbec4d2c21633d0254bbea5338d20640fd62574bb88"
 dependencies = [
  "libzcash_script",
  "rand 0.8.7",
- "thiserror 2.0.18",
- "zcash_primitives 0.29.0",
+ "thiserror 2.0.19",
+ "zcash_primitives 0.30.0",
  "zcash_script",
  "zebra-chain",
 ]
 
 [[package]]
 name = "zebra-state"
-version = "10.1.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39295d344c1cc56ed725646cfc7bb7e16f8edae7518ea5a9e599665f979e9cf6"
+checksum = "b01b530a3fdd28a9d2988895272e970bc0053acf6dbf467785f146cabf21ac3f"
 dependencies = [
  "bincode",
  "chrono",
@@ -7669,7 +7707,7 @@ dependencies = [
  "serde",
  "serde-big-array",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -7694,7 +7732,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7714,7 +7752,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -7735,7 +7773,7 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7769,7 +7807,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -7780,7 +7818,7 @@ checksum = "9b300001aff0db0e844ea42359640b6abe648776b055d7861fb7075782abb715"
 dependencies = [
  "hex",
  "minicbor",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7791,7 +7829,7 @@ checksum = "33950619fb1ed89b7878a8d147b23469f3000702706f631b3510ea340bdfff44"
 dependencies = [
  "aes",
  "bech32 0.12.0",
- "bitflags 2.13.0",
+ "bitflags 2.13.1",
  "blake2b_simd",
  "bridgetree",
  "bs58",
@@ -7806,7 +7844,7 @@ dependencies = [
  "secp256k1",
  "secrecy 0.8.0",
  "sha2 0.10.9",
- "thiserror 2.0.18",
+ "thiserror 2.0.19",
  "uuid",
  "zcash_address 0.12.0",
  "zcash_encoding",
@@ -7835,13 +7873,14 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address 0.13.0",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -30,17 +30,17 @@ orchard = "0.15.0"
 sapling = { package = "sapling-crypto", version = "0.7" }
 jsonrpsee = "0.24"
 tokio = { version = "1", features = ["net", "rt-multi-thread"] }
-transparent = { package = "zcash_transparent", version = "0.9.0" }
-zaino-common = "0.2"
-zaino-fetch = "0.2.1"
-zaino-state = "0.3.1"
-zcash_client_backend = "0.24.0-rc.1"
-zcash_keys = { version = "0.15.0", features = ["unstable"] }
-zcash_primitives = "0.29.0"
+transparent = { package = "zcash_transparent", version = "0.10.0" }
+zaino-common = "0.4"
+zaino-fetch = "0.4"
+zaino-state = "0.5"
+zcash_client_backend = "0.24.0-rc.4"
+zcash_keys = { version = "0.16.0", features = ["unstable"] }
+zcash_primitives = "0.30.0"
 zcash_protocol = "0.10.0"
-zebra-chain = "11"
-zebra-rpc = "11"
-zebra-state = "10"
+zebra-chain = "11.3"
+zebra-rpc = "15.0"
+zebra-state = "12.0.1"
 
 [features]
 default = []
@@ -72,27 +72,17 @@ once_cell = "1.2"
 tempfile = "3"
 
 [patch.crates-io]
-# Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-
-# TEMPORARY: pin the zaino crates to zingolabs/zaino `dev` (currently 8048bf8d),
-# which surfaces the Ironwood (NU6.3) note commitment treestate from
-# `get_treestate` (now a `(sapling, orchard, ironwood)` triple of
-# `PoolTreestate`). Reading the real Ironwood frontier is required for Ironwood
-# notes to be spendable; an empty frontier conflicts with the wallet's advancing
-# tree and sync fails with `CheckpointConflict`. Repoint at upstream zaino once
-# the NU6.3 work lands in a release.
-zaino-common = { git = "https://github.com/zingolabs/zaino.git", rev = "8048bf8df61cd409af8c22518a16514bee02a0fb" }
-zaino-fetch = { git = "https://github.com/zingolabs/zaino.git", rev = "8048bf8df61cd409af8c22518a16514bee02a0fb" }
-zaino-state = { git = "https://github.com/zingolabs/zaino.git", rev = "8048bf8df61cd409af8c22518a16514bee02a0fb" }
+# TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
+# `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash
+# 0.30/0.10 cohort matching this workspace and surfaces the Ironwood (NU6.3)
+# note commitment treestate from `get_treestate` (now a `(sapling, orchard,
+# ironwood)` triple of `PoolTreestate`). Reading the real Ironwood frontier is
+# required for Ironwood notes to be spendable; an empty frontier conflicts with
+# the wallet's advancing tree and sync fails with `CheckpointConflict`. This is
+# zingolabs/zaino#1428; repoint at upstream zaino once it (and the NU6.3 work)
+# lands in a release. The zebra crates are consumed from crates.io at the
+# librustzcash 0.30/0.10 versions (chain 11.3 / state 12.0.1 / rpc 15.0), so no
+# zebra [patch] is needed.
+zaino-common = { git = "https://github.com/zodl-inc/zaino.git", rev = "d2d06bdd" }
+zaino-fetch = { git = "https://github.com/zodl-inc/zaino.git", rev = "d2d06bdd" }
+zaino-state = { git = "https://github.com/zodl-inc/zaino.git", rev = "d2d06bdd" }

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -76,35 +76,6 @@ fn block_fetch_error(
     }
 }
 
-/// Converts the wallet's network parameters into Zaino's network type.
-fn network_to_zaino(network: Network) -> zaino_common::Network {
-    use zcash_protocol::consensus;
-    match network {
-        Network::Consensus(network) => match network {
-            consensus::Network::MainNetwork => zaino_common::Network::Mainnet,
-            consensus::Network::TestNetwork => zaino_common::Network::Testnet,
-        },
-        // TODO: This does not create a compatible regtest network because Zebra does
-        // not have the necessary flexibility.
-        Network::RegTest(local_network) => {
-            zaino_common::Network::Regtest(zaino_common::network::ActivationHeights {
-                before_overwinter: Some(1),
-                overwinter: local_network.overwinter.map(|h| h.into()),
-                sapling: local_network.sapling.map(|h| h.into()),
-                blossom: local_network.blossom.map(|h| h.into()),
-                heartwood: local_network.heartwood.map(|h| h.into()),
-                canopy: local_network.canopy.map(|h| h.into()),
-                nu5: local_network.nu5.map(|h| h.into()),
-                nu6: local_network.nu6.map(|h| h.into()),
-                nu6_1: local_network.nu6_1.map(|h| h.into()),
-                nu6_2: local_network.nu6_2.map(|h| h.into()),
-                nu6_3: local_network.nu6_3.map(|h| h.into()),
-                nu7: None,
-            })
-        }
-    }
-}
-
 /// Converts a `zcash_protocol` block height into a Zaino block height.
 fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
     u32::from(height)
@@ -115,8 +86,8 @@ fn to_zaino_height(height: BlockHeight) -> zaino_state::Height {
 /// The Zaino finalised-state database schema version to target.
 ///
 /// `1` selects Zaino's latest v1 finalised-state schema. We run the indexer in ephemeral
-/// mode (see [`ChainIndexConfig::new`] below), so no persistent finalised-state database
-/// is actually opened and this value has no on-disk effect; it is set to the current
+/// mode (see the [`ChainIndexConfig`] construction below), so no persistent finalised-state
+/// database is actually opened and this value has no on-disk effect; it is set to the current
 /// schema version for forward-compatibility if ephemeral mode is ever disabled.
 const ZAINO_FINALISED_DB_VERSION: u32 = 1;
 
@@ -206,8 +177,8 @@ impl ZainoChain {
         .await
         .map_err(|e| ErrorKind::Init.context(e))?;
 
-        let indexer_config = ChainIndexConfig::new(
-            StorageConfig {
+        let indexer_config = ChainIndexConfig {
+            storage: StorageConfig {
                 cache: CacheConfig::default(),
                 database: DatabaseConfig {
                     path: config.indexer_db_path().to_path_buf(),
@@ -219,12 +190,15 @@ impl ZainoChain {
                     ..Default::default()
                 },
             },
-            ZAINO_FINALISED_DB_VERSION,
-            network_to_zaino(params),
+            db_version: ZAINO_FINALISED_DB_VERSION,
+            // zaino 0.5 carries the runtime network (activation schedule adopted from
+            // the validator) as a `zebra_chain::parameters::Network`; zallet already
+            // derives that for the co-located-zebrad read-state path.
+            network: network_to_zebra(&params).map_err(|e| ErrorKind::Init.context(e))?,
             // Run the finalised state ephemerally: no persistent database, finalised
             // reads are served from the backing validator.
-            true,
-        );
+            ephemeral: true,
+        };
 
         // Select the chain-data source. By default Zaino fetches all chain data over
         // JSON-RPC; if `[indexer.read_state_service]` is configured, it instead reads
@@ -247,7 +221,7 @@ impl ZainoChain {
                 let source = ValidatorConnector::State(State {
                     read_state_service,
                     mempool_fetcher: fetcher.clone(),
-                    network: network_to_zaino(params),
+                    network: network_to_zebra(&params).map_err(|e| ErrorKind::Init.context(e))?,
                     chain_tip_change,
                     // The wallet retains ownership of the syncer via the
                     // `AbortOnDrop` guard below (aborted on every shutdown path),

--- a/backends/zaino/supply-chain/config.toml
+++ b/backends/zaino/supply-chain/config.toml
@@ -22,11 +22,12 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
+[imports.zebra]
+url = "https://raw.githubusercontent.com/ZcashFoundation/zebra/main/supply-chain/audits.toml"
+
 [policy.equihash]
-audit-as-crates-io = false
 
 [policy.f4jumble]
-audit-as-crates-io = false
 
 [policy.incrementalmerkletree]
 
@@ -49,33 +50,24 @@ audit-as-crates-io = false
 audit-as-crates-io = false
 
 [policy.zcash_address]
-audit-as-crates-io = false
 
 [policy.zcash_client_backend]
-audit-as-crates-io = false
 
 [policy.zcash_client_sqlite]
-audit-as-crates-io = false
 
 [policy.zcash_encoding]
-audit-as-crates-io = false
 
 [policy.zcash_history]
 
 [policy.zcash_keys]
-audit-as-crates-io = false
 
 [policy.zcash_primitives]
-audit-as-crates-io = false
 
 [policy.zcash_proofs]
-audit-as-crates-io = false
 
 [policy.zcash_protocol]
-audit-as-crates-io = false
 
 [policy.zcash_transparent]
-audit-as-crates-io = false
 
 [policy.zebra-chain]
 
@@ -92,7 +84,6 @@ audit-as-crates-io = false
 [policy.zebra-state]
 
 [policy.zip321]
-audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -215,7 +206,7 @@ version = "0.6.0-pre.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitflags]]
-version = "2.13.0"
+version = "2.13.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.bitflags-serde-legacy]]
@@ -663,7 +654,7 @@ version = "0.1.16"
 criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
-version = "0.2.15"
+version = "0.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.getrandom]]
@@ -844,10 +835,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.impl-codec]]
 version = "0.6.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.impl-codec]]
-version = "0.7.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.impl-trait-for-tuples]]
@@ -1086,16 +1073,8 @@ criteria = "safe-to-deploy"
 version = "0.7.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.nix]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.nom]]
 version = "8.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.nonempty]]
-version = "0.12.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.num-bigint]]
@@ -1258,10 +1237,6 @@ criteria = "safe-to-deploy"
 version = "0.12.2"
 criteria = "safe-to-deploy"
 
-[[exemptions.primitive-types]]
-version = "0.14.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.proc-macro-crate]]
 version = "3.5.0"
 criteria = "safe-to-deploy"
@@ -1312,10 +1287,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.quinn-proto]]
 version = "0.11.15"
-criteria = "safe-to-deploy"
-
-[[exemptions.quote]]
-version = "1.0.46"
 criteria = "safe-to-deploy"
 
 [[exemptions.r-efi]]
@@ -1519,11 +1490,11 @@ version = "0.1.29"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars]]
-version = "1.2.1"
+version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemars_derive]]
-version = "1.2.1"
+version = "1.2.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.schemerz]]
@@ -1579,7 +1550,7 @@ version = "0.5.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_derive_internals]]
-version = "0.29.1"
+version = "0.30.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.serde_json]]
@@ -1679,7 +1650,11 @@ version = "1.0.109"
 criteria = "safe-to-deploy"
 
 [[exemptions.syn]]
-version = "2.0.118"
+version = "2.0.119"
+criteria = "safe-to-deploy"
+
+[[exemptions.syn]]
+version = "3.0.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.sync_wrapper]]
@@ -1699,11 +1674,11 @@ version = "1.4.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror]]
-version = "2.0.17"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.thiserror-impl]]
-version = "2.0.17"
+version = "2.0.19"
 criteria = "safe-to-deploy"
 
 [[exemptions.time]]
@@ -1767,7 +1742,7 @@ version = "0.22.27"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_edit]]
-version = "0.25.12+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.toml_parser]]
@@ -1808,14 +1783,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.tower]]
 version = "0.5.3"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-batch-control]]
-version = "1.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-fallback]]
-version = "0.2.42"
 criteria = "safe-to-deploy"
 
 [[exemptions.tower-http]]
@@ -1886,10 +1853,6 @@ criteria = "safe-to-deploy"
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.uint]]
-version = "0.10.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.unicase]]
 version = "2.9.0"
 criteria = "safe-to-deploy"
@@ -1908,10 +1871,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
 version = "1.23.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.version_check]]
-version = "0.9.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.wait-timeout]]
@@ -1987,7 +1946,7 @@ version = "0.7.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.winnow]]
-version = "1.0.3"
+version = "1.0.4"
 criteria = "safe-to-deploy"
 
 [[exemptions.writeable]]
@@ -2027,31 +1986,31 @@ version = "0.4.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
-version = "11.1.0"
+version = "11.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-consensus]]
-version = "11.0.0"
+version = "14.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-network]]
-version = "10.1.0"
+version = "11.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-node-services]]
-version = "9.1.0"
+version = "9.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-rpc]]
-version = "11.1.0"
+version = "15.0.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-script]]
-version = "10.1.0"
+version = "10.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-state]]
-version = "10.1.0"
+version = "12.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/backends/zaino/supply-chain/imports.lock
+++ b/backends/zaino/supply-chain/imports.lock
@@ -29,6 +29,20 @@ user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
+[[publisher.equihash]]
+version = "0.3.0"
+when = "2026-04-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.f4jumble]]
+version = "0.1.1"
+when = "2024-12-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.halo2_gadgets]]
 version = "0.5.0"
 when = "2026-06-03"
@@ -58,8 +72,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.orchard]]
-version = "0.15.0"
-when = "2026-07-09"
+version = "0.15.3"
+when = "2026-07-22"
+user-id = 1244
+user-login = "ebfull"
+user-name = "Sean Bowe"
+
+[[publisher.pczt]]
+version = "0.9.1"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -77,6 +98,20 @@ when = "2025-10-26"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
+
+[[publisher.tower-batch-control]]
+version = "1.1.1"
+when = "2026-07-17"
+user-id = 235397
+user-login = "upbqdn"
+user-name = "Marek"
+
+[[publisher.tower-fallback]]
+version = "0.2.43"
+when = "2026-07-17"
+user-id = 235397
+user-login = "upbqdn"
+user-name = "Marek"
 
 [[publisher.unicode-normalization]]
 version = "0.1.25"
@@ -321,6 +356,34 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_address]]
+version = "0.13.0"
+when = "2026-07-09"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_backend]]
+version = "0.24.0-rc.4"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_sqlite]]
+version = "0.22.0-rc.4"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_encoding]]
+version = "0.4.0"
+when = "2026-04-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_history]]
 version = "0.5.0"
 when = "2026-07-09"
@@ -335,6 +398,20 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_keys]]
+version = "0.16.0"
+when = "2026-07-25"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_pool_migration]]
+version = "0.1.0-rc.3"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_primitives]]
 version = "0.28.0"
 when = "2026-06-03"
@@ -342,9 +419,30 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_primitives]]
+version = "0.30.0"
+when = "2026-07-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_proofs]]
+version = "0.30.0"
+when = "2026-07-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_protocol]]
 version = "0.9.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_protocol]]
+version = "0.10.1"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -359,6 +457,13 @@ user-name = "Daira-Emma Hopwood"
 [[publisher.zcash_transparent]]
 version = "0.8.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_transparent]]
+version = "0.10.0"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -383,6 +488,13 @@ when = "2025-09-17"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
+
+[[publisher.zip321]]
+version = "0.9.0-rc.1"
+when = "2026-07-12"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -516,6 +628,12 @@ who = "Alex Crichton <alex@alexcrichton.com>"
 criteria = "safe-to-deploy"
 delta = "0.2.3 -> 0.3.0"
 notes = "Nothing out of the ordinary, virtually no unsafe code."
+
+[[audits.bytecode-alliance.audits.crossbeam-epoch]]
+who = "Alex Crichton <alex@alexcrichton.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.18 -> 0.9.20"
+notes = "Minor updates, nothing out of place."
 
 [[audits.bytecode-alliance.audits.der]]
 who = "Chris Fallin <chris@cfallin.org>"
@@ -1074,6 +1192,13 @@ delta = "0.1.4 -> 0.1.5"
 notes = "No new `unsafe`."
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
+[[audits.google.audits.getrandom]]
+who = "David Koloski <dkoloski@google.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.2 -> 0.2.12"
+notes = "Audited at https://fxrev.dev/932979"
+aggregated-from = "https://fuchsia.googlesource.com/fuchsia/+/refs/heads/main/third_party/rust_crates/supply-chain/audits.toml?format=TEXT"
+
 [[audits.google.audits.glob]]
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
@@ -1261,6 +1386,56 @@ who = "Daniel Cheng <dcheng@chromium.org>"
 criteria = "safe-to-deploy"
 delta = "1.0.93 -> 1.0.94"
 notes = "Minor doc changes and clippy lint adjustments+fixes."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+version = "1.0.35"
+notes = """
+Grepped for "unsafe", "crypt", "cipher", "fs", "net" - there were no hits
+(except for benign "net" hit in tests and "fs" hit in README.md)
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Adrian Taylor <adetaylor@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.35 -> 1.0.36"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.36 -> 1.0.37"
+notes = """
+The delta just 1) inlines/expands `impl ToTokens` that used to be handled via
+`primitive!` macro and 2) adds `impl ToTokens` for `CStr` and `CString`.
+"""
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Dustin J. Mitchell <djmitche@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.37 -> 1.0.38"
+notes = "Still no unsafe"
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Daniel Cheng <dcheng@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.38 -> 1.0.39"
+notes = "Only minor changes for clippy lints and documentation."
+aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
+
+[[audits.google.audits.quote]]
+who = "Lukasz Anforowicz <lukasza@chromium.org>"
+criteria = "safe-to-deploy"
+delta = "1.0.39 -> 1.0.40"
+notes = """
+The delta is just a simplification of how `tokens.extend(...)` call is made.
+Still no `unsafe` anywhere.
+"""
 aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_party/rust/chromium_crates_io/supply-chain/audits.toml?format=TEXT"
 
 [[audits.google.audits.rand_chacha]]
@@ -1660,6 +1835,12 @@ criteria = "safe-to-deploy"
 version = "0.1.0"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
+[[audits.google.audits.version_check]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
 [[audits.isrg.audits.base64]]
 who = "Tim Geoghegan <timg@letsencrypt.org>"
 criteria = "safe-to-deploy"
@@ -1774,6 +1955,16 @@ who = "Tim Geoghegan <timg@divviup.org>"
 criteria = "safe-to-deploy"
 delta = "0.2.8 -> 0.2.9"
 notes = "No changes to Rust code between 0.2.8 and 0.2.9"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.12 -> 0.2.14"
+
+[[audits.isrg.audits.getrandom]]
+who = "David Cook <dcook@divviup.org>"
+criteria = "safe-to-deploy"
+delta = "0.2.14 -> 0.2.15"
 
 [[audits.isrg.audits.getrandom]]
 who = "David Cook <dcook@divviup.org>"
@@ -1907,20 +2098,10 @@ who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
 delta = "1.0.40 -> 1.0.43"
 
-[[audits.isrg.audits.thiserror]]
-who = "J.C. Jones <jc@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "2.0.17 -> 2.0.18"
-
 [[audits.isrg.audits.thiserror-impl]]
 who = "Brandon Pitman <bran@bran.land>"
 criteria = "safe-to-deploy"
 delta = "1.0.40 -> 1.0.43"
-
-[[audits.isrg.audits.thiserror-impl]]
-who = "J.C. Jones <jc@divviup.org>"
-criteria = "safe-to-deploy"
-delta = "2.0.17 -> 2.0.18"
 
 [[audits.isrg.audits.universal-hash]]
 who = "David Cook <dcook@divviup.org>"
@@ -2118,6 +2299,12 @@ who = "Alex Franchuk <afranchuk@mozilla.com>"
 criteria = "safe-to-deploy"
 delta = "0.1.1 -> 0.2.1"
 notes = "Very minor changes."
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.cfg_aliases]]
+who = "Erich Gubler <erichdongubler@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.1 -> 0.2.2"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.crossbeam-channel]]
@@ -2706,6 +2893,18 @@ who = "Max Leonard Inden <mail@max-inden.de>"
 criteria = "safe-to-deploy"
 delta = "0.5.12 -> 0.5.13"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.40 -> 1.0.45"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.quote]]
+who = "Jan-Erik Rediger <jrediger@mozilla.com>"
+criteria = "safe-to-deploy"
+delta = "1.0.45 -> 1.0.47"
+aggregated-from = "https://raw.githubusercontent.com/mozilla/glean/main/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.rand_distr]]
 who = "Ben Dean-Kawamura <bdk@mozilla.com>"
@@ -3518,3 +3717,18 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 notes = "Additive-only change that exposes the ability to decrypt by pk_d and esk. No functional changes."
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zebra.audits.nix]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.15.0"
+
+[[audits.zebra.audits.uint]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.5 -> 0.10.0"
+
+[[audits.zebra.audits.version_check]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.5"

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1430,7 +1430,8 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,7 +1467,8 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3350,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.15.0"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cca2ede6a4a77bd729eed3be9303d98a08b217edc85190dcf4dbe004086d5a65"
+checksum = "e8b67beade27dbebdbfee0819e23170b0b263dc7b4f558ee936151716baf6e1f"
 dependencies = [
  "aes",
  "bitvec",
@@ -3515,6 +3517,35 @@ dependencies = [
  "digest 0.10.7",
  "hmac 0.12.1",
  "password-hash",
+]
+
+[[package]]
+name = "pczt"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+dependencies = [
+ "blake2b_simd",
+ "bls12_381",
+ "document-features",
+ "ff",
+ "getset",
+ "jubjub",
+ "nonempty",
+ "orchard 0.15.3",
+ "pasta_curves",
+ "postcard",
+ "rand_core 0.6.4",
+ "redjubjub",
+ "sapling-crypto",
+ "secp256k1",
+ "serde",
+ "serde_with",
+ "zcash_note_encryption",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
+ "zcash_script",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
@@ -5578,9 +5609,9 @@ dependencies = [
 
 [[package]]
 name = "tower-batch-control"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e6cf52578f98b4da47335c26c4f883f7993b1a9b9d2f5420eb8dbfd5dd19a28"
+checksum = "58bb785abb0207bee98b1d7d874467bb1043d4e434f9a8c8a4714603563c762b"
 dependencies = [
  "futures",
  "futures-core",
@@ -5595,9 +5626,9 @@ dependencies = [
 
 [[package]]
 name = "tower-fallback"
-version = "0.2.41"
+version = "0.2.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4434e19ee996ee5c6aa42f11463a355138452592e5c5b5b73b6f0f19534556af"
+checksum = "c700b6ca0cca8b86ef35046dfc7bab9196b8271ab72e9d410f8f63d94857d14f"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -6493,7 +6524,7 @@ dependencies = [
  "known-folders",
  "nix 0.29.0",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "phf",
  "quote",
  "rand 0.8.7",
@@ -6531,14 +6562,14 @@ dependencies = [
  "zcash_client_backend",
  "zcash_client_sqlite",
  "zcash_encoding",
- "zcash_keys 0.15.0",
+ "zcash_keys 0.16.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zewif",
  "zewif-zcashd",
  "zip32",
@@ -6558,7 +6589,7 @@ dependencies = [
  "jsonrpsee",
  "jsonrpsee-http-client",
  "once_cell",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "regex",
  "sapling-crypto",
  "serde",
@@ -6568,9 +6599,9 @@ dependencies = [
  "trycmd",
  "zallet-core",
  "zcash_client_backend",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-rpc",
  "zebra-state",
@@ -6593,20 +6624,22 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.24.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e019c2adb1eb2c3479603f4556e85c01022723f14ce8837a3bb225cb2af4d3f"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6623,7 +6656,7 @@ dependencies = [
  "incrementalmerkletree",
  "memuse",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "pasta_curves",
  "percent-encoding",
  "prost",
@@ -6643,20 +6676,21 @@ dependencies = [
  "which",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_keys 0.15.0",
+ "zcash_keys 0.16.0",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zip32",
  "zip321",
 ]
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.22.0-rc.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a496ad83b77e790bd0ea1013db14961b3ff825550097a2658837dc7e92a23d53"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6671,7 +6705,7 @@ dependencies = [
  "jubjub",
  "maybe-rayon",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -6692,11 +6726,12 @@ dependencies = [
  "zcash_address 0.13.0",
  "zcash_client_backend",
  "zcash_encoding",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_keys 0.16.0",
+ "zcash_pool_migration",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zewif",
  "zip32",
 ]
@@ -6704,7 +6739,8 @@ dependencies = [
 [[package]]
 name = "zcash_encoding"
 version = "0.4.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1440921903cdb86133fb9e2fe800be488015db2939a30bedb413078a1acb0306"
 dependencies = [
  "corez",
  "hex",
@@ -6755,8 +6791,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_keys"
-version = "0.15.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc842e024fe37e52cfd3920826c4a28cc2a023fc9d77351d9c0f310becae3eb7"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6770,7 +6807,7 @@ dependencies = [
  "group",
  "memuse",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "rand_core 0.6.4",
  "regex",
  "sapling-crypto",
@@ -6780,8 +6817,8 @@ dependencies = [
  "tracing",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
- "zcash_transparent 0.9.0",
+ "zcash_protocol 0.10.1",
+ "zcash_transparent 0.10.0",
  "zeroize",
  "zip32",
 ]
@@ -6797,6 +6834,26 @@ dependencies = [
  "cipher",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "zcash_pool_migration"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7e4169a96a25de216d4a7265fe772003aaeea05ed2566b14cfc0b8146b1f99e"
+dependencies = [
+ "corez",
+ "getset",
+ "incrementalmerkletree",
+ "libm",
+ "orchard 0.15.3",
+ "pczt",
+ "rand_core 0.6.4",
+ "shardtree",
+ "zcash_client_backend",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]
@@ -6831,8 +6888,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6846,7 +6904,7 @@ dependencies = [
  "jubjub",
  "memuse",
  "nonempty",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "rand_core 0.6.4",
  "redjubjub",
  "sapling-crypto",
@@ -6854,15 +6912,16 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
 name = "zcash_proofs"
-version = "0.29.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6878,7 +6937,7 @@ dependencies = [
  "tracing",
  "wagyu-zcash-parameters",
  "xdg 3.0.0",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
 ]
 
 [[package]]
@@ -6896,8 +6955,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4034db33a1ce58416430e065b01474b958e4649caa3e06e20654683a95149710"
 dependencies = [
  "corez",
  "document-features",
@@ -6959,8 +7019,9 @@ dependencies = [
 
 [[package]]
 name = "zcash_transparent"
-version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
 dependencies = [
  "bip32",
  "bs58",
@@ -6975,7 +7036,7 @@ dependencies = [
  "subtle",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6983,9 +7044,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-chain"
-version = "11.1.0"
+version = "11.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "014adde138ea00b1cf6c873aaf56aacb5aa0d55b8e5451a3e3b1b06c461bd107"
+checksum = "825050a409c120d9dd0cffb36d99638a5e716e9cb092662009d087b4c227cc14"
 dependencies = [
  "bech32 0.11.1",
  "bitflags",
@@ -7011,7 +7072,7 @@ dependencies = [
  "jubjub",
  "lazy_static",
  "num-integer",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "primitive-types",
  "rand_core 0.6.4",
  "rayon",
@@ -7039,17 +7100,17 @@ dependencies = [
  "zcash_encoding",
  "zcash_history",
  "zcash_note_encryption",
- "zcash_primitives 0.29.0",
- "zcash_protocol 0.10.0",
+ "zcash_primitives 0.30.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
 ]
 
 [[package]]
 name = "zebra-consensus"
-version = "10.0.0"
+version = "14.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa2b2678c4ce6d18172bad73a9b72b24a4b3a65af4c2a5e9120a1470c3fc402"
+checksum = "1f2a2f87471e58f9cedee3698ac4eeb6502ec60d059b054d67796eccfb896439"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7065,7 +7126,7 @@ dependencies = [
  "metrics",
  "mset",
  "once_cell",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "rand 0.8.7",
  "rayon",
  "sapling-crypto",
@@ -7077,11 +7138,11 @@ dependencies = [
  "tower-fallback",
  "tracing",
  "tracing-futures",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-node-services",
  "zebra-script",
@@ -7090,9 +7151,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-network"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36b1e6ca4687bc8d128553ca04bb82cc38701c4dac7107f3e56717b39d4b18da"
+checksum = "4592281fa43e961048c4a2a4c153be1eacff481d64f0340bc70e1f9b84c53eca"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -7128,9 +7189,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-node-services"
-version = "9.1.0"
+version = "9.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006992c62b9c4742a13a306f2e7443646fa0b5b884aac63a6fba5b0be273f864"
+checksum = "aee11bf0e45b764d09722f1e8f4c5a8d86ef021d9698b576bdf81d325c75b9b8"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7144,9 +7205,9 @@ dependencies = [
 
 [[package]]
 name = "zebra-rpc"
-version = "11.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb180542f1ffc0f66c20e1cd66c7741662053ccda588e3847a8ed2df8c83dae7"
+checksum = "761839b2ad7ff46c1836521f674d76458cd1c78f555e56d2259ead4cc9ddb170"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7165,7 +7226,7 @@ dependencies = [
  "metrics",
  "nix 0.30.1",
  "openrpsee",
- "orchard 0.15.0",
+ "orchard 0.15.3",
  "phf",
  "prost",
  "rand 0.8.7",
@@ -7189,12 +7250,12 @@ dependencies = [
  "tracing",
  "which",
  "zcash_address 0.13.0",
- "zcash_keys 0.15.0",
- "zcash_primitives 0.29.0",
+ "zcash_keys 0.16.0",
+ "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
  "zcash_script",
- "zcash_transparent 0.9.0",
+ "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-consensus",
  "zebra-network",
@@ -7205,23 +7266,23 @@ dependencies = [
 
 [[package]]
 name = "zebra-script"
-version = "10.0.0"
+version = "10.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8648c201e3dadb1c95022eb7605d528de4bf94b6c0cebf76537805849aee76c5"
+checksum = "ad711c56bfe377e184a9dfbec4d2c21633d0254bbea5338d20640fd62574bb88"
 dependencies = [
  "libzcash_script",
  "rand 0.8.7",
  "thiserror 2.0.18",
- "zcash_primitives 0.29.0",
+ "zcash_primitives 0.30.0",
  "zcash_script",
  "zebra-chain",
 ]
 
 [[package]]
 name = "zebra-state"
-version = "10.1.0"
+version = "12.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39295d344c1cc56ed725646cfc7bb7e16f8edae7518ea5a9e599665f979e9cf6"
+checksum = "b01b530a3fdd28a9d2988895272e970bc0053acf6dbf467785f146cabf21ac3f"
 dependencies = [
  "bincode",
  "chrono",
@@ -7414,13 +7475,14 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=0531f9d89450d5def16d4c320972e4ce960f9175#0531f9d89450d5def16d4c320972e4ce960f9175"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address 0.13.0",
- "zcash_protocol 0.10.0",
+ "zcash_protocol 0.10.1",
 ]
 
 [[package]]

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -42,13 +42,13 @@ jsonrpsee = { version = "0.24", features = ["async-client"] }
 jsonrpsee-http-client = { version = "0.24", default-features = false }
 tokio = { version = "1", features = ["net", "rt-multi-thread"] }
 tower = { version = "0.4", features = ["timeout"] }
-transparent = { package = "zcash_transparent", version = "0.9.0" }
-zcash_client_backend = "0.24.0-rc.1"
-zcash_primitives = "0.29.0"
+transparent = { package = "zcash_transparent", version = "0.10.0" }
+zcash_client_backend = "0.24.0-rc.4"
+zcash_primitives = "0.30.0"
 zcash_protocol = "0.10.0"
 zebra-chain = "11"
-zebra-rpc = "11"
-zebra-state = { version = "10", features = ["indexer"] }
+zebra-rpc = "15"
+zebra-state = { version = "12", features = ["indexer"] }
 
 [dev-dependencies]
 abscissa_core = { version = "0.9", features = ["testing"] }
@@ -73,21 +73,6 @@ rpc-cli = ["zallet-core/rpc-cli"]
 
 ## `tokio-console` support.
 tokio-console = ["zallet-core/tokio-console"]
-
-[patch.crates-io]
-# Replace with the crates.io releases once they ship.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_encoding = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "0531f9d89450d5def16d4c320972e4ce960f9175" }
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [

--- a/backends/zebra/supply-chain/config.toml
+++ b/backends/zebra/supply-chain/config.toml
@@ -22,11 +22,12 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
+[imports.zebra]
+url = "https://raw.githubusercontent.com/ZcashFoundation/zebra/main/supply-chain/audits.toml"
+
 [policy.equihash]
-audit-as-crates-io = false
 
 [policy.f4jumble]
-audit-as-crates-io = false
 
 [policy.incrementalmerkletree]
 
@@ -37,33 +38,24 @@ audit-as-crates-io = false
 [policy.tower-fallback]
 
 [policy.zcash_address]
-audit-as-crates-io = false
 
 [policy.zcash_client_backend]
-audit-as-crates-io = false
 
 [policy.zcash_client_sqlite]
-audit-as-crates-io = false
 
 [policy.zcash_encoding]
-audit-as-crates-io = false
 
 [policy.zcash_history]
 
 [policy.zcash_keys]
-audit-as-crates-io = false
 
 [policy.zcash_primitives]
-audit-as-crates-io = false
 
 [policy.zcash_proofs]
-audit-as-crates-io = false
 
 [policy.zcash_protocol]
-audit-as-crates-io = false
 
 [policy.zcash_transparent]
-audit-as-crates-io = false
 
 [policy.zebra-chain]
 
@@ -80,7 +72,6 @@ audit-as-crates-io = false
 [policy.zebra-state]
 
 [policy.zip321]
-audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -1018,10 +1009,6 @@ criteria = "safe-to-deploy"
 version = "0.7.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.nix]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.nom]]
 version = "8.0.0"
 criteria = "safe-to-deploy"
@@ -1702,14 +1689,6 @@ criteria = "safe-to-deploy"
 version = "0.5.3"
 criteria = "safe-to-deploy"
 
-[[exemptions.tower-batch-control]]
-version = "1.0.1"
-criteria = "safe-to-deploy"
-
-[[exemptions.tower-fallback]]
-version = "0.2.41"
-criteria = "safe-to-deploy"
-
 [[exemptions.tower-http]]
 version = "0.6.11"
 criteria = "safe-to-deploy"
@@ -1774,10 +1753,6 @@ criteria = "safe-to-deploy"
 version = "0.9.5"
 criteria = "safe-to-deploy"
 
-[[exemptions.uint]]
-version = "0.10.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.unicase]]
 version = "2.9.0"
 criteria = "safe-to-deploy"
@@ -1796,10 +1771,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
 version = "1.23.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.version_check]]
-version = "0.9.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.wait-timeout]]
@@ -1903,31 +1874,31 @@ version = "0.4.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-chain]]
-version = "11.1.0"
+version = "11.3.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-consensus]]
-version = "10.0.0"
+version = "14.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-network]]
-version = "10.0.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-node-services]]
-version = "9.1.0"
-criteria = "safe-to-deploy"
-
-[[exemptions.zebra-rpc]]
 version = "11.0.0"
 criteria = "safe-to-deploy"
 
+[[exemptions.zebra-node-services]]
+version = "9.1.2"
+criteria = "safe-to-deploy"
+
+[[exemptions.zebra-rpc]]
+version = "15.0.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.zebra-script]]
-version = "10.0.0"
+version = "10.1.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.zebra-state]]
-version = "10.1.0"
+version = "12.0.1"
 criteria = "safe-to-deploy"
 
 [[exemptions.zerocopy]]

--- a/backends/zebra/supply-chain/imports.lock
+++ b/backends/zebra/supply-chain/imports.lock
@@ -29,6 +29,20 @@ user-id = 3788
 user-login = "emilio"
 user-name = "Emilio Cobos Álvarez"
 
+[[publisher.equihash]]
+version = "0.3.0"
+when = "2026-04-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.f4jumble]]
+version = "0.1.1"
+when = "2024-12-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.halo2_gadgets]]
 version = "0.5.0"
 when = "2026-06-03"
@@ -58,8 +72,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.orchard]]
-version = "0.15.0"
-when = "2026-07-09"
+version = "0.15.3"
+when = "2026-07-22"
+user-id = 1244
+user-login = "ebfull"
+user-name = "Sean Bowe"
+
+[[publisher.pczt]]
+version = "0.9.1"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -77,6 +98,20 @@ when = "2025-10-26"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
+
+[[publisher.tower-batch-control]]
+version = "1.1.1"
+when = "2026-07-17"
+user-id = 235397
+user-login = "upbqdn"
+user-name = "Marek"
+
+[[publisher.tower-fallback]]
+version = "0.2.43"
+when = "2026-07-17"
+user-id = 235397
+user-login = "upbqdn"
+user-name = "Marek"
 
 [[publisher.unicode-normalization]]
 version = "0.1.25"
@@ -321,6 +356,34 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_address]]
+version = "0.13.0"
+when = "2026-07-09"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_backend]]
+version = "0.24.0-rc.4"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_sqlite]]
+version = "0.22.0-rc.4"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_encoding]]
+version = "0.4.0"
+when = "2026-04-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_history]]
 version = "0.5.0"
 when = "2026-07-09"
@@ -335,6 +398,20 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_keys]]
+version = "0.16.0"
+when = "2026-07-25"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_pool_migration]]
+version = "0.1.0-rc.3"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_primitives]]
 version = "0.28.0"
 when = "2026-06-03"
@@ -342,9 +419,30 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_primitives]]
+version = "0.30.0"
+when = "2026-07-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_proofs]]
+version = "0.30.0"
+when = "2026-07-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_protocol]]
 version = "0.9.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_protocol]]
+version = "0.10.1"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -359,6 +457,13 @@ user-name = "Daira-Emma Hopwood"
 [[publisher.zcash_transparent]]
 version = "0.8.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_transparent]]
+version = "0.10.0"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -383,6 +488,13 @@ when = "2025-09-17"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
+
+[[publisher.zip321]]
+version = "0.9.0-rc.1"
+when = "2026-07-12"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -1595,6 +1707,12 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.version_check]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.isrg.audits.base64]]
@@ -3445,3 +3563,18 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 notes = "Additive-only change that exposes the ability to decrypt by pk_d and esk. No functional changes."
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zebra.audits.nix]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.15.0"
+
+[[audits.zebra.audits.uint]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.5 -> 0.10.0"
+
+[[audits.zebra.audits.version_check]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.5"

--- a/supply-chain/audits.toml
+++ b/supply-chain/audits.toml
@@ -683,6 +683,12 @@ end = "2026-04-09"
 
 [[trusted.orchard]]
 criteria = "safe-to-deploy"
+user-id = 1244 # Sean Bowe (ebfull)
+start = "2022-10-19"
+end = "2027-07-28"
+
+[[trusted.orchard]]
+criteria = "safe-to-deploy"
 user-id = 6289 # Jack Grigg (str4d)
 start = "2021-01-07"
 end = "2027-03-17"
@@ -692,6 +698,12 @@ criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-08-12"
 end = "2027-07-03"
+
+[[trusted.pczt]]
+criteria = "safe-to-deploy"
+user-id = 169181 # Kris Nuttycombe (nuttycom)
+start = "2024-12-17"
+end = "2027-07-28"
 
 [[trusted.pinentry]]
 criteria = "safe-to-deploy"
@@ -728,6 +740,18 @@ criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2022-12-15"
 end = "2026-03-04"
+
+[[trusted.tower-batch-control]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.tower-fallback]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
 
 [[trusted.windows-core]]
 criteria = "safe-to-deploy"
@@ -891,6 +915,12 @@ user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-01-15"
 end = "2027-07-03"
 
+[[trusted.zcash_pool_migration]]
+criteria = "safe-to-deploy"
+user-id = 169181 # Kris Nuttycombe (nuttycom)
+start = "2026-07-24"
+end = "2027-07-28"
+
 [[trusted.zcash_primitives]]
 criteria = "safe-to-deploy"
 user-id = 6289 # Jack Grigg (str4d)
@@ -962,6 +992,48 @@ criteria = "safe-to-deploy"
 user-id = 169181 # Kris Nuttycombe (nuttycom)
 start = "2024-12-17"
 end = "2027-07-03"
+
+[[trusted.zebra-chain]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.zebra-consensus]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.zebra-network]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.zebra-node-services]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.zebra-rpc]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.zebra-script]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
+
+[[trusted.zebra-state]]
+criteria = "safe-to-deploy"
+user-id = 235397
+start = "2023-10-17"
+end = "2027-07-28"
 
 [[trusted.zewif]]
 criteria = "safe-to-deploy"

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -22,45 +22,36 @@ url = "https://raw.githubusercontent.com/mozilla/supply-chain/main/audits.toml"
 [imports.zcash]
 url = "https://raw.githubusercontent.com/zcash/rust-ecosystem/main/supply-chain/audits.toml"
 
+[imports.zebra]
+url = "https://raw.githubusercontent.com/ZcashFoundation/zebra/main/supply-chain/audits.toml"
+
 [policy.equihash]
-audit-as-crates-io = false
 
 [policy.f4jumble]
-audit-as-crates-io = false
 
 [policy.incrementalmerkletree]
 
 [policy.shardtree]
 
 [policy.zcash_address]
-audit-as-crates-io = false
 
 [policy.zcash_client_backend]
-audit-as-crates-io = false
 
 [policy.zcash_client_sqlite]
-audit-as-crates-io = false
 
 [policy.zcash_encoding]
-audit-as-crates-io = false
 
 [policy.zcash_keys]
-audit-as-crates-io = false
 
 [policy.zcash_primitives]
-audit-as-crates-io = false
 
 [policy.zcash_proofs]
-audit-as-crates-io = false
 
 [policy.zcash_protocol]
-audit-as-crates-io = false
 
 [policy.zcash_transparent]
-audit-as-crates-io = false
 
 [policy.zip321]
-audit-as-crates-io = false
 
 [[exemptions.abscissa_core]]
 version = "0.9.0"
@@ -392,6 +383,18 @@ criteria = "safe-to-deploy"
 
 [[exemptions.daggy]]
 version = "0.8.1"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_core]]
+version = "0.23.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.darling_macro]]
+version = "0.23.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.deadpool]]
@@ -894,10 +897,6 @@ criteria = "safe-to-deploy"
 version = "0.7.0"
 criteria = "safe-to-deploy"
 
-[[exemptions.nix]]
-version = "0.15.0"
-criteria = "safe-to-deploy"
-
 [[exemptions.nom]]
 version = "8.0.0"
 criteria = "safe-to-deploy"
@@ -1262,6 +1261,14 @@ criteria = "safe-to-deploy"
 version = "1.1.1"
 criteria = "safe-to-deploy"
 
+[[exemptions.serde_with]]
+version = "3.21.0"
+criteria = "safe-to-deploy"
+
+[[exemptions.serde_with_macros]]
+version = "3.21.0"
+criteria = "safe-to-deploy"
+
 [[exemptions.serdect]]
 version = "0.2.0"
 criteria = "safe-to-deploy"
@@ -1532,10 +1539,6 @@ criteria = "safe-to-deploy"
 
 [[exemptions.uuid]]
 version = "1.23.4"
-criteria = "safe-to-deploy"
-
-[[exemptions.version_check]]
-version = "0.9.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.wait-timeout]]

--- a/supply-chain/imports.lock
+++ b/supply-chain/imports.lock
@@ -22,6 +22,20 @@ user-id = 696
 user-login = "fitzgen"
 user-name = "Nick Fitzgerald"
 
+[[publisher.equihash]]
+version = "0.3.0"
+when = "2026-04-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.f4jumble]]
+version = "0.1.1"
+when = "2024-12-13"
+user-id = 6289
+user-login = "str4d"
+user-name = "Jack Grigg"
+
 [[publisher.halo2_gadgets]]
 version = "0.5.0"
 when = "2026-06-03"
@@ -51,8 +65,15 @@ user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
 [[publisher.orchard]]
-version = "0.15.0"
-when = "2026-07-09"
+version = "0.15.3"
+when = "2026-07-22"
+user-id = 1244
+user-login = "ebfull"
+user-name = "Sean Bowe"
+
+[[publisher.pczt]]
+version = "0.9.1"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -314,9 +335,51 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_address]]
+version = "0.13.0"
+when = "2026-07-09"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_backend]]
+version = "0.24.0-rc.4"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_client_sqlite]]
+version = "0.22.0-rc.4"
+when = "2026-07-27"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_encoding]]
+version = "0.4.0"
+when = "2026-04-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_keys]]
 version = "0.14.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_keys]]
+version = "0.16.0"
+when = "2026-07-25"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_pool_migration]]
+version = "0.1.0-rc.3"
+when = "2026-07-27"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -328,9 +391,30 @@ user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
 
+[[publisher.zcash_primitives]]
+version = "0.30.0"
+when = "2026-07-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_proofs]]
+version = "0.30.0"
+when = "2026-07-24"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
 [[publisher.zcash_protocol]]
 version = "0.9.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_protocol]]
+version = "0.10.1"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -345,6 +429,13 @@ user-name = "Daira-Emma Hopwood"
 [[publisher.zcash_transparent]]
 version = "0.8.0"
 when = "2026-06-03"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
+
+[[publisher.zcash_transparent]]
+version = "0.10.0"
+when = "2026-07-24"
 user-id = 169181
 user-login = "nuttycom"
 user-name = "Kris Nuttycombe"
@@ -369,6 +460,13 @@ when = "2025-09-17"
 user-id = 6289
 user-login = "str4d"
 user-name = "Jack Grigg"
+
+[[publisher.zip321]]
+version = "0.9.0-rc.1"
+when = "2026-07-12"
+user-id = 169181
+user-login = "nuttycom"
+user-name = "Kris Nuttycombe"
 
 [[audits.bytecode-alliance.wildcard-audits.bumpalo]]
 who = "Nick Fitzgerald <fitzgen@gmail.com>"
@@ -1611,6 +1709,12 @@ aggregated-from = "https://chromium.googlesource.com/chromium/src/+/main/third_p
 who = "George Burgess IV <gbiv@google.com>"
 criteria = "safe-to-deploy"
 version = "0.1.0"
+aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
+
+[[audits.google.audits.version_check]]
+who = "George Burgess IV <gbiv@google.com>"
+criteria = "safe-to-deploy"
+version = "0.9.4"
 aggregated-from = "https://chromium.googlesource.com/chromiumos/third_party/rust_crates/+/refs/heads/main/cargo-vet/audits.toml?format=TEXT"
 
 [[audits.isrg.audits.base64]]
@@ -3202,3 +3306,13 @@ criteria = "safe-to-deploy"
 version = "0.4.1"
 notes = "Additive-only change that exposes the ability to decrypt by pk_d and esk. No functional changes."
 aggregated-from = "https://raw.githubusercontent.com/zcash/librustzcash/main/supply-chain/audits.toml"
+
+[[audits.zebra.audits.nix]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+version = "0.15.0"
+
+[[audits.zebra.audits.version_check]]
+who = "Alfredo Garcia <oxarbitrage@gmail.com>"
+criteria = "safe-to-deploy"
+delta = "0.9.4 -> 0.9.5"

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -15,12 +15,16 @@ use zcash_client_backend::{
         SAPLING_SHARD_HEIGHT, TargetValue, TransparentKeyOrigin, WalletCommitmentTrees, WalletRead,
         WalletWrite, Zip32Derivation,
         chain::ChainState,
-        error::{FindAccountForAddressError, RewindError},
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        error::{FindAccountForAddressError, LockError, RewindError},
+        scanning::ScanPriority,
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     fees::StandardFeeRule,
     keys::{UnifiedAddressRequest, UnifiedFullViewingKey, UnifiedSpendingKey},
-    wallet::{Note, ReceivedNote, TransparentAddressMetadata, WalletTransparentOutput},
+    wallet::{
+        LockOwner, Note, OutputRef, ReceivedNote, TransparentAddressMetadata,
+        WalletTransparentOutput,
+    },
 };
 use zcash_client_sqlite::{WalletDb, util::SystemClock};
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
@@ -258,6 +262,10 @@ impl WalletRead for DbConnection {
         self.with(|db_data| db_data.get_wallet_birthday())
     }
 
+    fn get_wallet_recover_until(&self) -> Result<Option<BlockHeight>, Self::Error> {
+        self.with(|db_data| db_data.get_wallet_recover_until())
+    }
+
     fn get_wallet_summary(
         &self,
         confirmations_policy: ConfirmationsPolicy,
@@ -441,8 +449,11 @@ impl InputSource for DbConnection {
         protocol: ShieldedPool,
         index: u32,
         target_height: TargetHeight,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Option<ReceivedNote<Self::NoteRef, Note>>, Self::Error> {
-        self.with(|db_data| db_data.get_spendable_note(txid, protocol, index, target_height))
+        self.with(|db_data| {
+            db_data.get_spendable_note(txid, protocol, index, target_height, lock_filter)
+        })
     }
 
     fn select_spendable_notes(
@@ -453,6 +464,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         exclude: &[Self::NoteRef],
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
         self.with(|db_data| {
             db_data.select_spendable_notes(
@@ -462,6 +474,7 @@ impl InputSource for DbConnection {
                 target_height,
                 confirmations_policy,
                 exclude,
+                lock_filter,
             )
         })
     }
@@ -472,8 +485,11 @@ impl InputSource for DbConnection {
         sources: &[ShieldedPool],
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        lock_filter: LockFilter<'_>,
     ) -> Result<ReceivedNotes<Self::NoteRef>, Self::Error> {
-        self.with(|db_data| db_data.select_unspent_notes(account, sources, target_height, exclude))
+        self.with(|db_data| {
+            db_data.select_unspent_notes(account, sources, target_height, exclude, lock_filter)
+        })
     }
 
     fn get_unspent_transparent_output(
@@ -490,6 +506,7 @@ impl InputSource for DbConnection {
         target_height: TargetHeight,
         confirmations_policy: ConfirmationsPolicy,
         output_filter: CoinbaseFilter,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.get_spendable_transparent_outputs(
@@ -497,6 +514,7 @@ impl InputSource for DbConnection {
                 target_height,
                 confirmations_policy,
                 output_filter,
+                lock_filter,
             )
         })
     }
@@ -512,6 +530,7 @@ impl InputSource for DbConnection {
         target_value: TargetValue,
         max_inputs: usize,
         fee_rule: &StandardFeeRule,
+        lock_filter: LockFilter<'_>,
     ) -> Result<Vec<WalletTransparentOutput<Self::AccountId>>, Self::Error> {
         self.with(|db_data| {
             db_data.select_spendable_transparent_outputs(
@@ -523,6 +542,7 @@ impl InputSource for DbConnection {
                 target_value,
                 max_inputs,
                 fee_rule,
+                lock_filter,
             )
         })
     }
@@ -533,8 +553,11 @@ impl InputSource for DbConnection {
         selector: &NoteFilter,
         target_height: TargetHeight,
         exclude: &[Self::NoteRef],
+        lock_filter: LockFilter<'_>,
     ) -> Result<AccountMeta, Self::Error> {
-        self.with(|db_data| db_data.get_account_metadata(account, selector, target_height, exclude))
+        self.with(|db_data| {
+            db_data.get_account_metadata(account, selector, target_height, exclude, lock_filter)
+        })
     }
 }
 
@@ -631,6 +654,31 @@ impl WalletWrite for DbConnection {
         blocks: Vec<zcash_client_backend::data_api::ScannedBlock<Self::AccountId>>,
     ) -> Result<(), Self::Error> {
         self.with_mut(|mut db_data| db_data.put_blocks(from_state, blocks))
+    }
+
+    fn prune_scan_queue_below(
+        &mut self,
+        height: BlockHeight,
+        retain_with_priority: Option<ScanPriority>,
+    ) -> Result<u64, Self::Error> {
+        self.with_mut(|mut db_data| db_data.prune_scan_queue_below(height, retain_with_priority))
+    }
+
+    fn lock_outputs(
+        &mut self,
+        outputs: &[OutputRef],
+        owner: LockOwner,
+        lock_expiry_height: BlockHeight,
+    ) -> Result<usize, LockError<Self::Error>> {
+        self.with_mut(|mut db_data| db_data.lock_outputs(outputs, owner, lock_expiry_height))
+    }
+
+    fn unlock_output(&mut self, output: &OutputRef, owner: LockOwner) -> Result<bool, Self::Error> {
+        self.with_mut(|mut db_data| db_data.unlock_output(output, owner))
+    }
+
+    fn clear_locked_outputs(&mut self, account: Self::AccountId) -> Result<usize, Self::Error> {
+        self.with_mut(|mut db_data| db_data.clear_locked_outputs(account))
     }
 
     fn put_received_transparent_utxo(
@@ -765,6 +813,13 @@ impl WalletCommitmentTrees for DbConnection {
         self.with_mut(|mut db_data| db_data.put_sapling_subtree_roots(start_index, roots))
     }
 
+    fn get_sapling_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<sapling::Node>, ShardTreeError<Self::Error>> {
+        self.with_mut(|mut db_data| db_data.get_sapling_subtree_root(index))
+    }
+
     type OrchardShardStore<'a> =
         <WalletDb<rusqlite::Connection, Network, SystemClock, OsRng> as WalletCommitmentTrees>::OrchardShardStore<'a>;
 
@@ -792,11 +847,19 @@ impl WalletCommitmentTrees for DbConnection {
         self.with_mut(|mut db_data| db_data.put_orchard_subtree_roots(start_index, roots))
     }
 
+    fn get_orchard_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        self.with_mut(|mut db_data| db_data.get_orchard_subtree_root(index))
+    }
+
     // Ironwood shares the Orchard note commitment tree's shape (same shard store and depths),
-    // so these mirror the Orchard methods; `with_ironwood_tree_mut` returns `Option` because a
-    // backend may not track an Ironwood tree, but `WalletDb` does, so we forward to it rather
-    // than fall back to the trait's no-op default (which would silently drop Ironwood tree
-    // updates made through this connection).
+    // so these mirror the Orchard methods; `with_ironwood_tree_mut`, `put_ironwood_subtree_roots`
+    // and `get_ironwood_subtree_root` all default to reporting that no Ironwood tree exists,
+    // because a backend may not track one. `WalletDb` does, so we forward to it rather than fall
+    // back to those defaults (which would silently drop Ironwood tree updates made through this
+    // connection, and hide its recorded subtree roots).
     fn with_ironwood_tree_mut<F, A, E>(&mut self, callback: F) -> Result<Option<A>, E>
     where
         for<'a> F: FnMut(
@@ -819,5 +882,12 @@ impl WalletCommitmentTrees for DbConnection {
         >],
     ) -> Result<(), ShardTreeError<Self::Error>> {
         self.with_mut(|mut db_data| db_data.put_ironwood_subtree_roots(start_index, roots))
+    }
+
+    fn get_ironwood_subtree_root(
+        &mut self,
+        index: u64,
+    ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
+        self.with_mut(|mut db_data| db_data.get_ironwood_subtree_root(index))
     }
 }

--- a/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_notes_count.rs
@@ -2,7 +2,10 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
-use zcash_client_backend::data_api::{InputSource, NoteFilter, WalletRead, wallet::TargetHeight};
+use zcash_client_backend::data_api::{
+    InputSource, NoteFilter, WalletRead,
+    wallet::{TargetHeight, input_selection::LockFilter},
+};
 use zcash_protocol::{ShieldedPool, value::Zatoshis};
 
 use crate::components::{
@@ -67,7 +70,15 @@ pub(crate) fn call(
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
     {
         let account_metadata = wallet
-            .get_account_metadata(account_id, &selector, target_height, &[])
+            // Locked notes are still unspent notes held by the account; a count that
+            // silently dropped them would fluctuate with in-flight proposals.
+            .get_account_metadata(
+                account_id,
+                &selector,
+                target_height,
+                &[],
+                LockFilter::Unfiltered,
+            )
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
         if let Some(note_count) = account_metadata.note_count(ShieldedPool::Sapling) {

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -13,7 +13,7 @@ use zcash_client_backend::{
     address::UnifiedAddress,
     data_api::{
         Account, AccountPurpose, CoinbaseFilter, InputSource, WalletRead,
-        wallet::{ConfirmationsPolicy, TargetHeight},
+        wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
     },
     encoding::AddressCodec,
     fees::{orchard::InputView as _, sapling::InputView as _},
@@ -237,6 +237,10 @@ pub(crate) fn call(
                             target_height,
                             confirmations_policy,
                             coinbase_filter,
+                            // A locked output is still an unspent output belonging to the
+                            // wallet, and this RPC reports the wallet's holdings rather than
+                            // selecting inputs, so lock state is not a filter here.
+                            LockFilter::Unfiltered,
                         )
                         .map_err(|e| {
                             RpcError::owned(
@@ -296,6 +300,7 @@ pub(crate) fn call(
                 ],
                 target_height,
                 &[],
+                LockFilter::Unfiltered,
             )
             .map_err(|e| {
                 RpcError::owned(

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -313,6 +313,10 @@ pub(crate) async fn call<C: Chain>(
         request,
         confirmations_policy,
         &spend_policy,
+        // Inputs are not locked: the proposal is built, signed and stored within this
+        // operation, and Zallet exposes no RPC by which a caller could release a lock
+        // left behind by an operation that failed partway through.
+        None,
         // Do not request a specific transaction version; building falls back to the version
         // implied by the target height.
         None,

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -16,7 +16,8 @@ use zcash_client_backend::{
         Account as _, CoinbaseFilter, InputSource, WalletRead,
         wallet::{
             ConfirmationsPolicy, SpendingKeys, TargetHeight, create_proposed_transactions,
-            input_selection::GreedyInputSelector, propose_shielding_coinbase,
+            input_selection::{GreedyInputSelector, LockFilter, LockedInputPolicy},
+            propose_shielding_coinbase,
         },
     },
     fees::StandardFeeRule,
@@ -221,6 +222,10 @@ pub(crate) async fn call<C: Chain>(
         to_zcash_address,
         memo,
         limit_usize,
+        // Inputs are not locked: the proposal is built, signed and stored within this
+        // operation, and Zallet exposes no RPC by which a caller could release a lock
+        // left behind by an operation that failed partway through.
+        None,
     )
     .map_err(|e| {
         LegacyCode::Wallet.with_message(format!("Failed to propose shielding transaction: {e}"))
@@ -489,6 +494,11 @@ fn enumerate_eligible(
                 target_height,
                 ConfirmationsPolicy::MIN,
                 CoinbaseFilter::CoinbaseOnly,
+                // This enumeration is subtracted from the proposal's selected inputs to
+                // report what remains shieldable, so it must mirror the candidate set the
+                // shielding selector drew from: `GreedyInputSelector`'s default
+                // `LockedInputPolicy`, which excludes locked outputs.
+                LockFilter::Policy(&LockedInputPolicy::Exclude),
             )
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
         total_utxos = total_utxos.saturating_add(utxos.len() as u64);

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -48,7 +48,7 @@ use tokio::{sync::Notify, time};
 #[cfg(not(feature = "spend-index"))]
 use zcash_client_backend::data_api::{
     CoinbaseFilter, InputSource, TransactionsInvolvingAddress,
-    wallet::{ConfirmationsPolicy, TargetHeight},
+    wallet::{ConfirmationsPolicy, TargetHeight, input_selection::LockFilter},
 };
 use zcash_client_backend::{
     data_api::{
@@ -858,6 +858,10 @@ async fn service_address_request<V: ChainView>(
         TargetHeight::from(view_tip + 1),
         ConfirmationsPolicy::MIN,
         CoinbaseFilter::AllTransparentOutputs,
+        // This is spend detection, not input selection: we need every tracked output
+        // regardless of lock state to compare against the chain's unspent set, so a
+        // locked output is not mistaken for a spent one.
+        LockFilter::Unfiltered,
     )?;
     let any_spent = our_outputs.iter().any(|output| {
         let outpoint = output.outpoint();


### PR DESCRIPTION
## What

Moves Zallet onto the librustzcash 0.30/0.10 dependency cohort
(`zcash_primitives 0.30.0`, `zcash_transparent 0.10.0`, `zcash_keys 0.16.0`,
`zcash_client_backend 0.24.0-rc.4`, `zcash_client_sqlite 0.22.0-rc.4`,
`orchard 0.15.3`, ...), and updates the **zaino backend** to zaino 0.5 in
lockstep.

## zaino backend (the main change in this PR)

`backends/zaino` previously pinned the zaino crates to `zingolabs/zaino` `dev`.
That pin carries the older librustzcash 0.29/0.9 cohort, so this PR repoints it
to the zodl-inc/zaino branch
[`update/librustzcash-0.24.0-rc.4`](https://github.com/zingolabs/zaino/pull/1428)
(**zingolabs/zaino#1428**), which bumps zaino to the same 0.30/0.10 versions and
carries the Ironwood (NU6.3) note-commitment treestate required for spendable
Ironwood notes. The zaino crates remain a git pin because zaino 0.5 is not yet
released on crates.io.

The zaino `0.3 → 0.5` upgrade brings zaino's ADR-0003 network redesign:

- `ChainIndexConfig::new` is now a struct-literal config whose `network` is a
  `zebra_chain::parameters::Network`; the old payload-carrying
  `zaino_common::Network` is gone. Both the indexer config and the `State`
  validator connector now take the runtime network from the existing
  `network_to_zebra` helper, so the `network_to_zaino` converter is removed.
- `get_spendable_transparent_outputs` (zcash_client_backend 0.24.0-rc.4) gained
  a `lock_filter` argument; the sync spend-detection path passes
  `LockFilter::Unfiltered` so that locked outputs are not mistaken for spent.

## Zebra dependency

The zebra crates are consumed from **crates.io** at the first librustzcash
0.30/0.10 releases, which Zebra has now published (`zebra-chain 11.3`,
`zebra-state 12.0.1`, `zebra-rpc 15.0`). Earlier published versions
(11.2 / 12.0 / 14.0) are still the older librustzcash 0.29/0.9 builds. Using the
released crates unifies on a single copy of each zebra crate and removes the
earlier dependency on a draft Zebra PR.

## Verification

- `cargo check --all-targets` — clean for root, `backends/zebra`, and
  `backends/zaino`.
- `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` — clean in
  `backends/zaino`.
- `cargo test` in `backends/zaino` — green (unit + acceptance).
- Wallet-critical librustzcash crates (`orchard 0.15.3`, `zcash_primitives
  0.30.0`, `zcash_transparent 0.10.0`, `shardtree 0.7.0`,
  `zcash_note_encryption 0.4.1`, ...) resolve identically across the three
  lockfiles, preserving the lockstep invariant (`utils/check-lockstep.sh`).

## Dependencies / cross-repo

- zaino: zingolabs/zaino#1428 (under review; drives the zaino backend pin)
- zebra: released to crates.io at the librustzcash 0.30/0.10 versions used here.

Co-Authored-By: ai-ron <noreply@zodl.com>