### PR TITLE
fix(sync): wake transaction enhancement after block scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@ be considered breaking changes.
 
 ### Fixed
 
+- Wallet sync wakes transaction enhancement after connected-block scanning has
+  queued its requests, so newly mined transparent funds become visible without
+  waiting for another chain-tip change.
+
 - A note commitment tree conflict during sync no longer shuts the wallet down
   permanently. Zallet now rolls the wallet back to a progressively older point
   and rescans, up to a bounded number of attempts and never below the wallet's

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -948,7 +948,6 @@ async fn steady_state_iteration<C: Chain>(
                 )
             })
             .expect("closure always returns Some");
-        tip_change_signal.notify_one();
         status.set_tip(current_tip.height());
 
         // Find where the wallet's history rejoins the backend's best chain.
@@ -1011,6 +1010,10 @@ async fn steady_state_iteration<C: Chain>(
             // Now that we're done applying the block, update our chain pointer.
             *prev_tip = current_block;
         }
+
+        // Scanning connected blocks can queue transaction enhancement requests. Wake the
+        // request worker only after those requests are visible in the wallet database.
+        tip_change_signal.notify_one();
     }
 
     // The backing node's tip may itself sit at or beyond the divergence height — e.g. the


### PR DESCRIPTION
Closes #705.

Connected-block scanning could queue transaction-enhancement requests after the transaction-data worker had already consumed its wake signal. Newly mined transparent funds could then remain invisible until another chain-tip change.

## What changes

- Emits the transaction-data wake signal after connected-block scans commit.
- Ensures enhancement requests queued by the scanned block are visible before the worker wakes.
- Leaves fork handling and mempool wake behavior unchanged.