### PR TITLE
fix(sync): serialize wallet reconfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,9 @@ be considered breaking changes.
   `zallet` spinning at full CPU after a sibling task failure. A backend whose
   every view operation awaits real I/O is unaffected.
 
+- Hot key imports, account creation, account recovery, and rescans now interrupt
+  mempool following to scan newly scheduled work through the unchanged chain tip.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Added

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -44,6 +44,10 @@ should be considered breaking changes.
 
 ### Changed
 
+- Shielded account and key mutations now exclude concurrent block-scan commits,
+  reload scanning keys before releasing mutation admission, and wake historical
+  recovery without requiring a wallet restart.
+
 - Migrated to `zcash_client_backend`/`zcash_client_sqlite` 0.24.0-rc.7 /
   0.22.0-rc.7 (as of rc.5, output-locking — `lock_outputs`, `unlock_output`,
   `clear_locked_outputs`, `get_locked_outputs` — is extracted off `WalletWrite`

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -46,7 +46,9 @@ should be considered breaking changes.
 
 - Shielded account and key mutations now exclude concurrent block-scan commits,
   reload scanning keys before releasing mutation admission, and wake historical
-  recovery without requiring a wallet restart.
+  recovery without requiring a wallet restart. Reimporting an existing viewing
+  key with `rescan="yes"` now atomically rewinds the wallet-wide scan queue while
+  lowering only that account's birthday when necessary.
 
 - Migrated to `zcash_client_backend`/`zcash_client_sqlite` 0.24.0-rc.7 /
   0.22.0-rc.7 (as of rc.5, output-locking — `lock_outputs`, `unlock_output`,

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -177,6 +177,8 @@ impl StartCmd {
 
         // Build the decryptor up front so the RPC server has its handle before the initial scan.
         let (decryptor_handle, decryptor_engine) = WalletSync::build_decryptor();
+        let reconfiguration =
+            crate::components::sync::WalletSyncReconfiguration::new(decryptor_handle);
 
         // The sync engine publishes its status over this channel; the RPC server reads it
         // to gate balance and spend methods while the wallet is not trustworthy.
@@ -191,7 +193,7 @@ impl StartCmd {
             keystore,
             chain.clone(),
             #[cfg(zallet_build = "wallet")]
-            decryptor_handle.clone(),
+            reconfiguration.clone(),
             sync_status_reader,
         )
         .await?;
@@ -208,7 +210,7 @@ impl StartCmd {
             db,
             chain,
             shutdown_height,
-            decryptor_handle,
+            reconfiguration,
             decryptor_engine,
             sync_status_writer,
         )

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -41,11 +41,17 @@ use crate::{
     network::Network,
 };
 
+/// Four wallet-sync tasks retain connections for their lifetimes, and shielded-key mutations
+/// must be able to reserve one foreground connection before waiting for sync reconfiguration.
+const WALLET_CONNECTION_POOL_SIZE: usize = 5;
+
 pub(super) fn pool(path: impl AsRef<Path>, params: Network) -> Result<WalletPool, Error> {
     let config = deadpool_sqlite::Config::new(path.as_ref());
     let manager = WalletManager::from_config(&config, params);
     WalletPool::builder(manager)
-        .config(deadpool::managed::PoolConfig::default())
+        .config(deadpool::managed::PoolConfig::new(
+            WALLET_CONNECTION_POOL_SIZE,
+        ))
         .build()
         .map_err(|e| ErrorKind::Generic.context(e).into())
 }
@@ -979,5 +985,23 @@ impl WalletCommitmentTrees for DbConnection {
         index: u64,
     ) -> Result<Option<orchard::tree::MerkleHashOrchard>, ShardTreeError<Self::Error>> {
         self.with_mut(|mut db_data| db_data.get_ironwood_subtree_root(index))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{WALLET_CONNECTION_POOL_SIZE, pool};
+    use crate::network::Network;
+
+    #[test]
+    fn pool_reserves_foreground_capacity_beyond_long_lived_sync_connections() {
+        let datadir = tempfile::tempdir().expect("creates temporary database directory");
+        let pool = pool(
+            datadir.path().join("wallet.sqlite"),
+            Network::Consensus(zcash_protocol::consensus::Network::TestNetwork),
+        )
+        .expect("creates wallet connection pool");
+
+        assert_eq!(pool.status().max_size, WALLET_CONNECTION_POOL_SIZE);
     }
 }

--- a/zallet-core/src/components/json_rpc.rs
+++ b/zallet-core/src/components/json_rpc.rs
@@ -19,7 +19,7 @@ use super::{TaskHandle, chain::Chain, database::Database, sync::SyncStatusReader
 #[cfg(zallet_build = "wallet")]
 use super::keystore::KeyStore;
 #[cfg(zallet_build = "wallet")]
-use super::sync::WalletDecryptorHandle;
+use super::sync::WalletSyncReconfiguration;
 
 #[cfg(zallet_build = "wallet")]
 mod asyncop;
@@ -40,7 +40,7 @@ impl JsonRpc {
         db: Database,
         #[cfg(zallet_build = "wallet")] keystore: KeyStore,
         chain: C,
-        #[cfg(zallet_build = "wallet")] decryptor: WalletDecryptorHandle,
+        #[cfg(zallet_build = "wallet")] reconfiguration: WalletSyncReconfiguration,
         sync_status: SyncStatusReader,
     ) -> Result<TaskHandle, Error> {
         let rpc = config.rpc.clone();
@@ -61,7 +61,7 @@ impl JsonRpc {
                 keystore,
                 chain,
                 #[cfg(zallet_build = "wallet")]
-                decryptor,
+                reconfiguration,
                 sync_status,
             )
             .await

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -14,7 +14,7 @@ use crate::components::{
 use {
     super::asyncop::{OperationId, OperationQueue},
     crate::components::{
-        json_rpc::payments::AmountParameter, keystore::KeyStore, sync::WalletDecryptorHandle,
+        json_rpc::payments::AmountParameter, keystore::KeyStore, sync::WalletSyncReconfiguration,
     },
 };
 
@@ -1011,7 +1011,7 @@ impl<C: Chain> RpcImpl<C> {
 pub(crate) struct WalletRpcImpl<C: Chain> {
     general: RpcImpl<C>,
     keystore: KeyStore,
-    decryptor: WalletDecryptorHandle,
+    reconfiguration: WalletSyncReconfiguration,
     async_ops: OperationQueue,
 }
 
@@ -1022,14 +1022,14 @@ impl<C: Chain> WalletRpcImpl<C> {
         wallet: Database,
         keystore: KeyStore,
         chain_view: C,
-        decryptor: WalletDecryptorHandle,
+        reconfiguration: WalletSyncReconfiguration,
         sync_status: SyncStatusReader,
         async_operation_limit: usize,
     ) -> Self {
         Self {
             general: RpcImpl::new(wallet, keystore.clone(), chain_view, sync_status),
             keystore,
-            decryptor,
+            reconfiguration,
             async_ops: OperationQueue::new(async_operation_limit),
         }
     }
@@ -1228,10 +1228,10 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         seedfp: Option<&str>,
     ) -> get_new_account::Response {
         get_new_account::call(
-            self.wallet().await?.as_mut(),
+            self.wallet().await?,
             &self.keystore,
             self.chain().await?,
-            &self.decryptor,
+            &self.reconfiguration,
             account_name,
             seedfp,
         )
@@ -1243,10 +1243,10 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         accounts: Vec<recover_accounts::AccountParameter<'_>>,
     ) -> recover_accounts::Response {
         recover_accounts::call(
-            self.wallet().await?.as_mut(),
+            self.wallet().await?,
             &self.keystore,
             self.chain().await?,
-            &self.decryptor,
+            &self.reconfiguration,
             accounts,
         )
         .await
@@ -1295,8 +1295,9 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         start_height: Option<u64>,
     ) -> import_viewing_key::Response {
         import_viewing_key::call(
-            self.wallet().await?.as_mut(),
+            self.wallet().await?,
             self.chain().await?,
+            &self.reconfiguration,
             vkey,
             rescan,
             start_height,
@@ -1352,10 +1353,10 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
         start_height: Option<u64>,
     ) -> import_key::Response {
         import_key::call(
-            self.wallet().await?.as_mut(),
+            self.wallet().await?,
             &self.keystore,
             self.chain().await?,
-            &self.decryptor,
+            &self.reconfiguration,
             key,
             rescan,
             start_height,

--- a/zallet-core/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_new_account.rs
@@ -107,7 +107,7 @@ pub(crate) async fn call<C: Chain>(
     drop(wallet);
 
     // Reload viewing keys so the new account is scanned without a restart (see z_importkey).
-    if !admitted.reload_keys_and_wake_history_recovery().await {
+    if !admitted.reload_keys_and_wake_wallet_recovery().await {
         tracing::warn!("sync engine has shut down; new account won't be scanned until restart");
     }
 

--- a/zallet-core/src/components/json_rpc/methods/get_new_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_new_account.rs
@@ -6,13 +6,13 @@ use zcash_client_backend::data_api::{AccountBirthday, WalletRead, WalletWrite};
 
 use crate::components::{
     chain::{Chain, ChainView},
-    database::DbConnection,
+    database::DbHandle,
     json_rpc::{
         server::LegacyCode,
         utils::{ensure_wallet_is_unlocked, parse_seedfp_parameter},
     },
     keystore::KeyStore,
-    sync::WalletDecryptorHandle,
+    sync::WalletSyncReconfiguration,
 };
 
 /// Response to a `z_getnewaccount` RPC request.
@@ -35,10 +35,10 @@ pub(super) const PARAM_SEEDFP_DESC: &str =
     "ZIP 32 seed fingerprint for the BIP 39 mnemonic phrase from which to derive the account.";
 
 pub(crate) async fn call<C: Chain>(
-    wallet: &mut DbConnection,
+    mut wallet: DbHandle,
     keystore: &KeyStore,
     chain: C,
-    decryptor: &WalletDecryptorHandle,
+    reconfiguration: &WalletSyncReconfiguration,
     account_name: &str,
     seedfp: Option<&str>,
 ) -> Response {
@@ -100,12 +100,14 @@ pub(crate) async fn call<C: Chain>(
         .await
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
+    let admitted = reconfiguration.admit_reconfiguration().await;
     let (account_id, _usk) = wallet
         .create_account(account_name, &seed, &birthday, None)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+    drop(wallet);
 
     // Reload viewing keys so the new account is scanned without a restart (see z_importkey).
-    if decryptor.reload_keys().await.is_none() {
+    if !admitted.reload_keys_and_wake_history_recovery().await {
         tracing::warn!("sync engine has shut down; new account won't be scanned until restart");
     }
 

--- a/zallet-core/src/components/json_rpc/methods/import_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_key.rs
@@ -208,7 +208,7 @@ pub(crate) async fn call<C: Chain>(
     // a re-import must be able to repair an account the sync engine never loaded. The admitted
     // reconfiguration orders the reload after earlier block scans and keeps later scans out until
     // the decryptor acknowledges it.
-    if !admitted.reload_keys_and_wake_history_recovery().await {
+    if !admitted.reload_keys_and_wake_wallet_recovery().await {
         tracing::warn!("sync engine has shut down; imported key won't be scanned until restart");
     }
 

--- a/zallet-core/src/components/json_rpc/methods/import_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_key.rs
@@ -9,10 +9,10 @@ use zcash_protocol::consensus::{BlockHeight, NetworkConstants};
 
 use crate::components::{
     chain::Chain,
-    database::DbConnection,
+    database::DbHandle,
     json_rpc::{server::LegacyCode, utils::fetch_account_birthday},
     keystore::KeyStore,
-    sync::WalletDecryptorHandle,
+    sync::WalletSyncReconfiguration,
 };
 
 /// Response to a `z_importkey` RPC request.
@@ -83,10 +83,10 @@ impl From<rusqlite::Error> for ImportError {
 }
 
 pub(crate) async fn call<C: Chain>(
-    wallet: &mut DbConnection,
+    wallet: DbHandle,
     keystore: &KeyStore,
     chain: C,
-    decryptor: &WalletDecryptorHandle,
+    reconfiguration: &WalletSyncReconfiguration,
     key: &str,
     rescan: Option<&str>,
     start_height: Option<u64>,
@@ -170,6 +170,7 @@ pub(crate) async fn call<C: Chain>(
     // wallet-database transaction: the account and its key commit together or not at all, so
     // the wallet can never track an account whose key is missing, nor hold a key for an
     // account it doesn't scan.
+    let admitted = reconfiguration.admit_reconfiguration().await;
     wallet
         .with_mut(|mut db_data| {
             db_data.transactionally_with_extension(|wdb, ext| -> Result<(), ImportError> {
@@ -201,12 +202,13 @@ pub(crate) async fn call<C: Chain>(
             ImportError::Database(e) => LegacyCode::Database.with_message(e.to_string()),
             ImportError::Keystore(e) => LegacyCode::Wallet.with_message(e.to_string()),
         })?;
+    drop(wallet);
 
     // Reload viewing keys so the key is scanned without a restart. Run this unconditionally:
-    // a re-import must be able to repair an account the sync engine never loaded. Don't wait
-    // for the reload to be processed; the marker is queued behind any blocks already in the
-    // decryptor, so awaiting it could block this call for a long time during sync.
-    if decryptor.reload_keys().await.is_none() {
+    // a re-import must be able to repair an account the sync engine never loaded. The admitted
+    // reconfiguration orders the reload after earlier block scans and keeps later scans out until
+    // the decryptor acknowledges it.
+    if !admitted.reload_keys_and_wake_history_recovery().await {
         tracing::warn!("sync engine has shut down; imported key won't be scanned until restart");
     }
 

--- a/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
@@ -11,8 +11,9 @@ use zcash_protocol::consensus::{BlockHeight, NetworkConstants};
 
 use crate::components::{
     chain::Chain,
-    database::DbConnection,
+    database::DbHandle,
     json_rpc::{server::LegacyCode, utils::fetch_account_birthday},
+    sync::WalletSyncReconfiguration,
 };
 
 /// Response to a `z_importviewingkey` RPC request.
@@ -78,8 +79,9 @@ fn decode_vkey_and_address(
 }
 
 pub(crate) async fn call<C: Chain>(
-    wallet: &mut DbConnection,
+    mut wallet: DbHandle,
     chain: C,
+    reconfiguration: &WalletSyncReconfiguration,
     vkey: &str,
     rescan: Option<&str>,
     start_height: Option<u64>,
@@ -119,7 +121,7 @@ pub(crate) async fn call<C: Chain>(
     let existing_account = wallet
         .get_account_for_ufvk(&ufvk)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
-    match existing_account {
+    let birthday = match existing_account {
         Some(account) => {
             if matches!(account.purpose(), AccountPurpose::Spending { .. }) {
                 return Err(LegacyCode::Wallet.with_message(format!(
@@ -131,6 +133,10 @@ pub(crate) async fn call<C: Chain>(
             // TODO: When rescan is "yes" and the key already exists, zcashd would force a
             // rescan from start_height. We could use `WalletWrite::rewind_to_chain_state`
             // for this (see `z_import_address` for an example).
+            return Ok(ResultType {
+                address_type: "sapling".to_string(),
+                address,
+            });
         }
         None => {
             // new key
@@ -143,8 +149,24 @@ pub(crate) async fn call<C: Chain>(
                 }
             };
 
-            let birthday = fetch_account_birthday(&chain, effective_height).await?;
+            fetch_account_birthday(&chain, effective_height).await?
+        }
+    };
 
+    let admitted = reconfiguration.admit_reconfiguration().await;
+    let existing_account = wallet
+        .get_account_for_ufvk(&ufvk)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+    let mutated = match existing_account {
+        Some(account) => {
+            if matches!(account.purpose(), AccountPurpose::Spending { .. }) {
+                return Err(LegacyCode::Wallet.with_message(format!(
+                    "The wallet already contains the private key for this viewing key (address: {address})",
+                )));
+            }
+            false
+        }
+        None => {
             wallet
                 .import_account_ufvk(
                     &format!("Imported Sapling viewing key {address}"),
@@ -154,7 +176,15 @@ pub(crate) async fn call<C: Chain>(
                     None,
                 )
                 .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+            true
         }
+    };
+    drop(wallet);
+
+    if mutated && !admitted.reload_keys_and_wake_history_recovery().await {
+        tracing::warn!(
+            "sync engine has shut down; imported viewing key won't be scanned until restart"
+        );
     }
 
     Ok(ResultType {

--- a/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
@@ -203,9 +203,9 @@ pub(crate) async fn call<C: Chain>(
     drop(wallet);
 
     match effect {
-        ViewingKeyImportEffect::RescanScheduled => admitted.wake_history_recovery(),
+        ViewingKeyImportEffect::RescanScheduled => admitted.wake_wallet_recovery(),
         ViewingKeyImportEffect::KeyImported => {
-            if !admitted.reload_keys_and_wake_history_recovery().await {
+            if !admitted.reload_keys_and_wake_wallet_recovery().await {
                 tracing::warn!(
                     "sync engine has shut down; imported viewing key won't be scanned until restart"
                 );
@@ -222,18 +222,37 @@ pub(crate) async fn call<C: Chain>(
 
 #[cfg(test)]
 mod tests {
+    use std::{ops::Range, sync::Arc, time::Duration};
+
     use super::*;
     use crate::{
         components::{
-            chain::MockChain,
+            chain::{
+                BlockLocator, Chain, ChainBlock, ChainError, ChainTx, ChainView, MockChain,
+                ReportedUpgrade,
+            },
             database::Database,
-            sync::{WalletSync, WalletSyncReconfiguration},
+            sync::{WalletSync, WalletSyncReconfiguration, status},
         },
         config::ZalletConfig,
+        error::Error,
+        network::Network,
+    };
+    use futures::{
+        StreamExt as _,
+        stream::{self, BoxStream},
+    };
+    #[cfg(not(feature = "spend-index"))]
+    use transparent::address::TransparentAddress;
+    #[cfg(feature = "spend-index")]
+    use transparent::bundle::OutPoint;
+    use transparent::{
+        builder::Coinbase,
+        bundle::{Bundle, TxIn},
     };
     use zcash_client_backend::data_api::{
-        AccountBirthday, ScannedBlock, WalletRead, WalletWrite,
-        chain::ChainState,
+        AccountBirthday, ScannedBlock, TransactionStatus, WalletRead, WalletWrite,
+        chain::{ChainState, CommitmentTreeRoot},
         scanning::{ScanPriority, ScanRange},
     };
     use zcash_client_backend::{
@@ -241,9 +260,333 @@ mod tests {
         scanning::{Nullifiers, ScanningKeys, scan_block},
     };
     use zcash_client_sqlite::AccountUuid;
+    use zcash_encoding::CompactSize;
     use zcash_keys::encoding::encode_extended_full_viewing_key;
-    use zcash_primitives::block::BlockHash;
-    use zcash_protocol::constants;
+    use zcash_primitives::{
+        block::{Block, BlockHash, BlockHeader, BlockHeaderData},
+        transaction::{Authorized, Transaction, TransactionData, TxVersion},
+    };
+    use zcash_protocol::{
+        TxId,
+        consensus::{BranchId, Network as ConsensusNetwork},
+        constants,
+    };
+
+    const FIXED_TIP: u32 = 3;
+
+    #[derive(Clone)]
+    struct FixedTipChain {
+        network: Network,
+        mempool_follow_started: Arc<tokio::sync::Notify>,
+    }
+
+    impl FixedTipChain {
+        fn new(network: Network) -> Self {
+            Self {
+                network,
+                mempool_follow_started: Arc::new(tokio::sync::Notify::new()),
+            }
+        }
+    }
+
+    #[derive(Clone)]
+    struct FixedTipView {
+        mempool_follow_started: Arc<tokio::sync::Notify>,
+    }
+
+    impl Chain for FixedTipChain {
+        type View = FixedTipView;
+
+        fn params(&self) -> &Network {
+            &self.network
+        }
+
+        async fn reported_upgrades(&self) -> Result<Vec<ReportedUpgrade>, Error> {
+            Ok(Vec::new())
+        }
+
+        async fn broadcast_transaction(&self, _tx: &Transaction) -> Result<(), ChainError> {
+            Err(ChainError::backend(
+                "fixed-tip test chain does not broadcast transactions",
+            ))
+        }
+
+        async fn get_sapling_subtree_roots(
+            &self,
+        ) -> Result<Vec<CommitmentTreeRoot<sapling::Node>>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        async fn get_orchard_subtree_roots(
+            &self,
+        ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        async fn get_ironwood_subtree_roots(
+            &self,
+        ) -> Result<Vec<CommitmentTreeRoot<orchard::tree::MerkleHashOrchard>>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        async fn snapshot(&self) -> Result<Self::View, ChainError> {
+            Ok(FixedTipView {
+                mempool_follow_started: self.mempool_follow_started.clone(),
+            })
+        }
+    }
+
+    impl ChainView for FixedTipView {
+        async fn tip(&self) -> Result<ChainBlock, ChainError> {
+            Ok(chain_block(height(FIXED_TIP)))
+        }
+
+        async fn find_fork_point(
+            &self,
+            locator: &BlockLocator,
+        ) -> Result<Option<ChainBlock>, ChainError> {
+            Ok((0..=FIXED_TIP).rev().find_map(|value| {
+                let block = chain_block(height(value));
+                locator.hashes().contains(&block.hash()).then_some(block)
+            }))
+        }
+
+        async fn tree_state_as_of(
+            &self,
+            height: BlockHeight,
+        ) -> Result<Option<ChainState>, ChainError> {
+            Ok((height <= BlockHeight::from_u32(FIXED_TIP))
+                .then(|| ChainState::empty(height, fixed_header(height).hash())))
+        }
+
+        async fn get_block_header(
+            &self,
+            height: BlockHeight,
+        ) -> Result<Option<BlockHeader>, ChainError> {
+            Ok((height <= BlockHeight::from_u32(FIXED_TIP)).then(|| fixed_header(height)))
+        }
+
+        async fn get_block(&self, height: BlockHeight) -> Result<Option<Block>, ChainError> {
+            Ok((height <= BlockHeight::from_u32(FIXED_TIP)).then(|| fixed_block(height)))
+        }
+
+        fn stream_blocks_to_tip(
+            &self,
+            start: BlockHeight,
+        ) -> BoxStream<'_, Result<Block, ChainError>> {
+            stream::iter(
+                (u32::from(start)..=FIXED_TIP)
+                    .map(|value| Ok(fixed_block(height(value))))
+                    .collect::<Vec<_>>(),
+            )
+            .boxed()
+        }
+
+        fn stream_blocks(
+            &self,
+            range: &Range<BlockHeight>,
+        ) -> BoxStream<'_, Result<Block, ChainError>> {
+            stream::iter(
+                (u32::from(range.start)..u32::from(range.end))
+                    .map(|value| Ok(fixed_block(height(value))))
+                    .collect::<Vec<_>>(),
+            )
+            .boxed()
+        }
+
+        async fn get_mempool_stream(
+            &self,
+        ) -> Result<Option<BoxStream<'_, Transaction>>, ChainError> {
+            self.mempool_follow_started.notify_one();
+            Ok(Some(stream::pending().boxed()))
+        }
+
+        async fn get_transaction(&self, _txid: TxId) -> Result<Option<ChainTx>, ChainError> {
+            Ok(None)
+        }
+
+        async fn get_transaction_status(
+            &self,
+            _txid: TxId,
+        ) -> Result<TransactionStatus, ChainError> {
+            Ok(TransactionStatus::TxidNotRecognized)
+        }
+
+        #[cfg(feature = "spend-index")]
+        async fn outpoint_spend_status(
+            &self,
+            _outpoint: &OutPoint,
+        ) -> Result<crate::components::chain::SpendStatus, ChainError> {
+            Ok(crate::components::chain::SpendStatus::Unspent)
+        }
+
+        #[cfg(not(feature = "spend-index"))]
+        async fn get_address_unspent_outpoints(
+            &self,
+            _address: &TransparentAddress,
+        ) -> Result<Vec<(TxId, u32)>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        #[cfg(not(feature = "spend-index"))]
+        async fn get_address_tx_ids(
+            &self,
+            _address: &TransparentAddress,
+            _range: Range<BlockHeight>,
+        ) -> Result<Vec<TxId>, ChainError> {
+            Ok(Vec::new())
+        }
+
+        #[cfg(all(zallet_build = "wallet", feature = "zcashd-import"))]
+        async fn block_height(&self, _hash: &BlockHash) -> Result<Option<BlockHeight>, ChainError> {
+            Ok(None)
+        }
+    }
+
+    fn chain_block(height: BlockHeight) -> ChainBlock {
+        ChainBlock::new(height, fixed_header(height).hash())
+    }
+
+    fn fixed_header(height: BlockHeight) -> BlockHeader {
+        let value = u32::from(height);
+        BlockHeaderData {
+            version: 4,
+            prev_block: if value == 0 {
+                BlockHash([0; 32])
+            } else {
+                fixed_header(BlockHeight::from_u32(value - 1)).hash()
+            },
+            merkle_root: [0; 32],
+            final_sapling_root: [0; 32],
+            time: 0,
+            bits: 0,
+            nonce: [u8::try_from(value).expect("test height fits in one byte"); 32],
+            solution: vec![],
+        }
+        .freeze()
+        .expect("test block header is structurally valid")
+    }
+
+    fn fixed_block(height: BlockHeight) -> Block {
+        let header = fixed_header(height);
+        let coinbase_authorization = Coinbase;
+        let transparent_bundle = Bundle {
+            vin: vec![
+                TxIn::<Coinbase>::coinbase(height, None)
+                    .expect("test coinbase height is structurally valid"),
+            ],
+            vout: Vec::new(),
+            authorization: coinbase_authorization.clone(),
+        }
+        .map_authorization(coinbase_authorization);
+        let transaction = TransactionData::<Authorized>::from_parts(
+            TxVersion::suggested_for_branch(BranchId::Sprout),
+            BranchId::Sprout,
+            0,
+            height,
+            Some(transparent_bundle),
+            None,
+            None,
+            None,
+        )
+        .freeze()
+        .expect("test transaction is structurally valid");
+
+        let mut bytes = Vec::new();
+        header
+            .write(&mut bytes)
+            .expect("serializes test block header");
+        CompactSize::write(&mut bytes, 1).expect("serializes test transaction count");
+        transaction
+            .write(&mut bytes)
+            .expect("serializes test coinbase transaction");
+
+        Block::read(bytes.as_slice(), &ConsensusNetwork::MainNetwork)
+            .expect("test block is structurally valid")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn hot_viewing_key_import_scans_to_an_unchanged_near_tip() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let chain = FixedTipChain::new(config.consensus.network());
+        let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+        let (sync_status, _sync_status_reader) = status::channel(config.sync.lock_threshold());
+        let (steady_state, recover_history, batch_decryptor, data_requests) = WalletSync::spawn(
+            &config,
+            database.clone(),
+            chain.clone(),
+            None,
+            reconfiguration.clone(),
+            decryptor_engine,
+            sync_status,
+        )
+        .await
+        .expect("starts wallet sync against the fixed-tip chain");
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            chain.mempool_follow_started.notified(),
+        )
+        .await
+        .expect("steady-state sync reaches stable mempool follow");
+
+        call(
+            database
+                .handle()
+                .await
+                .expect("opens wallet for hot viewing-key import"),
+            chain,
+            &reconfiguration,
+            &encoded_mainnet_extfvk(),
+            Some("yes"),
+            Some(0),
+        )
+        .await
+        .expect("imports viewing key while wallet sync is running");
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                let wallet = database
+                    .handle()
+                    .await
+                    .expect("opens wallet while waiting for near-tip recovery");
+                let pending_ranges = wallet
+                    .suggest_scan_ranges()
+                    .expect("reads suggested scan ranges");
+                if pending_ranges.is_empty() {
+                    assert_eq!(
+                        wallet.chain_height().expect("reads wallet chain height"),
+                        Some(height(FIXED_TIP)),
+                    );
+                    break;
+                }
+                drop(wallet);
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("hot viewing-key import is scanned through the unchanged tip");
+
+        for task in [
+            steady_state,
+            recover_history,
+            batch_decryptor,
+            data_requests,
+        ] {
+            task.abort();
+            let error = task.await.expect_err("aborted wallet-sync test task stops");
+            assert!(error.is_cancelled());
+        }
+    }
 
     /// Derives a test extended full viewing key from seed [0; 32] and encodes it.
     fn encoded_mainnet_extfvk() -> String {

--- a/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
+++ b/zallet-core/src/components/json_rpc/methods/import_viewing_key.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
@@ -86,6 +88,12 @@ pub(crate) async fn call<C: Chain>(
     rescan: Option<&str>,
     start_height: Option<u64>,
 ) -> Response {
+    enum ViewingKeyImportEffect {
+        KeyImported,
+        RescanScheduled,
+        Unchanged,
+    }
+
     let rescan = RescanPolicy::parse(rescan)?;
 
     // Parse start_height if provided, keeping it as Option so we can
@@ -128,15 +136,18 @@ pub(crate) async fn call<C: Chain>(
                     "The wallet already contains the private key for this viewing key (address: {address})",
                 )));
             }
-            // ViewOnly — key already exists, return result.
-            //
-            // TODO: When rescan is "yes" and the key already exists, zcashd would force a
-            // rescan from start_height. We could use `WalletWrite::rewind_to_chain_state`
-            // for this (see `z_import_address` for an example).
-            return Ok(ResultType {
-                address_type: "sapling".to_string(),
-                address,
-            });
+            match rescan {
+                RescanPolicy::Yes => {
+                    fetch_account_birthday(&chain, start_height.unwrap_or(BlockHeight::from_u32(0)))
+                        .await?
+                }
+                RescanPolicy::No | RescanPolicy::WhenKeyIsNew => {
+                    return Ok(ResultType {
+                        address_type: "sapling".to_string(),
+                        address,
+                    });
+                }
+            }
         }
         None => {
             // new key
@@ -157,14 +168,24 @@ pub(crate) async fn call<C: Chain>(
     let existing_account = wallet
         .get_account_for_ufvk(&ufvk)
         .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
-    let mutated = match existing_account {
+    let effect = match existing_account {
         Some(account) => {
             if matches!(account.purpose(), AccountPurpose::Spending { .. }) {
                 return Err(LegacyCode::Wallet.with_message(format!(
                     "The wallet already contains the private key for this viewing key (address: {address})",
                 )));
             }
-            false
+            if rescan == RescanPolicy::Yes {
+                wallet
+                    .rewind_to_chain_state(
+                        birthday.prior_chain_state().clone(),
+                        HashSet::from([account.id()]),
+                    )
+                    .map_err(|e| LegacyCode::Misc.with_message(format!("Rescan failed: {e}")))?;
+                ViewingKeyImportEffect::RescanScheduled
+            } else {
+                ViewingKeyImportEffect::Unchanged
+            }
         }
         None => {
             wallet
@@ -176,15 +197,21 @@ pub(crate) async fn call<C: Chain>(
                     None,
                 )
                 .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
-            true
+            ViewingKeyImportEffect::KeyImported
         }
     };
     drop(wallet);
 
-    if mutated && !admitted.reload_keys_and_wake_history_recovery().await {
-        tracing::warn!(
-            "sync engine has shut down; imported viewing key won't be scanned until restart"
-        );
+    match effect {
+        ViewingKeyImportEffect::RescanScheduled => admitted.wake_history_recovery(),
+        ViewingKeyImportEffect::KeyImported => {
+            if !admitted.reload_keys_and_wake_history_recovery().await {
+                tracing::warn!(
+                    "sync engine has shut down; imported viewing key won't be scanned until restart"
+                );
+            }
+        }
+        ViewingKeyImportEffect::Unchanged => {}
     }
 
     Ok(ResultType {
@@ -196,12 +223,35 @@ pub(crate) async fn call<C: Chain>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{
+        components::{
+            chain::MockChain,
+            database::Database,
+            sync::{WalletSync, WalletSyncReconfiguration},
+        },
+        config::ZalletConfig,
+    };
+    use zcash_client_backend::data_api::{
+        AccountBirthday, ScannedBlock, WalletRead, WalletWrite,
+        chain::ChainState,
+        scanning::{ScanPriority, ScanRange},
+    };
+    use zcash_client_backend::{
+        proto::compact_formats::{ChainMetadata, CompactBlock},
+        scanning::{Nullifiers, ScanningKeys, scan_block},
+    };
+    use zcash_client_sqlite::AccountUuid;
     use zcash_keys::encoding::encode_extended_full_viewing_key;
+    use zcash_primitives::block::BlockHash;
     use zcash_protocol::constants;
 
     /// Derives a test extended full viewing key from seed [0; 32] and encodes it.
     fn encoded_mainnet_extfvk() -> String {
-        let extsk = sapling::zip32::ExtendedSpendingKey::master(&[0; 32]);
+        encoded_mainnet_extfvk_for_seed([0; 32])
+    }
+
+    fn encoded_mainnet_extfvk_for_seed(seed: [u8; 32]) -> String {
+        let extsk = sapling::zip32::ExtendedSpendingKey::master(&seed);
         #[allow(deprecated)]
         let extfvk = extsk.to_extended_full_viewing_key();
         encode_extended_full_viewing_key(
@@ -219,6 +269,430 @@ mod tests {
             constants::testnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
             &extfvk,
         )
+    }
+
+    fn height(value: u32) -> BlockHeight {
+        BlockHeight::from_u32(value)
+    }
+
+    fn empty_birthday(value: u32) -> AccountBirthday {
+        AccountBirthday::from_parts(
+            ChainState::empty(height(value - 1), BlockHash([0; 32])),
+            None,
+        )
+    }
+
+    fn seed_retained_scanned_blocks(wallet: &mut DbHandle) -> Vec<BlockHeight> {
+        let scanning_keys = ScanningKeys::<AccountUuid, ()>::empty();
+        let nullifiers = Nullifiers::<AccountUuid>::empty();
+        let mut retained_blocks: Vec<ScannedBlock<AccountUuid>> = Vec::new();
+        for value in 500_048_u32..=500_100 {
+            let hash_byte =
+                u8::try_from(value - 500_047).expect("retained block offset fits in hash byte");
+            let predecessor_hash_byte = u8::try_from(value - 500_048)
+                .expect("retained predecessor offset fits in hash byte");
+            let scanned = scan_block(
+                wallet.params(),
+                CompactBlock {
+                    height: u64::from(value),
+                    hash: vec![hash_byte; 32],
+                    prev_hash: vec![predecessor_hash_byte; 32],
+                    chain_metadata: Some(ChainMetadata {
+                        sapling_commitment_tree_size: 0,
+                        orchard_commitment_tree_size: 0,
+                        ironwood_commitment_tree_size: 0,
+                    }),
+                    ..Default::default()
+                },
+                &scanning_keys,
+                &nullifiers,
+                retained_blocks
+                    .last()
+                    .map(|block| block.to_block_metadata())
+                    .as_ref(),
+            )
+            .expect("scans an empty retained block");
+            retained_blocks.push(scanned);
+        }
+        wallet
+            .put_blocks(
+                &ChainState::empty(height(500_047), BlockHash([0; 32])),
+                retained_blocks,
+            )
+            .expect("seeds retained scanned blocks");
+        (500_048..=500_100).map(height).collect()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_viewing_key_rescan_rewinds_wallet_wide_scan_queue() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let mut wallet = database.handle().await.expect("reserves wallet database");
+        let encoded = encoded_mainnet_extfvk();
+        let (extfvk, _) = decode_vkey_and_address(
+            constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+            &encoded,
+        )
+        .expect("decodes viewing key");
+        let ufvk = UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(extfvk)
+            .expect("constructs unified viewing key");
+        wallet
+            .import_account_ufvk(
+                "existing viewing-only account",
+                &ufvk,
+                &empty_birthday(500_050),
+                AccountPurpose::ViewOnly,
+                None,
+            )
+            .expect("imports viewing-only account");
+        wallet
+            .update_chain_tip(height(500_100))
+            .expect("records chain tip");
+        let (decryptor, engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+
+        call(
+            wallet,
+            MockChain::reporting(Vec::new(), 500_100),
+            &reconfiguration,
+            &encoded,
+            Some("yes"),
+            Some(0),
+        )
+        .await
+        .expect("existing viewing key rescan succeeds");
+
+        let wallet = database.handle().await.expect("reopens wallet database");
+        let account = wallet
+            .get_account_for_ufvk(&ufvk)
+            .expect("reads viewing-only account")
+            .expect("viewing-only account remains present");
+        assert_eq!(
+            wallet
+                .get_account_birthday(account.id())
+                .expect("reads rescan birthday"),
+            height(1)
+        );
+        assert_eq!(
+            wallet.suggest_scan_ranges().expect("reads scan queue"),
+            vec![ScanRange::from_parts(
+                height(1)..height(500_101),
+                ScanPriority::Historic,
+            )],
+        );
+        drop(engine);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_viewing_key_rescan_preserves_unrelated_account_birthdays() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let mut wallet = database.handle().await.expect("reserves wallet database");
+        let selected_encoded = encoded_mainnet_extfvk();
+        let unrelated_encoded = encoded_mainnet_extfvk_for_seed([1; 32]);
+        let mut account_ids = Vec::new();
+        for (name, encoded, birthday) in [
+            ("selected viewing-only account", &selected_encoded, 500_050),
+            (
+                "unrelated viewing-only account",
+                &unrelated_encoded,
+                500_070,
+            ),
+        ] {
+            let (extfvk, _) = decode_vkey_and_address(
+                constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+                constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+                encoded,
+            )
+            .expect("decodes viewing key");
+            let ufvk = UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(extfvk)
+                .expect("constructs unified viewing key");
+            account_ids.push(
+                wallet
+                    .import_account_ufvk(
+                        name,
+                        &ufvk,
+                        &empty_birthday(birthday),
+                        AccountPurpose::ViewOnly,
+                        None,
+                    )
+                    .expect("imports viewing-only account")
+                    .id(),
+            );
+        }
+        wallet
+            .update_chain_tip(height(500_100))
+            .expect("records chain tip");
+        let (decryptor, engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+
+        call(
+            wallet,
+            MockChain::reporting(Vec::new(), 500_100),
+            &reconfiguration,
+            &selected_encoded,
+            Some("yes"),
+            Some(0),
+        )
+        .await
+        .expect("existing viewing key rescan succeeds");
+
+        let wallet = database.handle().await.expect("reopens wallet database");
+        assert_eq!(
+            wallet
+                .get_account_birthday(account_ids[0])
+                .expect("reads selected birthday"),
+            height(1)
+        );
+        assert_eq!(
+            wallet
+                .get_account_birthday(account_ids[1])
+                .expect("reads unrelated birthday"),
+            height(500_070)
+        );
+        drop(engine);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_viewing_key_predecessor_failure_leaves_wallet_unchanged() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let mut wallet = database.handle().await.expect("reserves wallet database");
+        let encoded = encoded_mainnet_extfvk();
+        let (extfvk, _) = decode_vkey_and_address(
+            constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+            constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+            &encoded,
+        )
+        .expect("decodes viewing key");
+        let ufvk = UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(extfvk)
+            .expect("constructs unified viewing key");
+        let account_id = wallet
+            .import_account_ufvk(
+                "existing viewing-only account",
+                &ufvk,
+                &empty_birthday(500_050),
+                AccountPurpose::ViewOnly,
+                None,
+            )
+            .expect("imports viewing-only account")
+            .id();
+        wallet
+            .update_chain_tip(height(500_100))
+            .expect("records chain tip");
+        let retained_heights = seed_retained_scanned_blocks(&mut wallet);
+        let birthday_before = wallet
+            .get_account_birthday(account_id)
+            .expect("reads birthday before failed predecessor fetch");
+        let ranges_before = wallet
+            .suggest_scan_ranges()
+            .expect("reads scan ranges before failed predecessor fetch");
+        let hashes_before = retained_heights
+            .iter()
+            .map(|height| {
+                wallet
+                    .get_block_hash(*height)
+                    .expect("snapshots retained block hash")
+            })
+            .collect::<Vec<_>>();
+        let (decryptor, engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+
+        let error = call(
+            wallet,
+            MockChain::reporting(Vec::new(), 500_100),
+            &reconfiguration,
+            &encoded,
+            Some("yes"),
+            Some(10),
+        )
+        .await
+        .expect_err("missing predecessor state rejects the rescan");
+        assert_eq!(
+            error.code(),
+            jsonrpsee::types::ErrorCode::InternalError.code()
+        );
+        assert_eq!(error.message(), "No treestate available at height 9");
+
+        let wallet = database.handle().await.expect("reopens wallet database");
+        assert_eq!(
+            wallet
+                .get_account_birthday(account_id)
+                .expect("reads unchanged birthday"),
+            birthday_before
+        );
+        assert_eq!(
+            wallet
+                .suggest_scan_ranges()
+                .expect("reads unchanged scan ranges"),
+            ranges_before
+        );
+        assert_eq!(
+            retained_heights
+                .iter()
+                .map(|height| {
+                    wallet
+                        .get_block_hash(*height)
+                        .expect("reads unchanged retained block hash")
+                })
+                .collect::<Vec<_>>(),
+            hashes_before
+        );
+        drop(engine);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn existing_viewing_key_rescan_failure_rolls_back_birthdays_scan_ranges_and_blocks() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let mut wallet = database.handle().await.expect("reserves wallet database");
+        let encoded = encoded_mainnet_extfvk();
+        let unrelated_encoded = encoded_mainnet_extfvk_for_seed([1; 32]);
+        let mut account_ids = Vec::new();
+        for (name, encoded, birthday) in [
+            ("selected viewing-only account", &encoded, 500_050),
+            (
+                "unrelated viewing-only account",
+                &unrelated_encoded,
+                500_070,
+            ),
+        ] {
+            let (extfvk, _) = decode_vkey_and_address(
+                constants::mainnet::HRP_SAPLING_EXTENDED_FULL_VIEWING_KEY,
+                constants::mainnet::HRP_SAPLING_PAYMENT_ADDRESS,
+                encoded,
+            )
+            .expect("decodes viewing key");
+            let ufvk = UnifiedFullViewingKey::from_sapling_extended_full_viewing_key(extfvk)
+                .expect("constructs unified viewing key");
+            account_ids.push(
+                wallet
+                    .import_account_ufvk(
+                        name,
+                        &ufvk,
+                        &empty_birthday(birthday),
+                        AccountPurpose::ViewOnly,
+                        None,
+                    )
+                    .expect("imports viewing-only account")
+                    .id(),
+            );
+        }
+        let retained_heights = seed_retained_scanned_blocks(&mut wallet);
+        wallet
+            .update_chain_tip(height(500_100))
+            .expect("records chain tip");
+        let birthdays_before = account_ids
+            .iter()
+            .map(|account_id| {
+                wallet
+                    .get_account_birthday(*account_id)
+                    .expect("snapshots account birthday")
+            })
+            .collect::<Vec<_>>();
+        let ranges_before = wallet
+            .suggest_scan_ranges()
+            .expect("snapshots suggested scan ranges");
+        let hashes_before = retained_heights
+            .iter()
+            .map(|height| {
+                wallet
+                    .get_block_hash(*height)
+                    .expect("snapshots retained block hash")
+            })
+            .collect::<Vec<_>>();
+        wallet
+            .with_raw(|connection, _| {
+                connection.execute_batch(
+                    "CREATE TRIGGER fail_viewing_key_birthday_rewind
+                     AFTER UPDATE OF birthday_height ON accounts
+                     BEGIN
+                         SELECT RAISE(ABORT, 'injected birthday update failure');
+                     END;",
+                )
+            })
+            .expect("installs persistent birthday failure trigger");
+        let (decryptor, engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+
+        let error = call(
+            wallet,
+            MockChain::reporting(Vec::new(), 500_100),
+            &reconfiguration,
+            &encoded,
+            Some("yes"),
+            Some(0),
+        )
+        .await
+        .expect_err("injected rewind failure reaches the RPC");
+        assert_eq!(error.code(), LegacyCode::Misc as i32);
+        assert!(error.message().contains("Rescan failed"));
+        assert!(error.message().contains("injected birthday update failure"));
+
+        let wallet = database.handle().await.expect("reopens wallet database");
+        wallet
+            .with_raw(|connection, _| {
+                connection.execute_batch("DROP TRIGGER fail_viewing_key_birthday_rewind;")
+            })
+            .expect("removes persistent birthday failure trigger");
+        assert_eq!(
+            account_ids
+                .iter()
+                .map(|account_id| {
+                    wallet
+                        .get_account_birthday(*account_id)
+                        .expect("reads rolled-back account birthday")
+                })
+                .collect::<Vec<_>>(),
+            birthdays_before
+        );
+        assert_eq!(
+            wallet
+                .suggest_scan_ranges()
+                .expect("reads rolled-back scan ranges"),
+            ranges_before
+        );
+        assert_eq!(
+            retained_heights
+                .iter()
+                .map(|height| {
+                    wallet
+                        .get_block_hash(*height)
+                        .expect("reads rolled-back retained block hash")
+                })
+                .collect::<Vec<_>>(),
+            hashes_before
+        );
+        drop(engine);
     }
 
     // -- RescanPolicy::parse tests --

--- a/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
@@ -9,13 +9,13 @@ use zcash_protocol::consensus::BlockHeight;
 
 use crate::components::{
     chain::{Chain, ChainView},
-    database::DbConnection,
+    database::DbHandle,
     json_rpc::{
         server::LegacyCode,
         utils::{ensure_wallet_is_unlocked, parse_seedfp_parameter},
     },
     keystore::KeyStore,
-    sync::WalletDecryptorHandle,
+    sync::WalletSyncReconfiguration,
 };
 
 /// Response to a `z_recoveraccounts` RPC request.
@@ -52,10 +52,10 @@ pub(super) const PARAM_ACCOUNTS_DESC: &str =
 pub(super) const PARAM_ACCOUNTS_REQUIRED: bool = true;
 
 pub(crate) async fn call<C: Chain>(
-    wallet: &mut DbConnection,
+    mut wallet: DbHandle,
     keystore: &KeyStore,
     chain: C,
-    decryptor: &WalletDecryptorHandle,
+    reconfiguration: &WalletSyncReconfiguration,
     accounts: Vec<AccountParameter<'_>>,
 ) -> Response {
     ensure_wallet_is_unlocked(keystore).await?;
@@ -119,6 +119,7 @@ pub(crate) async fn call<C: Chain>(
     }
 
     // Import the accounts.
+    let admitted = reconfiguration.admit_reconfiguration().await;
     let accounts = account_args
         .into_iter()
         .map(|(account_name, seed_fp, account_index, birthday)| {
@@ -135,9 +136,10 @@ pub(crate) async fn call<C: Chain>(
             })
         })
         .collect::<Result<_, _>>()?;
+    drop(wallet);
 
     // Reload viewing keys so recovered accounts are scanned without a restart (see z_importkey).
-    if decryptor.reload_keys().await.is_none() {
+    if !admitted.reload_keys_and_wake_history_recovery().await {
         tracing::warn!(
             "sync engine has shut down; recovered accounts won't be scanned until restart"
         );

--- a/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
+++ b/zallet-core/src/components/json_rpc/methods/recover_accounts.rs
@@ -139,7 +139,7 @@ pub(crate) async fn call<C: Chain>(
     drop(wallet);
 
     // Reload viewing keys so recovered accounts are scanned without a restart (see z_importkey).
-    if !admitted.reload_keys_and_wake_history_recovery().await {
+    if !admitted.reload_keys_and_wake_wallet_recovery().await {
         tracing::warn!(
             "sync engine has shut down; recovered accounts won't be scanned until restart"
         );

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -19,7 +19,7 @@ use super::methods::{RpcImpl, RpcServer as _};
 #[cfg(zallet_build = "wallet")]
 use {
     super::methods::{WalletRpcImpl, WalletRpcServer},
-    crate::components::{keystore::KeyStore, sync::WalletDecryptorHandle},
+    crate::components::{keystore::KeyStore, sync::WalletSyncReconfiguration},
 };
 
 mod error;
@@ -39,7 +39,7 @@ pub(crate) async fn spawn<C: Chain>(
     wallet: Database,
     #[cfg(zallet_build = "wallet")] keystore: KeyStore,
     chain: C,
-    #[cfg(zallet_build = "wallet")] decryptor: WalletDecryptorHandle,
+    #[cfg(zallet_build = "wallet")] reconfiguration: WalletSyncReconfiguration,
     sync_status: SyncStatusReader,
 ) -> Result<ServerTask, Error> {
     // Caller should make sure `bind` only contains a single address (for now).
@@ -57,7 +57,7 @@ pub(crate) async fn spawn<C: Chain>(
         wallet.clone(),
         keystore.clone(),
         chain.clone(),
-        decryptor,
+        reconfiguration,
         sync_status.clone(),
         config.async_operation_limit(),
     );

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -44,7 +44,11 @@ use jsonrpsee::tracing::{self, debug, info, warn};
 use std::collections::HashSet;
 #[cfg(not(feature = "spend-index"))]
 use std::ops::Range;
-use tokio::{sync::Notify, task::AbortHandle, time};
+use tokio::{
+    sync::{Notify, OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock},
+    task::AbortHandle,
+    time,
+};
 #[cfg(not(feature = "spend-index"))]
 use zcash_client_backend::data_api::{
     CoinbaseFilter, InputSource, TransactionsInvolvingAddress,
@@ -91,6 +95,89 @@ pub(crate) type WalletDecryptorHandle = decryptor::Handle<AccountUuid, (AccountU
 
 /// Engine half of the batch decryptor, driven by the sync tasks spawned by [`WalletSync::spawn`].
 pub(crate) type WalletDecryptorEngine = decryptor::Engine<AccountUuid, (AccountUuid, Scope)>;
+
+#[derive(Clone)]
+pub(crate) struct WalletSyncReconfiguration {
+    inner: Arc<WalletSyncReconfigurationInner>,
+}
+
+struct WalletSyncReconfigurationInner {
+    admission: Arc<RwLock<()>>,
+    decryptor: WalletDecryptorHandle,
+    history_recovery: Notify,
+}
+
+pub(crate) struct AdmittedWalletSyncReconfiguration {
+    inner: Arc<WalletSyncReconfigurationInner>,
+    _admission: OwnedRwLockWriteGuard<()>,
+}
+
+pub(crate) struct AdmittedWalletBlockScan {
+    inner: Arc<WalletSyncReconfigurationInner>,
+    _admission: OwnedRwLockReadGuard<()>,
+}
+
+impl WalletSyncReconfiguration {
+    pub(crate) fn new(decryptor: WalletDecryptorHandle) -> Self {
+        Self {
+            inner: Arc::new(WalletSyncReconfigurationInner {
+                admission: Arc::new(RwLock::new(())),
+                decryptor,
+                history_recovery: Notify::new(),
+            }),
+        }
+    }
+
+    pub(crate) async fn admit_reconfiguration(&self) -> AdmittedWalletSyncReconfiguration {
+        AdmittedWalletSyncReconfiguration {
+            _admission: self.inner.admission.clone().write_owned().await,
+            inner: self.inner.clone(),
+        }
+    }
+
+    async fn admit_block_scan(&self) -> AdmittedWalletBlockScan {
+        AdmittedWalletBlockScan {
+            _admission: self.inner.admission.clone().read_owned().await,
+            inner: self.inner.clone(),
+        }
+    }
+
+    async fn wait_for_history_recovery(&self) {
+        self.inner.history_recovery.notified().await;
+    }
+}
+
+impl AdmittedWalletSyncReconfiguration {
+    pub(crate) fn wake_history_recovery(&self) {
+        self.inner.history_recovery.notify_one();
+    }
+
+    pub(crate) async fn reload_keys_and_wake_history_recovery(self) -> bool {
+        let completion = tokio::spawn(async move {
+            let reload_finished = self.inner.decryptor.reload_keys().await;
+            self.wake_history_recovery();
+
+            match reload_finished {
+                Some(reload_finished) => reload_finished.await.is_ok(),
+                None => false,
+            }
+        });
+
+        match completion.await {
+            Ok(reload_finished) => reload_finished,
+            Err(error) => {
+                tracing::error!(%error, "post-commit wallet-key reload task failed");
+                false
+            }
+        }
+    }
+}
+
+impl AdmittedWalletBlockScan {
+    fn decryptor(&self) -> &WalletDecryptorHandle {
+        &self.inner.decryptor
+    }
+}
 
 /// Owns cancellation for wallet-sync tasks until the complete task set is returned.
 struct PendingWalletSyncTasks {
@@ -139,7 +226,7 @@ impl WalletSync {
         db: Database,
         chain: C,
         shutdown_height: Option<BlockHeight>,
-        decryptor: WalletDecryptorHandle,
+        reconfiguration: WalletSyncReconfiguration,
         decryptor_engine: WalletDecryptorEngine,
         status: SyncStatusWriter,
     ) -> Result<(TaskHandle, TaskHandle, TaskHandle, TaskHandle), Error> {
@@ -162,7 +249,7 @@ impl WalletSync {
             &chain,
             &params,
             db_data.as_mut(),
-            decryptor.clone(),
+            reconfiguration.clone(),
             shutdown_height,
             &status,
         )
@@ -182,7 +269,7 @@ impl WalletSync {
         let steady_state_task = {
             let chain = chain.clone();
             let lower_boundary = current_boundary.clone();
-            let decryptor = decryptor.clone();
+            let reconfiguration = reconfiguration.clone();
             let status = status.clone();
             crate::spawn!("Steady state sync", async move {
                 steady_state(
@@ -192,7 +279,7 @@ impl WalletSync {
                     starting_tip,
                     lower_boundary,
                     tip_change_signal_source,
-                    decryptor,
+                    reconfiguration,
                     shutdown_height,
                     status,
                 )
@@ -206,13 +293,14 @@ impl WalletSync {
             let chain = chain.clone();
             let mut db_data = db.handle().await?;
             let upper_boundary = current_boundary.clone();
+            let reconfiguration = reconfiguration.clone();
             crate::spawn!("Recover history", async move {
                 recover_history(
                     chain,
                     &params,
                     db_data.as_mut(),
                     upper_boundary,
-                    decryptor,
+                    reconfiguration,
                     recover_batch_size,
                     shutdown_height,
                     status,
@@ -299,7 +387,7 @@ async fn initialize<C: Chain>(
     chain: &C,
     params: &Network,
     db_data: &mut DbConnection,
-    decryptor: WalletDecryptorHandle,
+    reconfiguration: WalletSyncReconfiguration,
     shutdown_height: Option<BlockHeight>,
     status: &SyncStatusWriter,
 ) -> Result<(ChainBlock, BlockHeight), SyncError> {
@@ -366,12 +454,13 @@ async fn initialize<C: Chain>(
                                     current_tip.height()
                                 )))
                             })?;
+                        let admitted_scan = reconfiguration.admit_block_scan().await;
                         steps::scan_block(
                             &chain_view,
                             db_data,
                             params,
                             tip_block,
-                            &decryptor,
+                            admitted_scan.decryptor(),
                             shutdown_height,
                         )
                         .await
@@ -397,16 +486,18 @@ async fn initialize<C: Chain>(
             }
         };
 
-        match steps::scan_blocks(
+        let admitted_scan = reconfiguration.admit_block_scan().await;
+        let scan_result = steps::scan_blocks(
             chain_view,
             db_data,
             params,
             &scan_range,
-            &decryptor,
+            admitted_scan.decryptor(),
             shutdown_height,
         )
-        .await
-        {
+        .await;
+        drop(admitted_scan);
+        match scan_result {
             Ok(flow) if flow.is_break() => {
                 // The chain has already reached the consensus-divergence height during
                 // initial scanning. Stop here with the tip we have; `steady_state` will
@@ -790,7 +881,7 @@ async fn steady_state<C: Chain>(
     mut prev_tip: ChainBlock,
     lower_boundary: Arc<AtomicU32>,
     tip_change_signal: Arc<Notify>,
-    decryptor: WalletDecryptorHandle,
+    reconfiguration: WalletSyncReconfiguration,
     shutdown_height: Option<BlockHeight>,
     status: SyncStatusWriter,
 ) -> Result<(), SyncError> {
@@ -810,7 +901,7 @@ async fn steady_state<C: Chain>(
             &mut prev_tip,
             &lower_boundary,
             &tip_change_signal,
-            &decryptor,
+            &reconfiguration,
             shutdown_height,
             &status,
         )
@@ -923,7 +1014,7 @@ async fn steady_state_iteration<C: Chain>(
     prev_tip: &mut ChainBlock,
     lower_boundary: &AtomicU32,
     tip_change_signal: &Notify,
-    decryptor: &WalletDecryptorHandle,
+    reconfiguration: &WalletSyncReconfiguration,
     shutdown_height: Option<BlockHeight>,
     status: &SyncStatusWriter,
 ) -> Result<ControlFlow<BlockHeight>, SyncError> {
@@ -993,12 +1084,13 @@ async fn steady_state_iteration<C: Chain>(
             // reporting the boundary instead. From there the backing node follows rules this
             // build cannot interpret, so we stop without recording the unscanned block as our
             // tip; ending the task triggers a graceful shutdown.
+            let admitted_scan = reconfiguration.admit_block_scan().await;
             match steps::scan_block(
                 &chain_view,
                 db_data,
                 params,
                 block,
-                decryptor,
+                admitted_scan.decryptor(),
                 shutdown_height,
             )
             .await?
@@ -1087,7 +1179,7 @@ async fn recover_history<C: Chain>(
     params: &Network,
     db_data: &mut DbConnection,
     upper_boundary: Arc<AtomicU32>,
-    decryptor: WalletDecryptorHandle,
+    reconfiguration: WalletSyncReconfiguration,
     batch_size: u32,
     shutdown_height: Option<BlockHeight>,
     status: SyncStatusWriter,
@@ -1112,9 +1204,13 @@ async fn recover_history<C: Chain>(
         {
             Some(r) => r,
             None => {
-                // Wait for scan ranges to become available.
+                // Wait for scan ranges to become available or for a wallet mutation to
+                // schedule historical recovery.
                 debug!("No scan ranges, sleeping");
-                interval.tick().await;
+                tokio::select! {
+                    _ = interval.tick() => {}
+                    () = reconfiguration.wait_for_history_recovery() => {}
+                }
                 continue;
             }
         };
@@ -1142,16 +1238,18 @@ async fn recover_history<C: Chain>(
             let mut attempt = 0;
             let outcome = loop {
                 let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
-                match steps::scan_blocks(
+                let admitted_scan = reconfiguration.admit_block_scan().await;
+                let scan_result = steps::scan_blocks(
                     chain_view,
                     db_data,
                     params,
                     &scan_range,
-                    &decryptor,
+                    admitted_scan.decryptor(),
                     shutdown_height,
                 )
-                .await
-                {
+                .await;
+                drop(admitted_scan);
+                match scan_result {
                     Ok(outcome) => break outcome,
                     Err(error)
                         if is_tree_divergence(&error) && attempt < TREE_DIVERGENCE_RETRIES =>
@@ -1426,8 +1524,8 @@ mod tests {
 
     use super::{
         ChainError, PendingWalletSyncTasks, SyncError, TREE_RECOVERY_LADDER, TreeRecovery,
-        WalletSync, is_retryable, is_tree_divergence, resume_point, rewind_step,
-        select_initial_scan_range, status, steady_state, tree_recovery_target,
+        WalletSync, WalletSyncReconfiguration, is_retryable, is_tree_divergence, resume_point,
+        rewind_step, select_initial_scan_range, status, steady_state, tree_recovery_target,
     };
     use crate::{
         components::{
@@ -1619,6 +1717,97 @@ mod tests {
         ScanRange::from_parts(h(start)..h(end), priority)
     }
 
+    #[tokio::test]
+    async fn rescan_waits_for_active_block_scan() {
+        let (decryptor, _engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+        let active_scan = reconfiguration.admit_block_scan().await;
+        let pending_reconfiguration = reconfiguration.admit_reconfiguration();
+        tokio::pin!(pending_reconfiguration);
+
+        assert!(futures::poll!(&mut pending_reconfiguration).is_pending());
+
+        drop(active_scan);
+        tokio::time::timeout(Duration::from_secs(1), &mut pending_reconfiguration)
+            .await
+            .expect("reconfiguration is admitted after the active scan commits");
+    }
+
+    #[tokio::test]
+    async fn queued_rescan_blocks_later_scan_admission() {
+        let (decryptor, _engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+        let active_scan = reconfiguration.admit_block_scan().await;
+        let pending_reconfiguration = reconfiguration.admit_reconfiguration();
+        tokio::pin!(pending_reconfiguration);
+        assert!(futures::poll!(&mut pending_reconfiguration).is_pending());
+
+        let later_scan = reconfiguration.admit_block_scan();
+        tokio::pin!(later_scan);
+        assert!(futures::poll!(&mut later_scan).is_pending());
+        drop(active_scan);
+
+        let admitted_reconfiguration =
+            tokio::time::timeout(Duration::from_secs(1), &mut pending_reconfiguration)
+                .await
+                .expect("queued reconfiguration is admitted first");
+        assert!(futures::poll!(&mut later_scan).is_pending());
+
+        drop(admitted_reconfiguration);
+        tokio::time::timeout(Duration::from_secs(1), &mut later_scan)
+            .await
+            .expect("later scan is admitted after reconfiguration completes");
+    }
+
+    #[tokio::test]
+    async fn rescan_wakes_history_recovery_without_restart() {
+        let (decryptor, engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+        drop(engine);
+        let history_recovery_woken = reconfiguration.wait_for_history_recovery();
+        let admitted = reconfiguration.admit_reconfiguration().await;
+
+        admitted.wake_history_recovery();
+
+        tokio::time::timeout(Duration::from_secs(1), history_recovery_woken)
+            .await
+            .expect("history recovery is woken by wallet reconfiguration");
+    }
+
+    #[tokio::test]
+    async fn committed_key_reload_survives_rpc_cancellation() {
+        let (decryptor, engine) = WalletSync::build_decryptor();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
+        let history_recovery_woken = reconfiguration.wait_for_history_recovery();
+        let admitted = reconfiguration.admit_reconfiguration().await;
+        let rpc_request =
+            tokio::spawn(async move { admitted.reload_keys_and_wake_history_recovery().await });
+
+        tokio::time::timeout(Duration::from_secs(1), history_recovery_woken)
+            .await
+            .expect("key reload wakes history before waiting for acknowledgement");
+        rpc_request.abort();
+        let rpc_error = rpc_request
+            .await
+            .expect_err("aborting the RPC request cancels its response future");
+        assert!(rpc_error.is_cancelled());
+
+        assert!(
+            reconfiguration
+                .inner
+                .admission
+                .clone()
+                .try_read_owned()
+                .is_err(),
+            "post-commit completion retains admission after RPC cancellation"
+        );
+
+        drop(engine);
+        tokio::time::timeout(Duration::from_secs(1), reconfiguration.admit_block_scan())
+            .await
+            .expect("sync-engine shutdown releases post-commit admission");
+    }
+
     #[tokio::test(flavor = "multi_thread")]
     async fn late_wallet_sync_error_cancels_all_earlier_tasks() {
         let (batch_cancelled, batch_cancelled_receiver) = mpsc::channel();
@@ -1691,6 +1880,7 @@ mod tests {
             .expect("creates a wallet database");
         let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
         let decryptor_observer = decryptor.clone();
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
         let (status, _status_reader) = status::channel(config.sync.lock_threshold());
 
         let result = WalletSync::spawn(
@@ -1698,7 +1888,7 @@ mod tests {
             database,
             MockChain::reporting(Vec::new(), 0),
             None,
-            decryptor,
+            reconfiguration,
             decryptor_engine,
             status,
         )
@@ -1743,6 +1933,7 @@ mod tests {
         // Drop the engine half; the steady-state task only needs the handle, and we
         // do not drive batch decryption here.
         drop(decryptor_engine);
+        let reconfiguration = WalletSyncReconfiguration::new(decryptor);
 
         // A MockChain whose every view operation returns `Poll::Ready`: `snapshot`
         // and `tip` are synchronous, and `get_mempool_stream` returns `Ok(None)`.
@@ -1774,7 +1965,7 @@ mod tests {
                 prev_tip,
                 lower_boundary,
                 tip_change_signal,
-                decryptor,
+                reconfiguration,
                 None,
                 status,
             )

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -85,7 +85,7 @@ pub(crate) mod status;
 pub(crate) use status::{SyncStatus, SyncStatusReader, SyncStatusWriter};
 
 mod locator;
-mod steps;
+pub(super) mod steps;
 
 #[derive(Debug)]
 pub(crate) struct WalletSync {}
@@ -105,6 +105,7 @@ struct WalletSyncReconfigurationInner {
     admission: Arc<RwLock<()>>,
     decryptor: WalletDecryptorHandle,
     history_recovery: Notify,
+    near_tip_recovery: Notify,
 }
 
 pub(crate) struct AdmittedWalletSyncReconfiguration {
@@ -124,6 +125,7 @@ impl WalletSyncReconfiguration {
                 admission: Arc::new(RwLock::new(())),
                 decryptor,
                 history_recovery: Notify::new(),
+                near_tip_recovery: Notify::new(),
             }),
         }
     }
@@ -145,17 +147,22 @@ impl WalletSyncReconfiguration {
     async fn wait_for_history_recovery(&self) {
         self.inner.history_recovery.notified().await;
     }
+
+    async fn wait_for_near_tip_recovery(&self) {
+        self.inner.near_tip_recovery.notified().await;
+    }
 }
 
 impl AdmittedWalletSyncReconfiguration {
-    pub(crate) fn wake_history_recovery(&self) {
+    pub(crate) fn wake_wallet_recovery(&self) {
         self.inner.history_recovery.notify_one();
+        self.inner.near_tip_recovery.notify_one();
     }
 
-    pub(crate) async fn reload_keys_and_wake_history_recovery(self) -> bool {
+    pub(crate) async fn reload_keys_and_wake_wallet_recovery(self) -> bool {
         let completion = tokio::spawn(async move {
             let reload_finished = self.inner.decryptor.reload_keys().await;
-            self.wake_history_recovery();
+            self.wake_wallet_recovery();
 
             match reload_finished {
                 Some(reload_finished) => reload_finished.await.is_ok(),
@@ -375,6 +382,28 @@ fn select_initial_scan_range(
             } else {
                 None
             }
+        })
+        .next()
+}
+
+/// Selects suggested scan work owned by [`steady_state`].
+///
+/// The lower bound preserves [`recover_history`]'s ownership of finalized history, while
+/// the exclusive upper bound prevents a fixed chain view from scanning beyond its captured
+/// tip. As during initialization, only `Historic` or higher-priority work is admitted;
+/// lower-priority suggestions retain their existing semantics.
+fn select_near_tip_scan_range(
+    suggested: impl IntoIterator<Item = ScanRange>,
+    lower_boundary: BlockHeight,
+    current_tip: BlockHeight,
+) -> Option<ScanRange> {
+    suggested
+        .into_iter()
+        .filter(|range| range.priority() >= ScanPriority::Historic)
+        .filter_map(|range| {
+            range
+                .truncate_start(lower_boundary)?
+                .truncate_end(current_tip + 1)
         })
         .next()
 }
@@ -1114,6 +1143,47 @@ async fn steady_state_iteration<C: Chain>(
         return Ok(ControlFlow::Break(boundary));
     }
 
+    let lower_boundary = BlockHeight::from_u32(lower_boundary.load(Ordering::Acquire));
+    if let Some(scan_range) = select_near_tip_scan_range(
+        db_data.suggest_scan_ranges()?,
+        lower_boundary,
+        current_tip.height(),
+    ) {
+        let admitted_scan = reconfiguration.admit_block_scan().await;
+        let scan_result = steps::scan_blocks(
+            chain_view.clone(),
+            db_data,
+            params,
+            &scan_range,
+            admitted_scan.decryptor(),
+            shutdown_height,
+        )
+        .await;
+        if let ControlFlow::Break(boundary) = scan_result? {
+            return Ok(ControlFlow::Break(boundary));
+        }
+
+        let next_scan_range = select_near_tip_scan_range(
+            db_data.suggest_scan_ranges()?,
+            lower_boundary,
+            current_tip.height(),
+        );
+        // Keep scan admission through this queue snapshot so a waiting wallet
+        // mutation cannot schedule a new, identical range that looks like
+        // scanner no-progress.
+        drop(admitted_scan);
+        if next_scan_range.as_ref() == Some(&scan_range) {
+            return Err(SyncError::Chain(ChainError::backend(format!(
+                "near-tip scan made no progress through suggested range {scan_range}"
+            ))));
+        }
+
+        // Capture a fresh view before admitting the next suggested range. This bounds one
+        // iteration to one range and lets an expired or incomplete view make no further
+        // scheduling decisions.
+        return Ok(ControlFlow::Continue(()));
+    }
+
     // The wallet has applied every block up to the current tip. Publish how far it is
     // fully scanned (which also reflects `recover_history`'s backfill), mark that steady
     // state has reached the tip, and clear any recovering state now that the rewind (if
@@ -1133,16 +1203,26 @@ async fn steady_state_iteration<C: Chain>(
     {
         Some(mempool_stream) => {
             info!("Reached chain tip, streaming mempool");
-            tokio::pin!(mempool_stream);
-            while let Some(tx) = mempool_stream.next().await {
-                info!("Scanning mempool tx {}", tx.txid());
-                // TODO: Route individual-transaction scanning through the batch
-                // decryptor (`Handle::queue_tx`) once a single-tx store path exists.
-                // See zcash/zallet#477.
-                decrypt_and_store_transaction(params, db_data, &tx, None)?;
+            tokio::select! {
+                biased;
+                result = async {
+                    tokio::pin!(mempool_stream);
+                    while let Some(tx) = mempool_stream.next().await {
+                        info!("Scanning mempool tx {}", tx.txid());
+                        // TODO: Route individual-transaction scanning through the batch
+                        // decryptor (`Handle::queue_tx`) once a single-tx store path exists.
+                        // See zcash/zallet#477.
+                        decrypt_and_store_transaction(params, db_data, &tx, None)?;
+                    }
+                    Ok::<(), SyncError>(())
+                } => result?,
+                () = reconfiguration.wait_for_near_tip_recovery() => {
+                    debug!("Wallet recovery scheduled near-tip scan work");
+                }
             }
 
-            // Mempool stream ended, signalling that the chain tip has changed.
+            // A completed stream signals a tip change; wallet recovery instead drops this
+            // fixed view so the next iteration can admit its newly suggested near-tip work.
         }
         // The chain tip already changed since this view was captured; loop around
         // immediately to observe it.
@@ -1503,7 +1583,7 @@ async fn data_requests<C: Chain>(
 /// Processes the queue of transactions that need to be scanned with the wallet's viewing
 /// keys.
 #[tracing::instrument(skip_all)]
-async fn batch_decryptor(
+pub(super) async fn batch_decryptor(
     params: Network,
     db_data: &mut DbConnection,
     decryptor: decryptor::Engine<AccountUuid, (AccountUuid, Scope)>,
@@ -1525,7 +1605,8 @@ mod tests {
     use super::{
         ChainError, PendingWalletSyncTasks, SyncError, TREE_RECOVERY_LADDER, TreeRecovery,
         WalletSync, WalletSyncReconfiguration, is_retryable, is_tree_divergence, resume_point,
-        rewind_step, select_initial_scan_range, status, steady_state, tree_recovery_target,
+        rewind_step, select_initial_scan_range, select_near_tip_scan_range, status, steady_state,
+        tree_recovery_target,
     };
     use crate::{
         components::{
@@ -1760,18 +1841,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rescan_wakes_history_recovery_without_restart() {
+    async fn rescan_wakes_both_recovery_owners_without_restart() {
         let (decryptor, engine) = WalletSync::build_decryptor();
         let reconfiguration = WalletSyncReconfiguration::new(decryptor);
         drop(engine);
         let history_recovery_woken = reconfiguration.wait_for_history_recovery();
+        let near_tip_recovery_woken = reconfiguration.wait_for_near_tip_recovery();
         let admitted = reconfiguration.admit_reconfiguration().await;
 
-        admitted.wake_history_recovery();
+        admitted.wake_wallet_recovery();
 
-        tokio::time::timeout(Duration::from_secs(1), history_recovery_woken)
-            .await
-            .expect("history recovery is woken by wallet reconfiguration");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(history_recovery_woken, near_tip_recovery_woken);
+        })
+        .await
+        .expect("both recovery owners are woken by wallet reconfiguration");
     }
 
     #[tokio::test]
@@ -1779,13 +1863,16 @@ mod tests {
         let (decryptor, engine) = WalletSync::build_decryptor();
         let reconfiguration = WalletSyncReconfiguration::new(decryptor);
         let history_recovery_woken = reconfiguration.wait_for_history_recovery();
+        let near_tip_recovery_woken = reconfiguration.wait_for_near_tip_recovery();
         let admitted = reconfiguration.admit_reconfiguration().await;
         let rpc_request =
-            tokio::spawn(async move { admitted.reload_keys_and_wake_history_recovery().await });
+            tokio::spawn(async move { admitted.reload_keys_and_wake_wallet_recovery().await });
 
-        tokio::time::timeout(Duration::from_secs(1), history_recovery_woken)
-            .await
-            .expect("key reload wakes history before waiting for acknowledgement");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            tokio::join!(history_recovery_woken, near_tip_recovery_woken);
+        })
+        .await
+        .expect("key reload wakes both recovery owners before waiting for acknowledgement");
         rpc_request.abort();
         let rpc_error = rpc_request
             .await
@@ -2077,6 +2164,18 @@ mod tests {
         assert_eq!(
             select_initial_scan_range(suggested, h(1_200), h(900)),
             Some(range(1_000, 1_100, ScanPriority::Historic)),
+        );
+    }
+
+    #[test]
+    fn near_tip_scan_range_preserves_priority_and_boundary_ownership() {
+        let suggested = vec![
+            range(950, 1_000, ScanPriority::Scanned),
+            range(500, 1_500, ScanPriority::Historic),
+        ];
+        assert_eq!(
+            select_near_tip_scan_range(suggested, h(900), h(1_200)),
+            Some(range(900, 1_201, ScanPriority::Historic)),
         );
     }
 


### PR DESCRIPTION
Closes #707.

Account and key mutations could race active block-scan commits, while hot imports and rescans near the current tip could remain idle until another block or restart. This change gives wallet reconfiguration one serialized admission path and wakes every recovery owner after commit.

## What changes

- Serializes shielded wallet reconfiguration with block scanning.
- Retains admission until committed key changes are reloaded.
- Supports atomic rescans for existing viewing keys.
- Wakes historical recovery and near-tip scanning after account creation, recovery, import, or rescan.