### PR TITLE
fix(start): own admitted runtime tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,9 @@ be considered breaking changes.
 ### Changed
 
 - MSRV updated to 1.95.
+- `zallet start` now completes chain-backend construction and consensus checks
+  before opening or migrating the wallet database. If startup exits before task
+  supervision begins, the backend's indexer task is cancelled instead of detached.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,8 +118,9 @@ be considered breaking changes.
 
 - MSRV updated to 1.95.
 - `zallet start` now completes chain-backend construction and consensus checks
-  before opening or migrating the wallet database. If startup exits before task
-  supervision begins, the backend's indexer task is cancelled instead of detached.
+  before opening or migrating the wallet database. If startup exits or is cancelled,
+  tasks started by the backend, RPC server, or wallet sync engine are cancelled
+  instead of detached.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,16 @@ be considered breaking changes.
   memory by starting operations without collecting their results.
 - `zallet start` now returns a failure when a supervised runtime task returns
   an error. Previously the first task exit was converted to a successful
-  process result.
+  process result, so a sync-engine or RPC crash could exit `zallet` with a zero
+  status and silently stop serving. Operators monitoring the process exit code
+  will now see the real failure.
+- The steady-state sync loop now yields to the runtime before re-iterating
+  when the chain backend reports an unchanged tip with no mempool stream.
+  Previously, a backend whose `snapshot`, `tip`, and `get_mempool_stream` all
+  return `Poll::Ready` from cached state could let an aborted `steady_state`
+  task complete a full iteration without ever polling its abort status, leaving
+  `zallet` spinning at full CPU after a sibling task failure. A backend whose
+  every view operation awaits real I/O is unaffected.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ be considered breaking changes.
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
 
+### Changed
+
+- `zallet start` now completes chain-backend construction and consensus checks
+  before opening or migrating the wallet database. If startup exits or is
+  cancelled, tasks started by the backend, RPC server, or wallet sync engine
+  are cancelled instead of detached.
+
 ### Fixed
 
 - `init-wallet-encryption` now canonicalizes the age recipients derived from
@@ -59,6 +66,9 @@ be considered breaking changes.
   rejected while the queue is full of unfinished operations. Previously the
   queue was unbounded, allowing an authenticated caller to exhaust wallet
   memory by starting operations without collecting their results.
+- `zallet start` now returns a failure when a supervised runtime task returns
+  an error. Previously the first task exit was converted to a successful
+  process result.
 
 ## [0.1.0-beta.2] - 2026-07-28
 
@@ -117,10 +127,6 @@ be considered breaking changes.
 ### Changed
 
 - MSRV updated to 1.95.
-- `zallet start` now completes chain-backend construction and consensus checks
-  before opening or migrating the wallet database. If startup exits or is cancelled,
-  tasks started by the backend, RPC server, or wallet sync engine are cancelled
-  instead of detached.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -57,8 +57,6 @@ async fn supervise_zallet_tasks(
     wallet_sync_data_requests_task_handle: TaskHandle,
 ) -> Result<(), Error> {
     // Retain abort-on-drop ownership while the supervisor itself is cancellable.
-    let _task_owner = task_owner;
-
     info!("Spawned Zallet tasks");
 
     // ongoing tasks.
@@ -69,76 +67,57 @@ async fn supervise_zallet_tasks(
     pin!(wallet_sync_batch_decryptor_task_handle);
     pin!(wallet_sync_data_requests_task_handle);
 
-    // Wait for tasks to finish.
-    let res = loop {
-        let exit_when_task_finishes = true;
+    // Every supervised task is ongoing, so the first exit shuts down Zallet. Preserve
+    // the selected task's inner result so a backend-runtime or sync failure makes the
+    // process fail rather than being converted to success.
+    let result = select! {
+        chain_indexer_join_result = &mut chain_indexer_task_handle => {
+            let chain_indexer_result = chain_indexer_join_result
+                .expect("unexpected panic in the chain indexer task");
+            info!(?chain_indexer_result, "Chain indexer task exited");
+            chain_indexer_result
+        }
 
-        let result = select! {
-            chain_indexer_join_result = &mut chain_indexer_task_handle => {
-                let chain_indexer_result = chain_indexer_join_result
-                    .expect("unexpected panic in the chain indexer task");
-                info!(?chain_indexer_result, "Chain indexer task exited");
-                Ok(())
-            }
+        rpc_join_result = &mut rpc_task_handle => {
+            let rpc_server_result = rpc_join_result
+                .expect("unexpected panic in the RPC task");
+            info!(?rpc_server_result, "RPC task exited");
+            rpc_server_result
+        }
 
-            rpc_join_result = &mut rpc_task_handle => {
-                let rpc_server_result = rpc_join_result
-                    .expect("unexpected panic in the RPC task");
-                info!(?rpc_server_result, "RPC task exited");
-                Ok(())
-            }
+        wallet_sync_join_result = &mut wallet_sync_steady_state_task_handle => {
+            let wallet_sync_result = wallet_sync_join_result
+                .expect("unexpected panic in the wallet steady-state sync task");
+            info!(?wallet_sync_result, "Wallet steady-state sync task exited");
+            wallet_sync_result
+        }
 
-            wallet_sync_join_result = &mut wallet_sync_steady_state_task_handle => {
-                let wallet_sync_result = wallet_sync_join_result
-                    .expect("unexpected panic in the wallet steady-state sync task");
-                info!(?wallet_sync_result, "Wallet steady-state sync task exited");
-                Ok(())
-            }
+        wallet_sync_join_result = &mut wallet_sync_recover_history_task_handle => {
+            let wallet_sync_result = wallet_sync_join_result
+                .expect("unexpected panic in the wallet recover-history sync task");
+            info!(?wallet_sync_result, "Wallet recover-history sync task exited");
+            wallet_sync_result
+        }
 
-            wallet_sync_join_result = &mut wallet_sync_recover_history_task_handle => {
-                let wallet_sync_result = wallet_sync_join_result
-                    .expect("unexpected panic in the wallet recover-history sync task");
-                info!(?wallet_sync_result, "Wallet recover-history sync task exited");
-                Ok(())
-            }
+        wallet_sync_join_result = &mut wallet_sync_batch_decryptor_task_handle => {
+            let wallet_sync_result = wallet_sync_join_result
+                .expect("unexpected panic in the wallet batch decryptor task");
+            info!(?wallet_sync_result, "Wallet batch decryptor task exited");
+            wallet_sync_result
+        }
 
-            wallet_sync_join_result = &mut wallet_sync_batch_decryptor_task_handle => {
-                let wallet_sync_result = wallet_sync_join_result
-                    .expect("unexpected panic in the wallet batch decryptor task");
-                info!(?wallet_sync_result, "Wallet batch decryptor task exited");
-                Ok(())
-            }
-
-            wallet_sync_join_result = &mut wallet_sync_data_requests_task_handle => {
-                let wallet_sync_result = wallet_sync_join_result
-                    .expect("unexpected panic in the wallet data-requests sync task");
-                info!(?wallet_sync_result, "Wallet data-requests sync task exited");
-                Ok(())
-            }
-        };
-
-        // Stop Zallet if a task finished and returned an error, or if an ongoing task
-        // exited.
-        match result {
-            Err(_) => break result,
-            Ok(()) if exit_when_task_finishes => break result,
-            Ok(()) => (),
+        wallet_sync_join_result = &mut wallet_sync_data_requests_task_handle => {
+            let wallet_sync_result = wallet_sync_join_result
+                .expect("unexpected panic in the wallet data-requests sync task");
+            info!(?wallet_sync_result, "Wallet data-requests sync task exited");
+            wallet_sync_result
         }
     };
 
-    info!("Exiting Zallet because an ongoing task exited; asking other tasks to stop");
+    info!("An ongoing Zallet task exited; cancelling the remaining tasks");
+    drop(task_owner);
 
-    // ongoing tasks
-    chain_indexer_task_handle.abort();
-    rpc_task_handle.abort();
-    wallet_sync_steady_state_task_handle.abort();
-    wallet_sync_recover_history_task_handle.abort();
-    wallet_sync_batch_decryptor_task_handle.abort();
-    wallet_sync_data_requests_task_handle.abort();
-
-    info!("All tasks have been asked to stop, waiting for remaining tasks to finish");
-
-    res
+    result
 }
 
 impl StartCmd {
@@ -285,6 +264,8 @@ mod tests {
 
     /// The error returned when the fake factory cannot admit its backend.
     const BACKEND_ADMISSION_FAILURE: &str = "required chain backend service is unavailable";
+    /// The error returned by a supervised task in the propagation test.
+    const SUPERVISED_TASK_FAILURE: &str = "supervised task failed";
     /// A compatible prior version that makes a database reopen observably record this build.
     const PRIOR_ZALLET_VERSION: &str = "0.1.0-beta.0";
 
@@ -527,6 +508,52 @@ mod tests {
         }
 
         assert_task_cancelled(chain_cancelled_receiver).await;
+        assert_task_cancelled(rpc_cancelled_receiver).await;
+        assert_task_cancelled(steady_cancelled_receiver).await;
+        assert_task_cancelled(recovery_cancelled_receiver).await;
+        assert_task_cancelled(batch_cancelled_receiver).await;
+        assert_task_cancelled(requests_cancelled_receiver).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn task_supervision_propagates_the_selected_task_error() {
+        let chain_task = tokio::spawn(async {
+            Err::<(), Error>(ErrorKind::Generic.context(SUPERVISED_TASK_FAILURE).into())
+        });
+        let (rpc_cancelled, rpc_cancelled_receiver) = mpsc::channel();
+        let rpc_task = observed_pending_task(rpc_cancelled).await;
+        let (steady_cancelled, steady_cancelled_receiver) = mpsc::channel();
+        let steady_task = observed_pending_task(steady_cancelled).await;
+        let (recovery_cancelled, recovery_cancelled_receiver) = mpsc::channel();
+        let recovery_task = observed_pending_task(recovery_cancelled).await;
+        let (batch_cancelled, batch_cancelled_receiver) = mpsc::channel();
+        let batch_task = observed_pending_task(batch_cancelled).await;
+        let (requests_cancelled, requests_cancelled_receiver) = mpsc::channel();
+        let requests_task = observed_pending_task(requests_cancelled).await;
+
+        let mut task_owner = StartupTaskOwner::new(&chain_task);
+        task_owner.include(&rpc_task);
+        task_owner.include(&steady_task);
+        task_owner.include(&recovery_task);
+        task_owner.include(&batch_task);
+        task_owner.include(&requests_task);
+
+        let error = supervise_zallet_tasks(
+            task_owner,
+            chain_task,
+            rpc_task,
+            steady_task,
+            recovery_task,
+            batch_task,
+            requests_task,
+        )
+        .await
+        .expect_err("a supervised task error must fail zallet start");
+
+        assert!(
+            error.to_string().contains(SUPERVISED_TASK_FAILURE),
+            "unexpected supervision error: {error}",
+        );
         assert_task_cancelled(rpc_cancelled_receiver).await;
         assert_task_cancelled(steady_cancelled_receiver).await;
         assert_task_cancelled(recovery_cancelled_receiver).await;

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -115,6 +115,10 @@ async fn supervise_zallet_tasks(
     };
 
     info!("An ongoing Zallet task exited; cancelling the remaining tasks");
+    // Dropping `task_owner` aborts every task it owns. The task whose exit `select!`
+    // just observed is already complete, so aborting it is a no-op; the remaining
+    // siblings are cancelled. `select!` drops the loser branches' futures, but the
+    // pinned `JoinHandle`s remain live until `task_owner` is dropped here.
     drop(task_owner);
 
     result

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -1,12 +1,13 @@
 //! `start` subcommand
 
 use abscissa_core::{FrameworkError, Runnable, config};
-use tokio::{pin, select};
+use tokio::{pin, select, task::AbortHandle};
 
 use crate::{
     cli::StartCmd,
     commands::AsyncRunnable,
     components::{
+        TaskHandle,
         chain::{ChainFactory, check_consensus_compatibility},
         database::Database,
         json_rpc::JsonRpc,
@@ -20,6 +21,31 @@ use crate::{
 
 #[cfg(zallet_build = "wallet")]
 use crate::components::keystore::KeyStore;
+
+/// Cancels the chain indexer if startup exits before task supervision begins.
+struct ChainIndexerStartupGuard {
+    abort_handle: Option<AbortHandle>,
+}
+
+impl ChainIndexerStartupGuard {
+    fn new(task: &TaskHandle) -> Self {
+        Self {
+            abort_handle: Some(task.abort_handle()),
+        }
+    }
+
+    fn transfer_to_supervisor(mut self) {
+        self.abort_handle = None;
+    }
+}
+
+impl Drop for ChainIndexerStartupGuard {
+    fn drop(&mut self) {
+        if let Some(abort_handle) = &self.abort_handle {
+            abort_handle.abort();
+        }
+    }
+}
 
 impl StartCmd {
     /// Runs `zallet start` against the chain backend produced by `factory`.
@@ -51,31 +77,18 @@ impl StartCmd {
             warn_unused("keystore.require_backup");
         }
 
-        // Connect to and validate the chain backend before opening the wallet database.
+        // Construct a structurally admitted chain backend before opening the wallet database.
         let (chain, chain_indexer_task_handle) = factory.build(config).await?;
+        let chain_indexer_startup_guard = ChainIndexerStartupGuard::new(&chain_indexer_task_handle);
 
         // Refuse to start if the backing full node already follows consensus rules we
         // cannot interpret. If the only incompatibilities are still in the future, this
         // returns the height at which to shut down before reaching them.
         let shutdown_height = check_consensus_compatibility(&chain).await?;
 
-        let db = match Database::open(config).await {
-            Ok(db) => db,
-            Err(error) => {
-                // Database failures occurred before this task existed under the previous
-                // startup order, so retain that cleanup behavior after moving construction.
-                chain_indexer_task_handle.abort();
-                return Err(error);
-            }
-        };
+        let db = Database::open(config).await?;
         #[cfg(zallet_build = "wallet")]
-        let keystore = match KeyStore::new(config, db.clone()) {
-            Ok(keystore) => keystore,
-            Err(error) => {
-                chain_indexer_task_handle.abort();
-                return Err(error);
-            }
-        };
+        let keystore = KeyStore::new(config, db.clone())?;
 
         // Build the decryptor up front so the RPC server has its handle before the initial scan.
         let (decryptor_handle, decryptor_engine) = WalletSync::build_decryptor();
@@ -115,6 +128,7 @@ impl StartCmd {
         )
         .await?;
 
+        chain_indexer_startup_guard.transfer_to_supervisor();
         info!("Spawned Zallet tasks");
 
         // ongoing tasks.
@@ -222,7 +236,9 @@ mod tests {
     use std::sync::{
         Arc,
         atomic::{AtomicBool, Ordering},
+        mpsc,
     };
+    use std::time::Duration;
 
     use rusqlite::Connection;
 
@@ -236,28 +252,61 @@ mod tests {
         error::{Error, ErrorKind},
     };
 
-    /// The error returned by the fake backend's capability preflight.
-    const CAPABILITY_PREFLIGHT_FAILURE: &str = "required scan capabilities are missing";
+    /// The error returned when the fake factory cannot admit its backend.
+    const BACKEND_ADMISSION_FAILURE: &str = "required chain backend service is unavailable";
     /// A compatible prior version that makes a database reopen observably record this build.
     const PRIOR_ZALLET_VERSION: &str = "0.1.0-beta.0";
 
-    struct RejectingBackend {
+    struct AdmissionRejectingFactory {
         build_was_attempted: Arc<AtomicBool>,
     }
 
-    impl ChainFactory for RejectingBackend {
+    struct TaskCancellationProbe(mpsc::Sender<()>);
+
+    impl Drop for TaskCancellationProbe {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
+    struct ConsensusIncompatibleFactory {
+        task_cancelled: mpsc::Sender<()>,
+    }
+
+    impl ChainFactory for ConsensusIncompatibleFactory {
         type Chain = MockChain;
 
-        const NAME: &'static str = "rejecting";
+        const NAME: &'static str = "consensus-incompatible";
+
+        async fn build(&self, _config: &ZalletConfig) -> Result<(Self::Chain, TaskHandle), Error> {
+            let cancellation_probe = TaskCancellationProbe(self.task_cancelled.clone());
+            let (task_started, task_started_receiver) = futures::channel::oneshot::channel();
+            let task = tokio::spawn(async move {
+                let _cancellation_probe = cancellation_probe;
+                let _ = task_started.send(());
+                std::future::pending::<Result<(), Error>>().await
+            });
+            task_started_receiver.await.map_err(|_| {
+                Error::from(ErrorKind::Init.context("fake chain indexer did not start"))
+            })?;
+
+            Ok((MockChain::reporting(Vec::new(), u32::MAX), task))
+        }
+    }
+
+    impl ChainFactory for AdmissionRejectingFactory {
+        type Chain = MockChain;
+
+        const NAME: &'static str = "admission-rejecting";
 
         async fn build(&self, _config: &ZalletConfig) -> Result<(Self::Chain, TaskHandle), Error> {
             self.build_was_attempted.store(true, Ordering::SeqCst);
-            Err(ErrorKind::Init.context(CAPABILITY_PREFLIGHT_FAILURE).into())
+            Err(ErrorKind::Init.context(BACKEND_ADMISSION_FAILURE).into())
         }
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn rejected_backend_preflight_does_not_create_wallet_database() {
+    async fn backend_admission_failure_does_not_create_wallet_database() {
         crate::i18n::load_languages(&[]);
 
         let datadir = tempfile::tempdir().expect("creates temporary data directory");
@@ -267,30 +316,30 @@ mod tests {
         };
         let wallet_db_path = config.wallet_db_path();
         let build_was_attempted = Arc::new(AtomicBool::new(false));
-        let factory = RejectingBackend {
+        let factory = AdmissionRejectingFactory {
             build_was_attempted: build_was_attempted.clone(),
         };
 
         let error = StartCmd::run_with_config(&config, &factory)
             .await
-            .expect_err("capability preflight rejects startup");
+            .expect_err("backend admission rejects startup");
 
         assert!(
             build_was_attempted.load(Ordering::SeqCst),
             "backend construction must run before wallet initialization",
         );
         assert!(
-            error.to_string().contains(CAPABILITY_PREFLIGHT_FAILURE),
+            error.to_string().contains(BACKEND_ADMISSION_FAILURE),
             "unexpected startup error: {error}",
         );
         assert!(
             !wallet_db_path.exists(),
-            "backend preflight failure must not create or migrate the wallet database",
+            "backend admission failure must not create or migrate the wallet database",
         );
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn rejected_backend_preflight_does_not_migrate_existing_wallet_database() {
+    async fn backend_admission_failure_does_not_migrate_existing_wallet_database() {
         crate::i18n::load_languages(&[]);
 
         let datadir = tempfile::tempdir().expect("creates temporary data directory");
@@ -320,17 +369,17 @@ mod tests {
         drop(connection);
 
         let build_was_attempted = Arc::new(AtomicBool::new(false));
-        let factory = RejectingBackend {
+        let factory = AdmissionRejectingFactory {
             build_was_attempted: build_was_attempted.clone(),
         };
 
         let error = StartCmd::run_with_config(&config, &factory)
             .await
-            .expect_err("capability preflight rejects startup");
+            .expect_err("backend admission rejects startup");
 
         assert!(build_was_attempted.load(Ordering::SeqCst));
         assert!(
-            error.to_string().contains(CAPABILITY_PREFLIGHT_FAILURE),
+            error.to_string().contains(BACKEND_ADMISSION_FAILURE),
             "unexpected startup error: {error}",
         );
 
@@ -347,7 +396,35 @@ mod tests {
             .expect("reads latest recorded Zallet version");
         assert_eq!(
             latest_version, PRIOR_ZALLET_VERSION,
-            "backend preflight failure must not run migrations or record this Zallet version",
+            "backend admission failure must not run migrations or record this Zallet version",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn consensus_rejection_cancels_admitted_backend_task_before_wallet_initialization() {
+        crate::i18n::load_languages(&[]);
+
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let (task_cancelled, task_cancelled_receiver) = mpsc::channel();
+        let factory = ConsensusIncompatibleFactory { task_cancelled };
+
+        StartCmd::run_with_config(&config, &factory)
+            .await
+            .expect_err("consensus incompatibility rejects startup");
+
+        tokio::task::spawn_blocking(move || {
+            task_cancelled_receiver.recv_timeout(Duration::from_secs(1))
+        })
+        .await
+        .expect("cancellation observer does not panic")
+        .expect("an admitted backend task is cancelled before startup returns");
+        assert!(
+            !config.wallet_db_path().exists(),
+            "consensus rejection must happen before wallet initialization",
         );
     }
 }

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -22,29 +22,123 @@ use crate::{
 #[cfg(zallet_build = "wallet")]
 use crate::components::keystore::KeyStore;
 
-/// Cancels the chain indexer if startup exits before task supervision begins.
-struct ChainIndexerStartupGuard {
-    abort_handle: Option<AbortHandle>,
+/// Owns cancellation for every task spawned by `zallet start`.
+struct StartupTaskOwner {
+    abort_handles: Vec<AbortHandle>,
 }
 
-impl ChainIndexerStartupGuard {
-    fn new(task: &TaskHandle) -> Self {
+impl StartupTaskOwner {
+    fn new(first_task: &TaskHandle) -> Self {
         Self {
-            abort_handle: Some(task.abort_handle()),
+            abort_handles: vec![first_task.abort_handle()],
         }
     }
 
-    fn transfer_to_supervisor(mut self) {
-        self.abort_handle = None;
+    fn include(&mut self, task: &TaskHandle) {
+        self.abort_handles.push(task.abort_handle());
     }
 }
 
-impl Drop for ChainIndexerStartupGuard {
+impl Drop for StartupTaskOwner {
     fn drop(&mut self) {
-        if let Some(abort_handle) = &self.abort_handle {
+        for abort_handle in &self.abort_handles {
             abort_handle.abort();
         }
     }
+}
+
+async fn supervise_zallet_tasks(
+    task_owner: StartupTaskOwner,
+    chain_indexer_task_handle: TaskHandle,
+    rpc_task_handle: TaskHandle,
+    wallet_sync_steady_state_task_handle: TaskHandle,
+    wallet_sync_recover_history_task_handle: TaskHandle,
+    wallet_sync_batch_decryptor_task_handle: TaskHandle,
+    wallet_sync_data_requests_task_handle: TaskHandle,
+) -> Result<(), Error> {
+    // Retain abort-on-drop ownership while the supervisor itself is cancellable.
+    let _task_owner = task_owner;
+
+    info!("Spawned Zallet tasks");
+
+    // ongoing tasks.
+    pin!(chain_indexer_task_handle);
+    pin!(rpc_task_handle);
+    pin!(wallet_sync_steady_state_task_handle);
+    pin!(wallet_sync_recover_history_task_handle);
+    pin!(wallet_sync_batch_decryptor_task_handle);
+    pin!(wallet_sync_data_requests_task_handle);
+
+    // Wait for tasks to finish.
+    let res = loop {
+        let exit_when_task_finishes = true;
+
+        let result = select! {
+            chain_indexer_join_result = &mut chain_indexer_task_handle => {
+                let chain_indexer_result = chain_indexer_join_result
+                    .expect("unexpected panic in the chain indexer task");
+                info!(?chain_indexer_result, "Chain indexer task exited");
+                Ok(())
+            }
+
+            rpc_join_result = &mut rpc_task_handle => {
+                let rpc_server_result = rpc_join_result
+                    .expect("unexpected panic in the RPC task");
+                info!(?rpc_server_result, "RPC task exited");
+                Ok(())
+            }
+
+            wallet_sync_join_result = &mut wallet_sync_steady_state_task_handle => {
+                let wallet_sync_result = wallet_sync_join_result
+                    .expect("unexpected panic in the wallet steady-state sync task");
+                info!(?wallet_sync_result, "Wallet steady-state sync task exited");
+                Ok(())
+            }
+
+            wallet_sync_join_result = &mut wallet_sync_recover_history_task_handle => {
+                let wallet_sync_result = wallet_sync_join_result
+                    .expect("unexpected panic in the wallet recover-history sync task");
+                info!(?wallet_sync_result, "Wallet recover-history sync task exited");
+                Ok(())
+            }
+
+            wallet_sync_join_result = &mut wallet_sync_batch_decryptor_task_handle => {
+                let wallet_sync_result = wallet_sync_join_result
+                    .expect("unexpected panic in the wallet batch decryptor task");
+                info!(?wallet_sync_result, "Wallet batch decryptor task exited");
+                Ok(())
+            }
+
+            wallet_sync_join_result = &mut wallet_sync_data_requests_task_handle => {
+                let wallet_sync_result = wallet_sync_join_result
+                    .expect("unexpected panic in the wallet data-requests sync task");
+                info!(?wallet_sync_result, "Wallet data-requests sync task exited");
+                Ok(())
+            }
+        };
+
+        // Stop Zallet if a task finished and returned an error, or if an ongoing task
+        // exited.
+        match result {
+            Err(_) => break result,
+            Ok(()) if exit_when_task_finishes => break result,
+            Ok(()) => (),
+        }
+    };
+
+    info!("Exiting Zallet because an ongoing task exited; asking other tasks to stop");
+
+    // ongoing tasks
+    chain_indexer_task_handle.abort();
+    rpc_task_handle.abort();
+    wallet_sync_steady_state_task_handle.abort();
+    wallet_sync_recover_history_task_handle.abort();
+    wallet_sync_batch_decryptor_task_handle.abort();
+    wallet_sync_data_requests_task_handle.abort();
+
+    info!("All tasks have been asked to stop, waiting for remaining tasks to finish");
+
+    res
 }
 
 impl StartCmd {
@@ -79,7 +173,7 @@ impl StartCmd {
 
         // Construct a structurally admitted chain backend before opening the wallet database.
         let (chain, chain_indexer_task_handle) = factory.build(config).await?;
-        let chain_indexer_startup_guard = ChainIndexerStartupGuard::new(&chain_indexer_task_handle);
+        let mut task_owner = StartupTaskOwner::new(&chain_indexer_task_handle);
 
         // Refuse to start if the backing full node already follows consensus rules we
         // cannot interpret. If the only incompatibilities are still in the future, this
@@ -110,6 +204,7 @@ impl StartCmd {
             sync_status_reader,
         )
         .await?;
+        task_owner.include(&rpc_task_handle);
 
         // Start the wallet sync process.
         let (
@@ -128,87 +223,23 @@ impl StartCmd {
         )
         .await?;
 
-        chain_indexer_startup_guard.transfer_to_supervisor();
-        info!("Spawned Zallet tasks");
+        // WalletSync transfers these handles immediately before returning; take over
+        // cancellation ownership before this startup future reaches another await.
+        task_owner.include(&wallet_sync_steady_state_task_handle);
+        task_owner.include(&wallet_sync_recover_history_task_handle);
+        task_owner.include(&wallet_sync_batch_decryptor_task_handle);
+        task_owner.include(&wallet_sync_data_requests_task_handle);
 
-        // ongoing tasks.
-        pin!(chain_indexer_task_handle);
-        pin!(rpc_task_handle);
-        pin!(wallet_sync_steady_state_task_handle);
-        pin!(wallet_sync_recover_history_task_handle);
-        pin!(wallet_sync_batch_decryptor_task_handle);
-        pin!(wallet_sync_data_requests_task_handle);
-
-        // Wait for tasks to finish.
-        let res = loop {
-            let exit_when_task_finishes = true;
-
-            let result = select! {
-                chain_indexer_join_result = &mut chain_indexer_task_handle => {
-                    let chain_indexer_result = chain_indexer_join_result
-                        .expect("unexpected panic in the chain indexer task");
-                    info!(?chain_indexer_result, "Chain indexer task exited");
-                    Ok(())
-                }
-
-                rpc_join_result = &mut rpc_task_handle => {
-                    let rpc_server_result = rpc_join_result
-                        .expect("unexpected panic in the RPC task");
-                    info!(?rpc_server_result, "RPC task exited");
-                    Ok(())
-                }
-
-                wallet_sync_join_result = &mut wallet_sync_steady_state_task_handle => {
-                    let wallet_sync_result = wallet_sync_join_result
-                        .expect("unexpected panic in the wallet steady-state sync task");
-                    info!(?wallet_sync_result, "Wallet steady-state sync task exited");
-                    Ok(())
-                }
-
-                wallet_sync_join_result = &mut wallet_sync_recover_history_task_handle => {
-                    let wallet_sync_result = wallet_sync_join_result
-                        .expect("unexpected panic in the wallet recover-history sync task");
-                    info!(?wallet_sync_result, "Wallet recover-history sync task exited");
-                    Ok(())
-                }
-
-                wallet_sync_join_result = &mut wallet_sync_batch_decryptor_task_handle => {
-                    let wallet_sync_result = wallet_sync_join_result
-                        .expect("unexpected panic in the wallet batch decryptor task");
-                    info!(?wallet_sync_result, "Wallet batch decryptor task exited");
-                    Ok(())
-                }
-
-                wallet_sync_join_result = &mut wallet_sync_data_requests_task_handle => {
-                    let wallet_sync_result = wallet_sync_join_result
-                        .expect("unexpected panic in the wallet data-requests sync task");
-                    info!(?wallet_sync_result, "Wallet data-requests sync task exited");
-                    Ok(())
-                }
-            };
-
-            // Stop Zallet if a task finished and returned an error, or if an ongoing task
-            // exited.
-            match result {
-                Err(_) => break result,
-                Ok(()) if exit_when_task_finishes => break result,
-                Ok(()) => (),
-            }
-        };
-
-        info!("Exiting Zallet because an ongoing task exited; asking other tasks to stop");
-
-        // ongoing tasks
-        chain_indexer_task_handle.abort();
-        rpc_task_handle.abort();
-        wallet_sync_steady_state_task_handle.abort();
-        wallet_sync_recover_history_task_handle.abort();
-        wallet_sync_batch_decryptor_task_handle.abort();
-        wallet_sync_data_requests_task_handle.abort();
-
-        info!("All tasks have been asked to stop, waiting for remaining tasks to finish");
-
-        res
+        supervise_zallet_tasks(
+            task_owner,
+            chain_indexer_task_handle,
+            rpc_task_handle,
+            wallet_sync_steady_state_task_handle,
+            wallet_sync_recover_history_task_handle,
+            wallet_sync_batch_decryptor_task_handle,
+            wallet_sync_data_requests_task_handle,
+        )
+        .await
     }
 }
 
@@ -242,7 +273,7 @@ mod tests {
 
     use rusqlite::Connection;
 
-    use super::StartCmd;
+    use super::{StartCmd, StartupTaskOwner, supervise_zallet_tasks};
     use crate::{
         components::{
             TaskHandle,
@@ -269,6 +300,27 @@ mod tests {
         }
     }
 
+    async fn observed_pending_task(task_cancelled: mpsc::Sender<()>) -> TaskHandle {
+        let cancellation_probe = TaskCancellationProbe(task_cancelled);
+        let (task_started, task_started_receiver) = futures::channel::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _cancellation_probe = cancellation_probe;
+            let _ = task_started.send(());
+            std::future::pending::<Result<(), Error>>().await
+        });
+        task_started_receiver
+            .await
+            .expect("cancellation-observed task starts");
+        task
+    }
+
+    async fn assert_task_cancelled(task_cancelled: mpsc::Receiver<()>) {
+        tokio::task::spawn_blocking(move || task_cancelled.recv_timeout(Duration::from_secs(1)))
+            .await
+            .expect("cancellation observer does not panic")
+            .expect("pre-supervision task is cancelled");
+    }
+
     struct ConsensusIncompatibleFactory {
         task_cancelled: mpsc::Sender<()>,
     }
@@ -279,16 +331,7 @@ mod tests {
         const NAME: &'static str = "consensus-incompatible";
 
         async fn build(&self, _config: &ZalletConfig) -> Result<(Self::Chain, TaskHandle), Error> {
-            let cancellation_probe = TaskCancellationProbe(self.task_cancelled.clone());
-            let (task_started, task_started_receiver) = futures::channel::oneshot::channel();
-            let task = tokio::spawn(async move {
-                let _cancellation_probe = cancellation_probe;
-                let _ = task_started.send(());
-                std::future::pending::<Result<(), Error>>().await
-            });
-            task_started_receiver.await.map_err(|_| {
-                Error::from(ErrorKind::Init.context("fake chain indexer did not start"))
-            })?;
+            let task = observed_pending_task(self.task_cancelled.clone()).await;
 
             Ok((MockChain::reporting(Vec::new(), u32::MAX), task))
         }
@@ -416,15 +459,78 @@ mod tests {
             .await
             .expect_err("consensus incompatibility rejects startup");
 
-        tokio::task::spawn_blocking(move || {
-            task_cancelled_receiver.recv_timeout(Duration::from_secs(1))
-        })
-        .await
-        .expect("cancellation observer does not panic")
-        .expect("an admitted backend task is cancelled before startup returns");
+        assert_task_cancelled(task_cancelled_receiver).await;
         assert!(
             !config.wallet_db_path().exists(),
             "consensus rejection must happen before wallet initialization",
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wallet_sync_initialization_error_cancels_chain_and_rpc_tasks() {
+        let (chain_task_cancelled, chain_task_cancelled_receiver) = mpsc::channel();
+        let chain_task = observed_pending_task(chain_task_cancelled).await;
+        let (rpc_task_cancelled, rpc_task_cancelled_receiver) = mpsc::channel();
+        let rpc_task = observed_pending_task(rpc_task_cancelled).await;
+
+        let initialization: Result<(), Error> = async {
+            let mut task_owner = StartupTaskOwner::new(&chain_task);
+            task_owner.include(&rpc_task);
+            Err(ErrorKind::Init
+                .context("simulated wallet sync initialization failure")
+                .into())
+        }
+        .await;
+
+        initialization.expect_err("late startup initialization fails");
+        assert_task_cancelled(chain_task_cancelled_receiver).await;
+        assert_task_cancelled(rpc_task_cancelled_receiver).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cancelling_task_supervision_stops_every_zallet_task() {
+        let (chain_cancelled, chain_cancelled_receiver) = mpsc::channel();
+        let chain_task = observed_pending_task(chain_cancelled).await;
+        let (rpc_cancelled, rpc_cancelled_receiver) = mpsc::channel();
+        let rpc_task = observed_pending_task(rpc_cancelled).await;
+        let (steady_cancelled, steady_cancelled_receiver) = mpsc::channel();
+        let steady_task = observed_pending_task(steady_cancelled).await;
+        let (recovery_cancelled, recovery_cancelled_receiver) = mpsc::channel();
+        let recovery_task = observed_pending_task(recovery_cancelled).await;
+        let (batch_cancelled, batch_cancelled_receiver) = mpsc::channel();
+        let batch_task = observed_pending_task(batch_cancelled).await;
+        let (requests_cancelled, requests_cancelled_receiver) = mpsc::channel();
+        let requests_task = observed_pending_task(requests_cancelled).await;
+
+        let mut task_owner = StartupTaskOwner::new(&chain_task);
+        task_owner.include(&rpc_task);
+        task_owner.include(&steady_task);
+        task_owner.include(&recovery_task);
+        task_owner.include(&batch_task);
+        task_owner.include(&requests_task);
+
+        {
+            let supervisor = supervise_zallet_tasks(
+                task_owner,
+                chain_task,
+                rpc_task,
+                steady_task,
+                recovery_task,
+                batch_task,
+                requests_task,
+            );
+            tokio::pin!(supervisor);
+            assert!(
+                futures::poll!(&mut supervisor).is_pending(),
+                "all supervised tasks are pending",
+            );
+        }
+
+        assert_task_cancelled(chain_cancelled_receiver).await;
+        assert_task_cancelled(rpc_cancelled_receiver).await;
+        assert_task_cancelled(steady_cancelled_receiver).await;
+        assert_task_cancelled(recovery_cancelled_receiver).await;
+        assert_task_cancelled(batch_cancelled_receiver).await;
+        assert_task_cancelled(requests_cancelled_receiver).await;
     }
 }

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -27,6 +27,13 @@ impl StartCmd {
         let config = APP.config();
         let _lock = config.lock_datadir()?;
 
+        Self::run_with_config(&config, factory).await
+    }
+
+    async fn run_with_config<F: ChainFactory>(
+        config: &ZalletConfig,
+        factory: &F,
+    ) -> Result<(), Error> {
         // BETA: Warn when currently-unused config options are set.
         let warn_unused =
             |option: &str| warn!("{}", fl!("warn-config-unused", option = option.to_string()));
@@ -44,17 +51,31 @@ impl StartCmd {
             warn_unused("keystore.require_backup");
         }
 
-        let db = Database::open(&config).await?;
-        #[cfg(zallet_build = "wallet")]
-        let keystore = KeyStore::new(&config, db.clone())?;
-
-        // Start monitoring the chain.
-        let (chain, chain_indexer_task_handle) = factory.build(&config).await?;
+        // Connect to and validate the chain backend before opening the wallet database.
+        let (chain, chain_indexer_task_handle) = factory.build(config).await?;
 
         // Refuse to start if the backing full node already follows consensus rules we
         // cannot interpret. If the only incompatibilities are still in the future, this
         // returns the height at which to shut down before reaching them.
         let shutdown_height = check_consensus_compatibility(&chain).await?;
+
+        let db = match Database::open(config).await {
+            Ok(db) => db,
+            Err(error) => {
+                // Database failures occurred before this task existed under the previous
+                // startup order, so retain that cleanup behavior after moving construction.
+                chain_indexer_task_handle.abort();
+                return Err(error);
+            }
+        };
+        #[cfg(zallet_build = "wallet")]
+        let keystore = match KeyStore::new(config, db.clone()) {
+            Ok(keystore) => keystore,
+            Err(error) => {
+                chain_indexer_task_handle.abort();
+                return Err(error);
+            }
+        };
 
         // Build the decryptor up front so the RPC server has its handle before the initial scan.
         let (decryptor_handle, decryptor_engine) = WalletSync::build_decryptor();
@@ -66,7 +87,7 @@ impl StartCmd {
 
         // Launch RPC server.
         let rpc_task_handle = JsonRpc::spawn(
-            &config,
+            config,
             db.clone(),
             #[cfg(zallet_build = "wallet")]
             keystore,
@@ -84,7 +105,7 @@ impl StartCmd {
             wallet_sync_batch_decryptor_task_handle,
             wallet_sync_data_requests_task_handle,
         ) = WalletSync::spawn(
-            &config,
+            config,
             db,
             chain,
             shutdown_height,
@@ -193,5 +214,140 @@ impl Runnable for StartCmd {
 impl config::Override<ZalletConfig> for StartCmd {
     fn override_config(&self, config: ZalletConfig) -> Result<ZalletConfig, FrameworkError> {
         Ok(config)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use rusqlite::Connection;
+
+    use super::StartCmd;
+    use crate::{
+        components::{
+            TaskHandle,
+            chain::{ChainFactory, MockChain},
+        },
+        config::ZalletConfig,
+        error::{Error, ErrorKind},
+    };
+
+    /// The error returned by the fake backend's capability preflight.
+    const CAPABILITY_PREFLIGHT_FAILURE: &str = "required scan capabilities are missing";
+    /// A compatible prior version that makes a database reopen observably record this build.
+    const PRIOR_ZALLET_VERSION: &str = "0.1.0-beta.0";
+
+    struct RejectingBackend {
+        build_was_attempted: Arc<AtomicBool>,
+    }
+
+    impl ChainFactory for RejectingBackend {
+        type Chain = MockChain;
+
+        const NAME: &'static str = "rejecting";
+
+        async fn build(&self, _config: &ZalletConfig) -> Result<(Self::Chain, TaskHandle), Error> {
+            self.build_was_attempted.store(true, Ordering::SeqCst);
+            Err(ErrorKind::Init.context(CAPABILITY_PREFLIGHT_FAILURE).into())
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejected_backend_preflight_does_not_create_wallet_database() {
+        crate::i18n::load_languages(&[]);
+
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let wallet_db_path = config.wallet_db_path();
+        let build_was_attempted = Arc::new(AtomicBool::new(false));
+        let factory = RejectingBackend {
+            build_was_attempted: build_was_attempted.clone(),
+        };
+
+        let error = StartCmd::run_with_config(&config, &factory)
+            .await
+            .expect_err("capability preflight rejects startup");
+
+        assert!(
+            build_was_attempted.load(Ordering::SeqCst),
+            "backend construction must run before wallet initialization",
+        );
+        assert!(
+            error.to_string().contains(CAPABILITY_PREFLIGHT_FAILURE),
+            "unexpected startup error: {error}",
+        );
+        assert!(
+            !wallet_db_path.exists(),
+            "backend preflight failure must not create or migrate the wallet database",
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn rejected_backend_preflight_does_not_migrate_existing_wallet_database() {
+        crate::i18n::load_languages(&[]);
+
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let wallet_db_path = config.wallet_db_path();
+
+        let database = super::Database::open(&config)
+            .await
+            .expect("creates a current wallet database");
+        drop(database);
+
+        let connection = Connection::open(&wallet_db_path).expect("opens wallet database");
+        let updated = connection
+            .execute(
+                "UPDATE ext_zallet_db_version_metadata
+                 SET version = ?1
+                 WHERE rowid = (
+                    SELECT MAX(rowid) FROM ext_zallet_db_version_metadata
+                 )",
+                [PRIOR_ZALLET_VERSION],
+            )
+            .expect("marks the database as last opened by the prior version");
+        assert_eq!(updated, 1, "setup updates exactly one version record");
+        drop(connection);
+
+        let build_was_attempted = Arc::new(AtomicBool::new(false));
+        let factory = RejectingBackend {
+            build_was_attempted: build_was_attempted.clone(),
+        };
+
+        let error = StartCmd::run_with_config(&config, &factory)
+            .await
+            .expect_err("capability preflight rejects startup");
+
+        assert!(build_was_attempted.load(Ordering::SeqCst));
+        assert!(
+            error.to_string().contains(CAPABILITY_PREFLIGHT_FAILURE),
+            "unexpected startup error: {error}",
+        );
+
+        let connection = Connection::open(&wallet_db_path).expect("reopens wallet database");
+        let latest_version: String = connection
+            .query_row(
+                "SELECT version
+                 FROM ext_zallet_db_version_metadata
+                 ORDER BY rowid DESC
+                 LIMIT 1",
+                [],
+                |row| row.get(0),
+            )
+            .expect("reads latest recorded Zallet version");
+        assert_eq!(
+            latest_version, PRIOR_ZALLET_VERSION,
+            "backend preflight failure must not run migrations or record this Zallet version",
+        );
     }
 }

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -729,6 +729,9 @@ pub enum SpendStatus {
 }
 
 #[cfg(test)]
+pub(crate) use tests::MockChain;
+
+#[cfg(test)]
 mod tests {
     use std::ops::Range;
 
@@ -764,7 +767,7 @@ mod tests {
     /// A trivial in-memory [`ChainView`], proving the trait is implementable by a non-Zaino
     /// backend and locking the contract.
     #[derive(Clone)]
-    struct MockChainView {
+    pub(crate) struct MockChainView {
         tip: ChainBlock,
     }
 
@@ -1161,7 +1164,7 @@ mod tests {
     /// `reported_upgrades`, and `snapshot` carry meaning; the compatibility check never reaches
     /// the other methods, so they are `unreachable!`.
     #[derive(Clone)]
-    struct MockChain {
+    pub(crate) struct MockChain {
         params: super::Network,
         upgrades: Vec<ReportedUpgrade>,
         tip: BlockHeight,

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -54,8 +54,15 @@ pub trait ChainFactory: Send + Sync + 'static {
     /// and by convention matches the `zallet-<NAME>` binary that ships the backend.
     const NAME: &'static str;
 
-    /// Connects to the chain-data source described by `config`, returning the
-    /// backend handle and the task driving its indexer.
+    /// Connects to and structurally admits the chain-data source described by `config`,
+    /// returning the backend handle and the task driving its indexer.
+    ///
+    /// `Ok` guarantees that backend-specific discovery has found every service and
+    /// capability required to implement this binary's complete [`Chain`] contract.
+    /// Factories must reject a partially usable composition with an initialization error.
+    /// This admission guarantee covers the composed service shape, not perpetual runtime
+    /// availability; individual chain operations can still fail. Consensus compatibility
+    /// is checked separately after construction.
     fn build(
         &self,
         config: &ZalletConfig,
@@ -1170,6 +1177,16 @@ mod tests {
         tip: BlockHeight,
     }
 
+    impl MockChain {
+        pub(crate) fn reporting(upgrades: Vec<ReportedUpgrade>, tip: u32) -> Self {
+            Self {
+                params: super::Network::Consensus(Network::MainNetwork),
+                upgrades,
+                tip: BlockHeight::from_u32(tip),
+            }
+        }
+    }
+
     impl Chain for MockChain {
         type View = MockChainView;
 
@@ -1215,11 +1232,7 @@ mod tests {
 
     /// A [`MockChain`] on mainnet reporting `upgrades`, with its tip at `tip`.
     fn mock_chain(upgrades: Vec<ReportedUpgrade>, tip: u32) -> MockChain {
-        MockChain {
-            params: super::Network::Consensus(Network::MainNetwork),
-            upgrades,
-            tip: BlockHeight::from_u32(tip),
-        }
+        MockChain::reporting(upgrades, tip)
     }
 
     #[tokio::test]

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -1166,10 +1166,11 @@ mod tests {
         assert!(detect(&all_known()).is_empty());
     }
 
-    /// A minimal [`Chain`] that serves a fixed upgrade set and tip on mainnet, for exercising
-    /// the end-to-end `check_consensus_compatibility` orchestration. Only `params`,
-    /// `reported_upgrades`, and `snapshot` carry meaning; the compatibility check never reaches
-    /// the other methods, so they are `unreachable!`.
+    /// A minimal [`Chain`] that serves a fixed upgrade set and tip on mainnet.
+    ///
+    /// `params`, `reported_upgrades`, and `snapshot` support consensus checks. Operations
+    /// outside that scope return a backend error, which also lets component tests exercise
+    /// startup failure after accepting this chain.
     #[derive(Clone)]
     pub(crate) struct MockChain {
         params: super::Network,
@@ -1199,25 +1200,33 @@ mod tests {
         }
 
         async fn broadcast_transaction(&self, _tx: &Transaction) -> Result<(), ChainError> {
-            unreachable!("the compatibility check does not broadcast transactions")
+            Err(ChainError::backend(
+                "mock chain does not broadcast transactions",
+            ))
         }
 
         async fn get_sapling_subtree_roots(
             &self,
         ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError> {
-            unreachable!("the compatibility check does not read subtree roots")
+            Err(ChainError::backend(
+                "mock chain does not serve wallet subtree roots",
+            ))
         }
 
         async fn get_orchard_subtree_roots(
             &self,
         ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
-            unreachable!("the compatibility check does not read subtree roots")
+            Err(ChainError::backend(
+                "mock chain does not serve wallet subtree roots",
+            ))
         }
 
         async fn get_ironwood_subtree_roots(
             &self,
         ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
-            unreachable!("the compatibility check does not read subtree roots")
+            Err(ChainError::backend(
+                "mock chain does not serve wallet subtree roots",
+            ))
         }
 
         async fn snapshot(&self) -> Result<Self::View, ChainError> {

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -782,7 +782,20 @@ async fn steady_state_iteration<C: Chain>(
         }
         // The chain tip already changed since this view was captured; loop around
         // immediately to observe it.
-        None if tip_changed => (),
+        //
+        // Yield to the runtime and pause briefly before re-iterating. `snapshot`,
+        // `tip`, and `get_mempool_stream` can all return `Poll::Ready` from cached
+        // state (MockChain does, and the Zaino `FetchServiceSubscriber` was observed
+        // doing so in #136), so without this yield an aborted `steady_state` task
+        // can complete a full iteration without ever polling its abort status,
+        // spinning until the backend's view changes. The yield lets tokio observe
+        // the abort and end the task; the sleep bounds the CPU cost of a non-aborted
+        // task that is legitimately re-polling a backend serving a stale cached view
+        // (a backend contract violation, but one Zaino has been observed to exhibit).
+        None if tip_changed => {
+            tokio::task::yield_now().await;
+            time::sleep(Duration::from_millis(500)).await;
+        }
         // The chain tip has not changed, and no mempool stream is available (e.g.
         // because the chain indexer is still syncing its finalized state). Pause
         // briefly to avoid spinning.
@@ -1116,14 +1129,20 @@ mod tests {
 
     use super::{
         ChainError, PendingWalletSyncTasks, SyncError, WalletSync, is_retryable, rewind_step,
-        select_initial_scan_range,
+        select_initial_scan_range, status, steady_state,
     };
     use crate::{
-        components::{TaskHandle, chain::MockChain, database::Database},
+        components::{
+            TaskHandle,
+            chain::{ChainBlock, MockChain},
+            database::Database,
+        },
         config::ZalletConfig,
         error::{Error, ErrorKind},
     };
+    use tokio::sync::Notify;
     use zcash_client_backend::data_api::scanning::{ScanPriority, ScanRange};
+    use zcash_primitives::block::BlockHash;
     use zcash_protocol::consensus::BlockHeight;
 
     struct TaskCancellationProbe(mpsc::Sender<()>);
@@ -1235,6 +1254,7 @@ mod tests {
             .expect("creates a wallet database");
         let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
         let decryptor_observer = decryptor.clone();
+        let (status, _status_reader) = status::channel(config.sync.lock_threshold());
 
         let result = WalletSync::spawn(
             &config,
@@ -1243,16 +1263,104 @@ mod tests {
             None,
             decryptor,
             decryptor_engine,
+            status,
         )
         .await;
 
         assert!(result.is_err(), "mock chain rejects wallet sync startup");
+        // `reload_keys` returns `None` only when the decryptor handle has no engine to
+        // reload, which itself indicates the engine was dropped during the failed
+        // startup. Either outcome proves the batch decryptor is not left running;
+        // assert the `Some` case explicitly, and accept `None` as equivalent shutdown.
         if let Some(reload_finished) = decryptor_observer.reload_keys().await {
             assert!(
                 reload_finished.await.is_err(),
                 "failed wallet sync startup must not leave its batch decryptor running",
             );
         }
+        // `None` means there is no engine to reload — the decryptor is already down.
+    }
+
+    // Regression for zallet#136: when a sibling task fails and `steady_state` is
+    // aborted, the task must exit at its next yield point. The `None if tip_changed`
+    // arm of `steady_state_iteration` previously returned without an intervening
+    // await, so against a `ChainView` whose `snapshot`, `tip`, and
+    // `get_mempool_stream` all return `Poll::Ready` from cached state (the in-tree
+    // `MockChain`, and the Zaino `FetchServiceSubscriber` as reported in #136), the
+    // task could complete a full iteration without ever polling its abort status and
+    // spin indefinitely. The fix inserts `tokio::task::yield_now().await` in that arm;
+    // this test asserts the aborted task now exits within a bounded time.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn aborted_steady_state_exits_when_the_backend_returns_cached_state() {
+        crate::i18n::load_languages(&[]);
+
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates a wallet database");
+        let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
+        // Drop the engine half; the steady-state task only needs the handle, and we
+        // do not drive batch decryption here.
+        drop(decryptor_engine);
+
+        // A MockChain whose every view operation returns `Poll::Ready`: `snapshot`
+        // and `tip` are synchronous, and `get_mempool_stream` returns `Ok(None)`.
+        // Its tip sits at height 100, while the wallet starts from height 0, so
+        // every iteration takes the `tip_changed` branch and lands in the
+        // `None if tip_changed` arm — the exact no-yield fast path from #136.
+        let chain = MockChain::reporting(Vec::new(), 100);
+        let params = config.consensus.network();
+        // The status channel is write-only here; the reader half is dropped and the
+        // steady-state task's status writes go unobserved.
+        let (status, _status_reader) = status::channel(config.sync.lock_threshold());
+
+        let mut db_data = database.handle().await.expect("opens the wallet database");
+        // `prev_tip` differs from the chain tip in height, so `tip_changed` is true;
+        // the fresh wallet has an empty block locator, so `locate_fork_point`
+        // returns `prev_tip` and no reorg rewind or block scanning occurs. The
+        // `stream_blocks_to_tip` call yields an empty stream, so the inner while
+        // loop never updates `prev_tip`, leaving `tip_changed` true on every
+        // subsequent iteration as well.
+        let prev_tip = ChainBlock::new(BlockHeight::from_u32(0), BlockHash([0xff; 32]));
+        let lower_boundary = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let tip_change_signal = std::sync::Arc::new(Notify::new());
+
+        let steady_state_task = tokio::spawn(async move {
+            steady_state(
+                chain,
+                &params,
+                db_data.as_mut(),
+                prev_tip,
+                lower_boundary,
+                tip_change_signal,
+                decryptor,
+                None,
+                status,
+            )
+            .await
+        });
+
+        // Give the task a chance to enter its loop, then abort it. Without the
+        // `yield_now().await` in the `None if tip_changed` arm, the task never
+        // yields to check its abort status and the timeout below fires.
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        steady_state_task.abort();
+
+        let join_result = tokio::time::timeout(Duration::from_secs(2), steady_state_task)
+            .await
+            .expect(
+                "aborted steady_state must exit within a bounded time when the backend \
+                 returns cached state (zallet#136)",
+            );
+        // A tokio task aborted before completion joins with `Err(JoinError::Cancelled)`.
+        assert!(
+            join_result.is_err(),
+            "aborted steady_state task must not complete normally: {join_result:?}",
+        );
     }
 
     // The #636 repro: the wallet DB has recorded a higher chain tip than the current

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -44,7 +44,7 @@ use jsonrpsee::tracing::{self, debug, info, warn};
 use std::collections::HashSet;
 #[cfg(not(feature = "spend-index"))]
 use std::ops::Range;
-use tokio::{sync::Notify, time};
+use tokio::{sync::Notify, task::AbortHandle, time};
 #[cfg(not(feature = "spend-index"))]
 use zcash_client_backend::data_api::{
     CoinbaseFilter, InputSource, TransactionsInvolvingAddress,
@@ -92,6 +92,35 @@ pub(crate) type WalletDecryptorHandle = decryptor::Handle<AccountUuid, (AccountU
 /// Engine half of the batch decryptor, driven by the sync tasks spawned by [`WalletSync::spawn`].
 pub(crate) type WalletDecryptorEngine = decryptor::Engine<AccountUuid, (AccountUuid, Scope)>;
 
+/// Owns cancellation for wallet-sync tasks until the complete task set is returned.
+struct PendingWalletSyncTasks {
+    abort_handles: Vec<AbortHandle>,
+}
+
+impl PendingWalletSyncTasks {
+    fn new(first_task: &TaskHandle) -> Self {
+        Self {
+            abort_handles: vec![first_task.abort_handle()],
+        }
+    }
+
+    fn include(&mut self, task: &TaskHandle) {
+        self.abort_handles.push(task.abort_handle());
+    }
+
+    fn transfer_to_caller(mut self) {
+        self.abort_handles.clear();
+    }
+}
+
+impl Drop for PendingWalletSyncTasks {
+    fn drop(&mut self) {
+        for abort_handle in &self.abort_handles {
+            abort_handle.abort();
+        }
+    }
+}
+
 impl WalletSync {
     /// Builds the batch decryptor. Split from [`WalletSync::spawn`] so the RPC server can be
     /// handed a handle before `spawn`'s initial scan, which would otherwise delay RPC startup.
@@ -101,6 +130,10 @@ impl WalletSync {
         decryptor::new().build()
     }
 
+    /// Initializes wallet sync and returns its complete task set.
+    ///
+    /// On success, the caller owns cancellation for every returned task and must register
+    /// that ownership before its next cancellable await.
     pub(crate) async fn spawn<C: Chain>(
         config: &ZalletConfig,
         db: Database,
@@ -121,6 +154,7 @@ impl WalletSync {
                 Ok(())
             })
         };
+        let mut pending_tasks = PendingWalletSyncTasks::new(&batch_decryptor_task);
 
         // Ensure the wallet is in a state that the sync tasks can work with.
         let mut db_data = db.handle().await?;
@@ -166,6 +200,7 @@ impl WalletSync {
                 Ok(())
             })
         };
+        pending_tasks.include(&steady_state_task);
 
         let recover_history_task = {
             let chain = chain.clone();
@@ -186,6 +221,7 @@ impl WalletSync {
                 Ok(())
             })
         };
+        pending_tasks.include(&recover_history_task);
 
         let mut db_data = db.handle().await?;
         let data_requests_task = crate::spawn!("Data requests", async move {
@@ -198,6 +234,11 @@ impl WalletSync {
             .await?;
             Ok(())
         });
+        pending_tasks.include(&data_requests_task);
+
+        // This handoff and the return must stay free of awaits: the caller registers every
+        // returned handle with its own abort-on-drop owner in the same executor poll.
+        pending_tasks.transfer_to_caller();
 
         Ok((
             steady_state_task,
@@ -1071,9 +1112,48 @@ async fn batch_decryptor(
 
 #[cfg(test)]
 mod tests {
-    use super::{ChainError, SyncError, is_retryable, rewind_step, select_initial_scan_range};
+    use std::{sync::mpsc, time::Duration};
+
+    use super::{
+        ChainError, PendingWalletSyncTasks, SyncError, WalletSync, is_retryable, rewind_step,
+        select_initial_scan_range,
+    };
+    use crate::{
+        components::{TaskHandle, chain::MockChain, database::Database},
+        config::ZalletConfig,
+        error::{Error, ErrorKind},
+    };
     use zcash_client_backend::data_api::scanning::{ScanPriority, ScanRange};
     use zcash_protocol::consensus::BlockHeight;
+
+    struct TaskCancellationProbe(mpsc::Sender<()>);
+
+    impl Drop for TaskCancellationProbe {
+        fn drop(&mut self) {
+            let _ = self.0.send(());
+        }
+    }
+
+    async fn observed_pending_task(task_cancelled: mpsc::Sender<()>) -> TaskHandle {
+        let cancellation_probe = TaskCancellationProbe(task_cancelled);
+        let (task_started, task_started_receiver) = futures::channel::oneshot::channel();
+        let task = tokio::spawn(async move {
+            let _cancellation_probe = cancellation_probe;
+            let _ = task_started.send(());
+            std::future::pending::<Result<(), Error>>().await
+        });
+        task_started_receiver
+            .await
+            .expect("cancellation-observed task starts");
+        task
+    }
+
+    async fn assert_task_cancelled(task_cancelled: mpsc::Receiver<()>) {
+        tokio::task::spawn_blocking(move || task_cancelled.recv_timeout(Duration::from_secs(1)))
+            .await
+            .expect("cancellation observer does not panic")
+            .expect("partially initialized wallet sync task is cancelled");
+    }
 
     fn h(height: u32) -> BlockHeight {
         BlockHeight::from_u32(height)
@@ -1081,6 +1161,98 @@ mod tests {
 
     fn range(start: u32, end: u32, priority: ScanPriority) -> ScanRange {
         ScanRange::from_parts(h(start)..h(end), priority)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn late_wallet_sync_error_cancels_all_earlier_tasks() {
+        let (batch_cancelled, batch_cancelled_receiver) = mpsc::channel();
+        let batch_task = observed_pending_task(batch_cancelled).await;
+        let (steady_cancelled, steady_cancelled_receiver) = mpsc::channel();
+        let steady_task = observed_pending_task(steady_cancelled).await;
+        let (recovery_cancelled, recovery_cancelled_receiver) = mpsc::channel();
+        let recovery_task = observed_pending_task(recovery_cancelled).await;
+
+        let initialization: Result<(), Error> = async {
+            let mut pending_tasks = PendingWalletSyncTasks::new(&batch_task);
+            pending_tasks.include(&steady_task);
+            pending_tasks.include(&recovery_task);
+            Err(ErrorKind::Init
+                .context("simulated late wallet sync failure")
+                .into())
+        }
+        .await;
+
+        initialization.expect_err("late wallet sync initialization fails");
+        assert_task_cancelled(batch_cancelled_receiver).await;
+        assert_task_cancelled(steady_cancelled_receiver).await;
+        assert_task_cancelled(recovery_cancelled_receiver).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wallet_sync_initialization_cancellation_stops_all_earlier_tasks() {
+        let (batch_cancelled, batch_cancelled_receiver) = mpsc::channel();
+        let batch_task = observed_pending_task(batch_cancelled).await;
+        let (steady_cancelled, steady_cancelled_receiver) = mpsc::channel();
+        let steady_task = observed_pending_task(steady_cancelled).await;
+        let (recovery_cancelled, recovery_cancelled_receiver) = mpsc::channel();
+        let recovery_task = observed_pending_task(recovery_cancelled).await;
+        let (initialization_waiting, initialization_waiting_receiver) =
+            futures::channel::oneshot::channel();
+
+        let initialization = tokio::spawn(async move {
+            let mut pending_tasks = PendingWalletSyncTasks::new(&batch_task);
+            pending_tasks.include(&steady_task);
+            pending_tasks.include(&recovery_task);
+            let _ = initialization_waiting.send(());
+            std::future::pending::<()>().await;
+            pending_tasks.transfer_to_caller();
+        });
+
+        initialization_waiting_receiver
+            .await
+            .expect("wallet sync initialization reaches its cancellable await");
+        initialization.abort();
+        initialization
+            .await
+            .expect_err("wallet sync initialization is cancelled");
+
+        assert_task_cancelled(batch_cancelled_receiver).await;
+        assert_task_cancelled(steady_cancelled_receiver).await;
+        assert_task_cancelled(recovery_cancelled_receiver).await;
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn wallet_sync_error_shuts_down_the_spawned_batch_decryptor() {
+        crate::i18n::load_languages(&[]);
+
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates a wallet database");
+        let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
+        let decryptor_observer = decryptor.clone();
+
+        let result = WalletSync::spawn(
+            &config,
+            database,
+            MockChain::reporting(Vec::new(), 0),
+            None,
+            decryptor,
+            decryptor_engine,
+        )
+        .await;
+
+        assert!(result.is_err(), "mock chain rejects wallet sync startup");
+        if let Some(reload_finished) = decryptor_observer.reload_keys().await {
+            assert!(
+                reload_finished.await.is_err(),
+                "failed wallet sync startup must not leave its batch decryptor running",
+            );
+        }
     }
 
     // The #636 repro: the wallet DB has recorded a higher chain tip than the current


### PR DESCRIPTION
Closes #702. Also closes #136 (see the final commit).

Backend admission and partial startup failures could mutate the wallet database or detach runtime tasks before supervision took ownership. This change makes chain construction the admission boundary and retains abort-on-drop ownership through startup and supervision.

## What changes

- Constructs and validates the selected chain backend before opening or migrating the wallet database.
- Keeps chain, RPC, and sync task ownership across startup failures and cancellation.
- Propagates the first supervised task failure instead of leaving sibling tasks detached.

## #136 follow-up (final commit)

The task-ownership rework above ensures `abort()` reaches `steady_state`, but the loop's `None if tip_changed` arm returned without an intervening await. Against a `ChainView` whose `snapshot`, `tip`, and `get_mempool_stream` all return `Poll::Ready` from cached state (the in-tree `MockChain`, and the Zaino `FetchServiceSubscriber` as reported in #136), the task could complete a full iteration without polling its abort status and spin indefinitely. The final commit inserts `tokio::task::yield_now().await` in that arm and adds a regression test.