### PR TITLE
fix(sync): retry unavailable chain snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,9 @@ be considered breaking changes.
   `zallet` spinning at full CPU after a sibling task failure. A backend whose
   every view operation awaits real I/O is unaffected.
 
+- Steady-state sync retries temporarily unavailable fixed-view acquisition during
+  chain-tip transitions.
+
 - Wallet sync now loads a complete block range from one fixed-history view
   before queueing decryption or database work. If the view expires partway
   through the range, the partial batch is discarded and the entire range is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,11 @@ be considered breaking changes.
   `zallet` spinning at full CPU after a sibling task failure. A backend whose
   every view operation awaits real I/O is unaffected.
 
+- Wallet sync now loads a complete block range from one fixed-history view
+  before queueing decryption or database work. If the view expires partway
+  through the range, the partial batch is discarded and the entire range is
+  retried against a fresh view, including during history recovery.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Added

--- a/backends/zaino/CHANGELOG.md
+++ b/backends/zaino/CHANGELOG.md
@@ -34,6 +34,9 @@ should be considered breaking changes.
   This backend was not implicated in the reports that prompted the fix, which
   were all on `zallet-zebra`; the same unguarded fallback existed here.
 
+- Wallet scans now discard and reacquire a fixed chain view when Zebra reports
+  that a selected block height is no longer in the best chain.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Changed

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -62,15 +62,15 @@ use zallet_core::components::chain::{
 /// genuine backend errors.
 ///
 /// Zebra returns RPC error -5 ("block height not in best chain") when a block is requested
-/// by height but it no longer exists in the best chain — this happens during reorgs and is
-/// transient. Returning `Unavailable` instead of `Backend` lets callers retry rather than
-/// treating the error as fatal.
+/// by height but it no longer exists in the best chain. That means the fixed history
+/// represented by the current view has expired, so callers must discard the view rather
+/// than retry the individual request against it.
 fn block_fetch_error(
     e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
 ) -> ChainError {
     let e: Box<dyn std::error::Error + Send + Sync + 'static> = e.into();
     if e.to_string().contains("block height not in best chain") {
-        ChainError::Unavailable(e)
+        ChainError::view_expired(e)
     } else {
         ChainError::Backend(e)
     }
@@ -842,12 +842,12 @@ mod tests {
     use super::*;
 
     #[test]
-    fn block_not_in_best_chain_is_unavailable() {
+    fn block_not_in_best_chain_expires_the_fixed_view() {
         // The exact message zebra returns (embedded inside a tonic Status message).
         let e = "unexpected error response from server: RPC Error (code: -5): block height not in best chain";
         assert!(
-            matches!(block_fetch_error(e), ChainError::Unavailable(_)),
-            "expected Unavailable for the reorg-window -5 error"
+            matches!(block_fetch_error(e), ChainError::ViewExpired(_)),
+            "expected ViewExpired for the reorg-window -5 error"
         );
     }
 

--- a/backends/zebra/CHANGELOG.md
+++ b/backends/zebra/CHANGELOG.md
@@ -47,6 +47,9 @@ should be considered breaking changes.
   wallet. Reads below a pool's activation height, where an absent tree genuinely
   means the empty tree, are unaffected.
 
+- Wallet scans now discard and reacquire a fixed chain view when a pinned block,
+  Sapling tree, Orchard tree, or Ironwood tree has reorged away.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Changed

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -276,7 +276,7 @@ impl<R: ChainReader> ZebraChainView<R> {
                 .block_header_by_hash(cur_hash)
                 .await?
                 .ok_or_else(|| {
-                    ChainError::unavailable("pinned block reorged away during resolve")
+                    ChainError::view_expired("pinned block reorged away during resolve")
                 })?;
             cur_hash = header.previous_block_hash;
             cur_height = BlockHeight::from_u32(u32::from(cur_height) - 1);
@@ -346,7 +346,7 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
                      after that pool's activation; refusing to substitute an empty frontier"
                 ))
             } else {
-                ChainError::unavailable(format!("pinned {pool} treestate reorged away"))
+                ChainError::view_expired(format!("pinned {pool} treestate reorged away"))
             }
         };
         let absent_tree_is_empty = |pool: TreePool| {
@@ -913,8 +913,8 @@ mod tests {
 
     #[tokio::test]
     async fn tree_state_as_of_still_reports_reorged_away_non_finalized_trees() {
-        // Above the finalized floor the pre-existing behaviour is unchanged: a missing tree
-        // means the pinned hash left the best chain, regardless of activation.
+        // Above the finalized floor a missing tree means the pinned hash left the best chain,
+        // so the fixed view has expired regardless of activation.
         let calls = Arc::new(AtomicU32::new(0));
         let view = test_view_with_params(10, 2, calls, regtest_with_all_pools_at(9));
 
@@ -923,6 +923,6 @@ mod tests {
             .await
             .expect_err("a non-finalized height with no tree bytes is unavailable");
 
-        assert!(matches!(err, ChainError::Unavailable(_)));
+        assert!(matches!(err, ChainError::ViewExpired(_)));
     }
 }

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -56,6 +56,11 @@ should be considered breaking changes.
   (zcash/librustzcash#2941); a backend workspace must carry the same patch
   so the cohort resolves to a single source.
 
+- Chain backends can now report `ChainError::ViewExpired` when a fixed-history
+  view has been invalidated. Wallet sync reacquires a view only for this
+  precise condition instead of conflating it with general source
+  unavailability.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Changed

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -837,7 +837,13 @@ pub(crate) use tests::MockChain;
 
 #[cfg(test)]
 mod tests {
-    use std::ops::Range;
+    use std::{
+        ops::Range,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+    };
 
     use futures::{
         StreamExt as _,
@@ -1273,6 +1279,8 @@ mod tests {
         params: super::Network,
         upgrades: Vec<ReportedUpgrade>,
         tip: BlockHeight,
+        remaining_unavailable_snapshots: Arc<AtomicUsize>,
+        snapshot_attempts: Arc<AtomicUsize>,
     }
 
     impl MockChain {
@@ -1281,7 +1289,19 @@ mod tests {
                 params: super::Network::Consensus(Network::MainNetwork),
                 upgrades,
                 tip: BlockHeight::from_u32(tip),
+                remaining_unavailable_snapshots: Arc::new(AtomicUsize::new(0)),
+                snapshot_attempts: Arc::new(AtomicUsize::new(0)),
             }
+        }
+
+        pub(crate) fn with_unavailable_snapshots(self, attempts: usize) -> Self {
+            self.remaining_unavailable_snapshots
+                .store(attempts, Ordering::SeqCst);
+            self
+        }
+
+        pub(crate) fn snapshot_attempts(&self) -> usize {
+            self.snapshot_attempts.load(Ordering::SeqCst)
         }
     }
 
@@ -1327,6 +1347,19 @@ mod tests {
         }
 
         async fn snapshot(&self) -> Result<Self::View, ChainError> {
+            self.snapshot_attempts.fetch_add(1, Ordering::SeqCst);
+            if self
+                .remaining_unavailable_snapshots
+                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |remaining| {
+                    remaining.checked_sub(1)
+                })
+                .is_ok()
+            {
+                return Err(ChainError::unavailable(
+                    "injected chain snapshot unavailability",
+                ));
+            }
+
             Ok(MockChainView {
                 tip: ChainBlock {
                     height: self.tip,

--- a/zallet-core/src/components/chain/error.rs
+++ b/zallet-core/src/components/chain/error.rs
@@ -18,6 +18,10 @@ pub enum ChainError {
     /// Zaino backend currently classifies all opaque failures as [`ChainError::Backend`].
     #[allow(dead_code)]
     Unavailable(BoxError),
+    /// The fixed chain view was invalidated while serving a read, usually because a
+    /// non-finalized block was reorged away. The caller must capture a fresh view before
+    /// retrying the operation.
+    ViewExpired(BoxError),
     /// The chain source returned data that could not be decoded, or that violated an
     /// invariant the wallet relies on (a non-canonical encoding, an unexpected response
     /// shape). Not retryable; indicates a bug, corruption, or a version mismatch.
@@ -39,6 +43,11 @@ impl ChainError {
         ChainError::Unavailable(source.into())
     }
 
+    /// Wraps an arbitrary error as a [`ChainError::ViewExpired`].
+    pub fn view_expired(source: impl Into<BoxError>) -> Self {
+        ChainError::ViewExpired(source.into())
+    }
+
     /// Wraps an arbitrary error as a [`ChainError::InvalidData`].
     #[allow(dead_code)] // unused by whichever backend is not compiled
     pub fn invalid_data(source: impl Into<BoxError>) -> Self {
@@ -50,6 +59,7 @@ impl fmt::Display for ChainError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ChainError::Unavailable(e) => write!(f, "chain source unavailable: {e}"),
+            ChainError::ViewExpired(e) => write!(f, "chain view expired: {e}"),
             ChainError::InvalidData(e) => write!(f, "chain source returned invalid data: {e}"),
             ChainError::Backend(e) => write!(f, "chain backend error: {e}"),
         }
@@ -59,9 +69,10 @@ impl fmt::Display for ChainError {
 impl std::error::Error for ChainError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
-            ChainError::Unavailable(e) | ChainError::InvalidData(e) | ChainError::Backend(e) => {
-                Some(e.as_ref())
-            }
+            ChainError::Unavailable(e)
+            | ChainError::ViewExpired(e)
+            | ChainError::InvalidData(e)
+            | ChainError::Backend(e) => Some(e.as_ref()),
         }
     }
 }

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -441,16 +441,20 @@ async fn initialize<C: Chain>(
     Ok((current_tip, starting_boundary))
 }
 
-/// How long to wait before re-pinning the chain view after a stale-view error, so a
-/// backend that is briefly unable to serve reads (still syncing its non-finalized state,
-/// or a reorg in progress) is not polled in a tight loop.
+/// How long to wait before re-pinning the chain view after a retryable chain error, so a
+/// backend that is briefly unable to serve reads or has expired a non-finalized view is not
+/// polled in a tight loop.
 const REORG_RETRY_BACKOFF: Duration = Duration::from_millis(200);
 
-/// Whether a sync error reflects a chain view that went stale mid-read — the captured
-/// snapshot referenced a non-finalized block that was reorged away — and so should be
-/// retried by re-pinning to the current tip, rather than propagated as fatal.
+/// Whether a sync error should be retried after re-pinning to the current tip, rather than
+/// propagated as fatal. `ViewExpired` is the precise fixed-view invalidation signal; the
+/// legacy `Unavailable` category remains retryable for backends that cannot classify the
+/// transient condition more precisely.
 fn is_retryable(error: &SyncError) -> bool {
-    matches!(error, SyncError::Chain(ChainError::Unavailable(_)))
+    matches!(
+        error,
+        SyncError::Chain(ChainError::Unavailable(_) | ChainError::ViewExpired(_))
+    )
 }
 
 /// How far back to step each time the wallet's recorded history is found to be off the
@@ -1153,6 +1157,13 @@ async fn recover_history<C: Chain>(
                 .await
                 {
                     Ok(outcome) => break outcome,
+                    Err(error) if is_retryable(&error) => {
+                        warn!(
+                            "History recovery chain view became unavailable; re-pinning before \
+                             retrying {scan_range}: {error}"
+                        );
+                        time::sleep(REORG_RETRY_BACKOFF).await;
+                    }
                     Err(error)
                         if is_tree_divergence(&error) && attempt < TREE_DIVERGENCE_RETRIES =>
                     {
@@ -1916,6 +1927,13 @@ mod tests {
     #[test]
     fn stale_view_errors_are_retryable() {
         assert!(is_retryable(&SyncError::Chain(ChainError::unavailable(
+            "pinned block reorged away",
+        ))));
+    }
+
+    #[test]
+    fn expired_view_errors_are_retryable() {
+        assert!(is_retryable(&SyncError::Chain(ChainError::view_expired(
             "pinned block reorged away",
         ))));
     }

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -446,15 +446,10 @@ async fn initialize<C: Chain>(
 /// polled in a tight loop.
 const REORG_RETRY_BACKOFF: Duration = Duration::from_millis(200);
 
-/// Whether a sync error should be retried after re-pinning to the current tip, rather than
-/// propagated as fatal. `ViewExpired` is the precise fixed-view invalidation signal; the
-/// legacy `Unavailable` category remains retryable for backends that cannot classify the
-/// transient condition more precisely.
+/// Whether a sync error proves that the current fixed-history view expired and should be
+/// retried after re-pinning to the current tip, rather than propagated as fatal.
 fn is_retryable(error: &SyncError) -> bool {
-    matches!(
-        error,
-        SyncError::Chain(ChainError::Unavailable(_) | ChainError::ViewExpired(_))
-    )
+    matches!(error, SyncError::Chain(ChainError::ViewExpired(_)))
 }
 
 /// How far back to step each time the wallet's recorded history is found to be off the
@@ -931,7 +926,16 @@ async fn steady_state_iteration<C: Chain>(
     shutdown_height: Option<BlockHeight>,
     status: &SyncStatusWriter,
 ) -> Result<ControlFlow<BlockHeight>, SyncError> {
-    let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
+    let chain_view = loop {
+        match chain.snapshot().await {
+            Ok(chain_view) => break chain_view,
+            Err(error @ ChainError::Unavailable(_)) => {
+                warn!("Chain source unavailable while capturing a fixed view; retrying: {error}");
+                time::sleep(REORG_RETRY_BACKOFF).await;
+            }
+            Err(error) => return Err(SyncError::Chain(error)),
+        }
+    };
     let current_tip = chain_view.tip().await.map_err(SyncError::Chain)?;
     let tip_changed = current_tip != *prev_tip;
 
@@ -1433,7 +1437,10 @@ async fn batch_decryptor(
 
 #[cfg(test)]
 mod tests {
-    use std::{sync::mpsc, time::Duration};
+    use std::{
+        sync::{Arc, atomic::AtomicU32, mpsc},
+        time::Duration,
+    };
 
     use super::{
         ChainError, PendingWalletSyncTasks, SyncError, TREE_RECOVERY_LADDER, TreeRecovery,
@@ -1774,8 +1781,8 @@ mod tests {
         // loop never updates `prev_tip`, leaving `tip_changed` true on every
         // subsequent iteration as well.
         let prev_tip = ChainBlock::new(BlockHeight::from_u32(0), BlockHash([0xff; 32]));
-        let lower_boundary = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let tip_change_signal = std::sync::Arc::new(Notify::new());
+        let lower_boundary = Arc::new(AtomicU32::new(0));
+        let tip_change_signal = Arc::new(Notify::new());
 
         let steady_state_task = tokio::spawn(async move {
             steady_state(
@@ -1925,9 +1932,9 @@ mod tests {
     }
 
     #[test]
-    fn stale_view_errors_are_retryable() {
-        assert!(is_retryable(&SyncError::Chain(ChainError::unavailable(
-            "pinned block reorged away",
+    fn unavailable_errors_are_fatal_after_snapshot_capture() {
+        assert!(!is_retryable(&SyncError::Chain(ChainError::unavailable(
+            "backend stopped serving the captured view",
         ))));
     }
 
@@ -1936,6 +1943,46 @@ mod tests {
         assert!(is_retryable(&SyncError::Chain(ChainError::view_expired(
             "pinned block reorged away",
         ))));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn steady_state_retries_unavailable_snapshot_capture() {
+        crate::i18n::load_languages(&[]);
+        let datadir = tempfile::tempdir().expect("creates temporary data directory");
+        let config = ZalletConfig {
+            datadir: Some(datadir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let database = Database::open(&config)
+            .await
+            .expect("creates wallet database");
+        let mut wallet = database.handle().await.expect("opens wallet database");
+        let tip = h(0);
+        let chain = MockChain::reporting(Vec::new(), u32::from(tip)).with_unavailable_snapshots(1);
+        let (decryptor, decryptor_engine) = WalletSync::build_decryptor();
+        drop(decryptor_engine);
+        let params = config.consensus.network();
+        let (status, _status_reader) = status::channel(config.sync.lock_threshold());
+
+        tokio::time::timeout(
+            Duration::from_secs(1),
+            steady_state(
+                chain.clone(),
+                &params,
+                wallet.as_mut(),
+                ChainBlock::new(tip, BlockHash([0; 32])),
+                Arc::new(AtomicU32::new(0)),
+                Arc::new(Notify::new()),
+                decryptor,
+                Some(tip),
+                status,
+            ),
+        )
+        .await
+        .expect("snapshot retry remains bounded")
+        .expect("steady state retries a temporarily unavailable snapshot");
+
+        assert_eq!(chain.snapshot_attempts(), 2);
     }
 
     #[test]

--- a/zallet-core/src/components/sync/steps.rs
+++ b/zallet-core/src/components/sync/steps.rs
@@ -7,7 +7,8 @@ use jsonrpsee::tracing::info;
 use transparent::{address::TransparentAddress, keys::TransparentKeyScope};
 use zcash_client_backend::{
     data_api::{
-        BlockMetadata, WalletCommitmentTrees, WalletRead, WalletWrite, scanning::ScanRange,
+        BlockMetadata, WalletCommitmentTrees, WalletRead, WalletWrite, chain::ChainState,
+        scanning::ScanRange,
     },
     scanning::{
         Nullifiers,
@@ -120,6 +121,33 @@ fn clamp_to_boundary(
     }
 }
 
+/// Loads a predecessor tree state and a complete contiguous block range from one chain
+/// view.
+///
+/// The returned batch is all-or-nothing. If the view expires while its block stream is
+/// in flight, the partial vector is dropped with the error before any block is queued for
+/// decryption or written to the wallet database.
+async fn collect_block_range<V: ChainView>(
+    chain_view: &V,
+    range: &Range<BlockHeight>,
+) -> Result<Option<(ChainState, Vec<Block>)>, SyncError> {
+    let Some(from_state) = chain_view
+        .tree_state_as_of(range.start - 1)
+        .await
+        .map_err(SyncError::Chain)?
+    else {
+        return Ok(None);
+    };
+
+    let blocks = chain_view
+        .stream_blocks(range)
+        .try_collect()
+        .await
+        .map_err(SyncError::Chain)?;
+
+    Ok(Some((from_state, blocks)))
+}
+
 /// Scans a contiguous sequence of blocks in the main chain.
 pub(super) async fn scan_blocks<V: ChainView>(
     chain_view: V,
@@ -145,20 +173,16 @@ pub(super) async fn scan_blocks<V: ChainView>(
         scan_range
     };
 
-    // Ignore scan ranges beyond the end of the current chain tip (which indicates a race
-    // with a chain reorg).
-    if let Some(from_state) = chain_view
-        .tree_state_as_of(scan_range.block_range().start - 1)
-        .await
-        .map_err(SyncError::Chain)?
+    // Load the whole fixed-view batch before beginning decryption or database work. An
+    // expired view therefore discards every block collected from that view.
+    if let Some((from_state, blocks_to_apply)) =
+        collect_block_range(&chain_view, scan_range.block_range()).await?
     {
         info!("Scanning blocks {}", scan_range);
-        let blocks_to_apply = chain_view.stream_blocks(scan_range.block_range());
-        tokio::pin!(blocks_to_apply);
 
         // Queue the blocks for batch decryption.
         let mut batch = Vec::with_capacity(scan_range.len());
-        while let Some(block) = blocks_to_apply.try_next().await.map_err(SyncError::Chain)? {
+        for block in blocks_to_apply {
             let height = block.claimed_height();
             let result = decryptor
                 .queue_block(block)


### PR DESCRIPTION
Closes #703.

Depends on #712, which separates concrete fixed-view expiry from temporary source unavailability. This PR then restores retry only at snapshot acquisition, where `ChainError::Unavailable` is safe to retry.

Temporary fixed-view acquisition failures during a chain-tip transition should not terminate steady-state sync, but invalid data and backend failures must remain fail-stop.

## What changes

- Retries only `ChainError::Unavailable` from snapshot acquisition.
- Reacquires a fresh view using bounded backoff.
- Preserves terminal handling for every other snapshot and mempool error.