### PR TITLE
fix(sync): propagate mempool stream failures

### DIFF
--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -577,7 +577,9 @@ impl ChainView for ZainoChainView {
         self.stream_blocks_inner(range.start, Some(range.end - 1))
     }
 
-    async fn get_mempool_stream(&self) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+    async fn get_mempool_stream(
+        &self,
+    ) -> Result<Option<BoxStream<'_, Result<Transaction, ChainError>>>, ChainError> {
         let mempool_height = self.tip().await?.height() + 1;
         let consensus_branch_id = consensus::BranchId::for_height(&self.params, mempool_height);
 
@@ -598,6 +600,7 @@ impl ChainView for ZainoChainView {
                                     .ok()
                             })
                     })
+                    .map(Ok)
                     .boxed()
             }))
     }

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -436,7 +436,9 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
         self.stream_blocks_inner(range.start, range.end - 1)
     }
 
-    async fn get_mempool_stream(&self) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+    async fn get_mempool_stream(
+        &self,
+    ) -> Result<Option<BoxStream<'_, Result<Transaction, ChainError>>>, ChainError> {
         // If the tip already moved past the captured view, signal "tip changed" (no stream).
         let current_tip = self.reader.tip().await?;
         if current_tip.map(|t| t.hash()) != Some(self.tip.hash()) {
@@ -452,7 +454,7 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
             tip_hash: BlockHash,
             branch_id: BranchId,
             seen: HashSet<String>,
-            pending: VecDeque<Transaction>,
+            pending: VecDeque<Result<Transaction, ChainError>>,
             interval: tokio::time::Interval,
         }
 
@@ -508,7 +510,7 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
                         }
                     };
                     match Transaction::read(&bytes[..], s.branch_id) {
-                        Ok(tx) => s.pending.push_back(tx),
+                        Ok(tx) => s.pending.push_back(Ok(tx)),
                         Err(e) => warn!("invalid mempool transaction: {e}"),
                     }
                 }

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -61,6 +61,10 @@ should be considered breaking changes.
   precise condition instead of conflating it with general source
   unavailability.
 
+- `ChainView::get_mempool_stream` now yields fallible transaction items.
+  Steady-state sync propagates an item error instead of treating that item as
+  ordinary stream completion. Existing backend error classification is unchanged.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Changed

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -61,8 +61,12 @@ should be considered breaking changes.
   view has been invalidated. Wallet sync reacquires a view only for this
   precise condition instead of conflating it with general source
   unavailability.
+- `ChainView::get_mempool_stream` now yields fallible transaction items.
+  Steady-state sync propagates an item error instead of treating that item as
+  ordinary stream completion. Existing backend error classification is unchanged.
 
 ### Removed
+
 - `config::KeyStoreSection::require_backup`, the accessor that resolved the
   option's default. The default now depends on `consensus.network` (it is off on
   regtest), which a section cannot see, so resolving it moved to a crate-internal

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -635,9 +635,14 @@ pub trait ChainView: Clone + Send + Sync + 'static {
     /// Streams the current mempool. The stream ends when this view's tip changes.
     ///
     /// Returns `None` if the tip has already changed since the view was captured.
+    /// Errors encountered while acquiring the stream are returned by the outer result;
+    /// errors encountered while consuming it are yielded as stream items. A cleanly
+    /// completed stream is the signal that the view's tip changed.
     fn get_mempool_stream(
         &self,
-    ) -> impl Future<Output = Result<Option<BoxStream<'_, Transaction>>, ChainError>> + Send;
+    ) -> impl Future<
+        Output = Result<Option<BoxStream<'_, Result<Transaction, ChainError>>>, ChainError>,
+    > + Send;
 
     /// Returns the transaction with the given txid, if known.
     fn get_transaction(
@@ -926,7 +931,7 @@ mod tests {
 
         async fn get_mempool_stream(
             &self,
-        ) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+        ) -> Result<Option<BoxStream<'_, Result<Transaction, ChainError>>>, ChainError> {
             Ok(None)
         }
 

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -38,7 +38,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use futures::{StreamExt as _, TryStreamExt as _};
+use futures::TryStreamExt as _;
 use jsonrpsee::tracing::{self, debug, info, warn};
 #[cfg(not(feature = "spend-index"))]
 use std::collections::HashSet;
@@ -1048,7 +1048,7 @@ async fn steady_state_iteration<C: Chain>(
         Some(mempool_stream) => {
             info!("Reached chain tip, streaming mempool");
             tokio::pin!(mempool_stream);
-            while let Some(tx) = mempool_stream.next().await {
+            while let Some(tx) = mempool_stream.try_next().await.map_err(SyncError::Chain)? {
                 info!("Scanning mempool tx {}", tx.txid());
                 // TODO: Route individual-transaction scanning through the batch
                 // decryptor (`Handle::queue_tx`) once a single-tx store path exists.
@@ -2097,7 +2097,7 @@ mod fork_fallback_tests {
 
         async fn get_mempool_stream(
             &self,
-        ) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+        ) -> Result<Option<BoxStream<'_, Result<Transaction, ChainError>>>, ChainError> {
             Ok(None)
         }
 

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -38,7 +38,7 @@ use std::sync::{
 };
 use std::time::Duration;
 
-use futures::{StreamExt as _, TryStreamExt as _};
+use futures::TryStreamExt as _;
 use jsonrpsee::tracing::{self, debug, info, warn};
 #[cfg(not(feature = "spend-index"))]
 use std::collections::HashSet;
@@ -1046,7 +1046,7 @@ async fn steady_state_iteration<C: Chain>(
         Some(mempool_stream) => {
             info!("Reached chain tip, streaming mempool");
             tokio::pin!(mempool_stream);
-            while let Some(tx) = mempool_stream.next().await {
+            while let Some(tx) = mempool_stream.try_next().await.map_err(SyncError::Chain)? {
                 info!("Scanning mempool tx {}", tx.txid());
                 // TODO: Route individual-transaction scanning through the batch
                 // decryptor (`Handle::queue_tx`) once a single-tx store path exists.
@@ -2089,7 +2089,7 @@ mod fork_fallback_tests {
 
         async fn get_mempool_stream(
             &self,
-        ) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+        ) -> Result<Option<BoxStream<'_, Result<Transaction, ChainError>>>, ChainError> {
             Ok(None)
         }
 


### PR DESCRIPTION
Closes #709.

A mempool stream could report acquisition failure, but it could not distinguish an item error from clean completion after acquisition. Wallet sync therefore risked interpreting a source or decoding failure as an ordinary chain-tip transition.

## What changes

- Makes acquired mempool streams yield fallible transaction items.
- Propagates the first item error through the sync task.
- Preserves the existing meanings of fixed-view expiry and clean stream completion.
- Updates Zebra and Zaino without broadening their current error classification; #690 tracks surfacing backend errors they still discard before the stream boundary.