### PR TITLE
getwalletinfo: report the wallet's seed fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,20 @@ be considered breaking changes.
   through an authenticated, encrypted tunnel such as SSH port forwarding or a
   VPN. Previously any bind address was accepted without a warning.
 
+- `getwalletinfo`’s `mnemonic_seedfp` field now reports the wallet’s ZIP 32 seed
+  fingerprint, instead of the placeholder string `"TODO"`. It is omitted when
+  the wallet holds no mnemonic phrases, matching `zcashd`, which emitted the
+  field only when its wallet had a mnemonic.
+
+  A Zallet wallet may hold any number of phrases, which this `zcashd`-inherited
+  field cannot represent, so a wallet holding several gets a sentence saying how
+  many instead of a fingerprint. Use `z_listaccounts` to learn which phrase an
+  individual account derives from.
+
+  Note that Zallet reports the fingerprint in its ZIP 32 bech32m encoding
+  (`zip32seedfp1…`), as `z_listaccounts` already does, whereas `zcashd` reported
+  the `uint256` hex form.
+
 ### Fixed
 
 - `migrate-zcashd-wallet` now passes a fallback network to the wallet parser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,14 +131,18 @@ be considered breaking changes.
   VPN. Previously any bind address was accepted without a warning.
 
 - `getwalletinfo`’s `mnemonic_seedfp` field now reports the wallet’s ZIP 32 seed
-  fingerprint, instead of the placeholder string `"TODO"`. It is omitted when
-  the wallet holds no mnemonic phrases, matching `zcashd`, which emitted the
-  field only when its wallet had a mnemonic.
+  fingerprint, instead of the placeholder string `"TODO"`. It is present only
+  when the wallet holds exactly one mnemonic phrase: `zcashd` had at most one per
+  wallet and omitted the field when it had none, while a Zallet wallet may hold
+  any number, and there is no one fingerprint to report when it holds several.
 
-  A Zallet wallet may hold any number of phrases, which this `zcashd`-inherited
-  field cannot represent, so a wallet holding several gets a sentence saying how
-  many instead of a fingerprint. Use `z_listaccounts` to learn which phrase an
-  individual account derives from.
+  A new `mnemonic_seedfps` field lists every ZIP 32 seed fingerprint the wallet
+  holds, in lexicographic order, so a wallet with several phrases is no longer
+  unreportable. It is empty when the wallet holds no mnemonic phrases, and is
+  omitted — along with `mnemonic_seedfp` — only when the key store could not be
+  queried, which is what distinguishes a wallet with no phrases from a failed
+  lookup. Use `z_listaccounts` to learn which phrase an individual account
+  derives from.
 
   Note that Zallet reports the fingerprint in its ZIP 32 bech32m encoding
   (`zip32seedfp1…`), as `z_listaccounts` already does, whereas `zcashd` reported

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -77,6 +77,29 @@ Changes to response:
   every pool in the account, even when the queried address is a Sapling
   address.
 
+### `getwalletinfo`
+
+Changes to response:
+- The balance fields (`balance`, `unconfirmed_balance`, `immature_balance`,
+  `shielded_balance`, `shielded_unconfirmed_balance`) are not populated — use
+  the dedicated balance methods ([#55]).
+- `mnemonic_seedfp` is the ZIP 32 seed fingerprint in its bech32m encoding
+  (`zip32seedfp1…`), as `z_listaccounts` reports it, whereas `zcashd` reported
+  the `uint256` hex form. Zallet accepts both encodings wherever a fingerprint
+  is given as a parameter, so this affects readers only.
+- `mnemonic_seedfp` is present only when the wallet holds exactly one mnemonic
+  phrase. A `zcashd` wallet had at most one, and omitted the field when it had
+  none; a Zallet wallet may hold any number, and there is no one fingerprint to
+  report when it holds several. Its absence therefore no longer implies that the
+  wallet has no mnemonic — read `mnemonic_seedfps` to tell the cases apart.
+- New `mnemonic_seedfps` field, listing every ZIP 32 seed fingerprint the wallet
+  holds in lexicographic order. It is empty if the wallet holds no mnemonic
+  phrases, and is omitted — along with `mnemonic_seedfp` — only if the key store
+  could not be queried, so that a wallet with no phrases is distinguishable from
+  a failed lookup.
+- The remaining fields (`walletversion`, `txcount`, `keypoololdest`,
+  `keypoolsize`) are still placeholders ([#620]).
+
 ### `getrawtransaction`
 
 Changes to parameters:
@@ -231,6 +254,8 @@ creation and validation). It measured `zcashd` code that Zallet does not
 contain, so there is nothing equivalent for Zallet to measure and no
 replacement is planned.
 
+[#55]: https://github.com/zcash/zallet/issues/55
+[#620]: https://github.com/zcash/zallet/issues/620
 [pczts]: https://github.com/zcash/zallet/issues/99
 [ZIP 32]: https://zips.z.cash/zip-0032
 [ZIP 317]: https://zips.z.cash/zip-0317

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -56,6 +56,11 @@ Changes to response:
 - Transparent addresses for which we have BIP 44 derivation information are now
   listed in a new `derived_transparent` field (an array of objects) instead of
   the `transparent` field.
+- The `seedfp` field of each `unified` group is the ZIP 32 seed fingerprint in
+  its bech32m encoding (`zip32seedfp1…`), whereas `zcashd` reported the
+  `uint256` hex form. Zallet accepts both encodings wherever a fingerprint is
+  given as a parameter, so this affects readers only. The `seedfp` field of each
+  `derived_transparent` group uses the same encoding.
 
 ### `z_exportviewingkey`
 

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -31,7 +31,7 @@ Statuses:
 | `getreceivedbyaddress` | Not yet implemented | [#52](https://github.com/zcash/zallet/issues/52) |
 | `gettransaction` | Not planned | Superseded by `z_viewtransaction`, which now includes its top-level fields ([altered semantics](json_rpc.md#z_viewtransaction)); `gettransaction` cannot represent partially-shielded transactions correctly |
 | `getunconfirmedbalance` | Not yet implemented | [#54](https://github.com/zcash/zallet/issues/54) |
-| `getwalletinfo` | Implemented (partial) | Balance fields will not be populated — use dedicated balance methods ([#55](https://github.com/zcash/zallet/issues/55)). `unlocked_until` and `mnemonic_seedfp` are meaningful; the remaining fields are still placeholders ([#620](https://github.com/zcash/zallet/issues/620)) |
+| `getwalletinfo` | Implemented (partial) | Balance fields will not be populated — use dedicated balance methods ([#55](https://github.com/zcash/zallet/issues/55)). `unlocked_until` and the seed fingerprints are meaningful, the latter with [altered semantics](json_rpc.md#getwalletinfo) and a new `mnemonic_seedfps` field; the remaining fields are still placeholders ([#620](https://github.com/zcash/zallet/issues/620)) |
 | `importaddress` | Omitted | Use the [`zallet import-address`](../cli/import-address.md) CLI command ([#56](https://github.com/zcash/zallet/issues/56)), which accepts a bare address, a public key, or a redeem script, and imports into the legacy transparent account by default; `z_importaddress` covers the public-key and redeem-script forms over RPC |
 | `importprivkey` | Not yet implemented | [#57](https://github.com/zcash/zallet/issues/57) |
 | `importpubkey` | Omitted | Use `z_importaddress` |

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -31,7 +31,7 @@ Statuses:
 | `getreceivedbyaddress` | Not yet implemented | [#52](https://github.com/zcash/zallet/issues/52) |
 | `gettransaction` | Not planned | Superseded by `z_viewtransaction`, which now includes its top-level fields ([altered semantics](json_rpc.md#z_viewtransaction)); `gettransaction` cannot represent partially-shielded transactions correctly |
 | `getunconfirmedbalance` | Not yet implemented | [#54](https://github.com/zcash/zallet/issues/54) |
-| `getwalletinfo` | Implemented (partial) | Balance fields will not be populated — use dedicated balance methods ([#55](https://github.com/zcash/zallet/issues/55)); most other fields are currently placeholders, and only `unlocked_until` is meaningful |
+| `getwalletinfo` | Implemented (partial) | Balance fields will not be populated — use dedicated balance methods ([#55](https://github.com/zcash/zallet/issues/55)). `unlocked_until` and `mnemonic_seedfp` are meaningful; the remaining fields are still placeholders ([#620](https://github.com/zcash/zallet/issues/620)) |
 | `importaddress` | Omitted | Use the [`zallet import-address`](../cli/import-address.md) CLI command ([#56](https://github.com/zcash/zallet/issues/56)), which accepts a bare address, a public key, or a redeem script, and imports into the legacy transparent account by default; `z_importaddress` covers the public-key and redeem-script forms over RPC |
 | `importprivkey` | Not yet implemented | [#57](https://github.com/zcash/zallet/issues/57) |
 | `importpubkey` | Omitted | Use `z_importaddress` |

--- a/zallet-core/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_wallet_info.rs
@@ -7,10 +7,7 @@ use serde::Serialize;
 use zcash_protocol::value::Zatoshis;
 
 use crate::components::{
-    json_rpc::{
-        server::LegacyCode,
-        utils::{JsonZec, value_from_zatoshis},
-    },
+    json_rpc::utils::{JsonZec, value_from_zatoshis},
     keystore::KeyStore,
 };
 
@@ -60,41 +57,57 @@ pub(crate) struct GetWalletInfo {
 
     /// The ZIP 32 seed fingerprint of the wallet's mnemonic phrase.
     ///
-    /// Omitted if the wallet holds no mnemonic phrases, as in `zcashd`.
-    ///
-    /// A Zallet wallet may hold any number of phrases, which this `zcashd`-inherited
-    /// field cannot represent. It is the fingerprint when the wallet holds exactly one,
-    /// and otherwise a sentence saying how many it holds. Use `z_listaccounts` to learn
-    /// which phrase an individual account derives from.
+    /// Present only when the wallet holds exactly one mnemonic phrase, so that this
+    /// `zcashd`-inherited field always means what `zcashd` meant by it: `zcashd` had at
+    /// most one phrase per wallet, and omitted this field when it had none. A Zallet
+    /// wallet may hold any number, so see `mnemonic_seedfps` for the general case.
     #[serde(skip_serializing_if = "Option::is_none")]
     mnemonic_seedfp: Option<String>,
+
+    /// Every ZIP 32 seed fingerprint the wallet holds, in lexicographic order.
+    ///
+    /// Empty if the wallet holds no mnemonic phrases. Omitted, along with
+    /// `mnemonic_seedfp`, only if the key store could not be queried.
+    ///
+    /// Use `z_listaccounts` to learn which phrase an individual account derives from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mnemonic_seedfps: Option<Vec<String>>,
 }
 
 pub(crate) async fn call(keystore: &KeyStore) -> Response {
     // https://github.com/zcash/zallet/issues/620
-    warn!("TODO: Implement getwalletinfo");
+    warn!(
+        "TODO: getwalletinfo still reports placeholders for walletversion, balance, \
+         unconfirmed_balance, immature_balance, shielded_balance, \
+         shielded_unconfirmed_balance, txcount, keypoololdest, and keypoolsize"
+    );
 
-    let seed_fps = keystore
-        .list_seed_fingerprints()
-        .await
-        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-        .into_iter()
-        .collect::<Vec<_>>();
+    let mnemonic_seedfps = match keystore.list_seed_fingerprints().await {
+        Ok(seed_fps) => {
+            let mut seed_fps = seed_fps
+                .into_iter()
+                .map(|seed_fp| seed_fp.to_string())
+                .collect::<Vec<_>>();
+            // `list_seed_fingerprints` returns a `HashSet`, whose iteration order varies
+            // between calls; sort so that repeated calls agree.
+            seed_fps.sort();
+            Some(seed_fps)
+        }
+        Err(e) => {
+            // Degrade rather than failing the whole method: every other field here is
+            // computable without the key store database, and omitting these two is
+            // unambiguous because `mnemonic_seedfps` is otherwise always present.
+            warn!("Failed to list the wallet's seed fingerprints: {e}");
+            None
+        }
+    };
 
-    // TODO: Report several seed fingerprints properly instead of describing them in
-    //       prose. `zcashd` had at most one mnemonic phrase per wallet, so this field is
-    //       shaped to hold one fingerprint; Zallet supports any number, and a caller
-    //       whose wallet holds several currently gets a sentence where it expects a
-    //       fingerprint. Replacing that case needs a field that can carry a list.
-    let mnemonic_seedfp = match seed_fps.as_slice() {
-        [seed_fp] => Some(seed_fp.to_string()),
-        // `zcashd` omitted this field when the wallet had no mnemonic, rather than
-        // reporting a placeholder; a wallet with no phrases has no fingerprint to give.
-        [] => None,
-        several => Some(format!(
-            "This wallet holds {} mnemonic phrases",
-            several.len()
-        )),
+    // `zcashd` omitted this field when the wallet had no mnemonic, rather than reporting
+    // a placeholder. Zallet additionally omits it when the wallet holds several, since
+    // there is no one fingerprint to report; `mnemonic_seedfps` covers that case.
+    let mnemonic_seedfp = match mnemonic_seedfps.as_deref() {
+        Some([seed_fp]) => Some(seed_fp.clone()),
+        _ => None,
     };
 
     let unlocked_until = if keystore.uses_encrypted_identities() {
@@ -121,5 +134,6 @@ pub(crate) async fn call(keystore: &KeyStore) -> Response {
         keypoolsize: 0,
         unlocked_until,
         mnemonic_seedfp,
+        mnemonic_seedfps,
     })
 }

--- a/zallet-core/src/components/json_rpc/methods/get_wallet_info.rs
+++ b/zallet-core/src/components/json_rpc/methods/get_wallet_info.rs
@@ -7,7 +7,10 @@ use serde::Serialize;
 use zcash_protocol::value::Zatoshis;
 
 use crate::components::{
-    json_rpc::utils::{JsonZec, value_from_zatoshis},
+    json_rpc::{
+        server::LegacyCode,
+        utils::{JsonZec, value_from_zatoshis},
+    },
     keystore::KeyStore,
 };
 
@@ -55,13 +58,44 @@ pub(crate) struct GetWalletInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     unlocked_until: Option<u64>,
 
-    /// The BLAKE2b-256 hash of the HD seed derived from the wallet's emergency recovery phrase.
-    mnemonic_seedfp: String,
+    /// The ZIP 32 seed fingerprint of the wallet's mnemonic phrase.
+    ///
+    /// Omitted if the wallet holds no mnemonic phrases, as in `zcashd`.
+    ///
+    /// A Zallet wallet may hold any number of phrases, which this `zcashd`-inherited
+    /// field cannot represent. It is the fingerprint when the wallet holds exactly one,
+    /// and otherwise a sentence saying how many it holds. Use `z_listaccounts` to learn
+    /// which phrase an individual account derives from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mnemonic_seedfp: Option<String>,
 }
 
 pub(crate) async fn call(keystore: &KeyStore) -> Response {
-    // https://github.com/zcash/zallet/issues/55
+    // https://github.com/zcash/zallet/issues/620
     warn!("TODO: Implement getwalletinfo");
+
+    let seed_fps = keystore
+        .list_seed_fingerprints()
+        .await
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .into_iter()
+        .collect::<Vec<_>>();
+
+    // TODO: Report several seed fingerprints properly instead of describing them in
+    //       prose. `zcashd` had at most one mnemonic phrase per wallet, so this field is
+    //       shaped to hold one fingerprint; Zallet supports any number, and a caller
+    //       whose wallet holds several currently gets a sentence where it expects a
+    //       fingerprint. Replacing that case needs a field that can carry a list.
+    let mnemonic_seedfp = match seed_fps.as_slice() {
+        [seed_fp] => Some(seed_fp.to_string()),
+        // `zcashd` omitted this field when the wallet had no mnemonic, rather than
+        // reporting a placeholder; a wallet with no phrases has no fingerprint to give.
+        [] => None,
+        several => Some(format!(
+            "This wallet holds {} mnemonic phrases",
+            several.len()
+        )),
+    };
 
     let unlocked_until = if keystore.uses_encrypted_identities() {
         Some(
@@ -86,6 +120,6 @@ pub(crate) async fn call(keystore: &KeyStore) -> Response {
         keypoololdest: 0,
         keypoolsize: 0,
         unlocked_until,
-        mnemonic_seedfp: "TODO".into(),
+        mnemonic_seedfp,
     })
 }


### PR DESCRIPTION
`getwalletinfo`'s `mnemonic_seedfp` field returned the literal string `"TODO"`,
so a caller reading it got a value that was neither a fingerprint nor an error.
It now reports the wallet's real ZIP 32 seed fingerprint.

Part of #620, which lists this among the method's placeholder fields.

## How this surfaced, and why it only half helps

This came out of the `walletrequirebackup` work (#201, #728), where I went
looking for a way to discover a wallet's seed fingerprints and found there
isn't one. A seed with no accounts derived from it appears in no listing:
`z_listaccounts` derives each account's `seedfp` from its key derivation, so a
seed with no accounts cannot appear there, and `getwalletinfo` — the one place
that looks like it should answer the question — said `"TODO"`. The only place a
fingerprint is ever shown is the stdout of `generate-mnemonic` /
`import-mnemonic`, at the moment the phrase is created.

That matters because #728 puts the fingerprint on the critical path:
`export-mnemonic` and `confirm-backup` both need to name a seed. An operator
who has lost that terminal output cannot name it, and cannot derive accounts.

**This change does not fix that**, and it is worth being explicit about why. A
fingerprint is only *needed* when a wallet holds more than one phrase — with a
single phrase, every command falls back on it and nobody has to name anything.
But this field can only report a fingerprint when there is exactly one phrase;
with several it reports how many, because the `zcashd`-inherited field has room
for one value. So it gives you the fingerprint precisely when you do not need
it, and withholds it precisely when you do.

What it does fix is the narrower bug that the field lied: `"TODO"` is not a
fingerprint, and a caller had no way to know that. Closing the discoverability
gap properly needs somewhere that can carry a list — a `list-seeds` command, or
a field that reports every fingerprint — most likely alongside human-readable
names, since fingerprints are not what an operator wants to tell wallets apart
by. A `TODO` in the code marks the multi-phrase case as waiting on that.

## Behaviour

| Wallet holds | `mnemonic_seedfp` |
|---|---|
| one mnemonic phrase | the ZIP 32 seed fingerprint |
| no mnemonic phrases | the field is omitted |
| several phrases | `"This wallet holds N mnemonic phrases"` |

Omitting the field when there is no mnemonic matches `zcashd`, which pushed
`mnemonic_seedfp` only when `GetMnemonicHDChain()` had a value rather than
emitting a placeholder — the same treatment it gave the optional
`legacy_seedfp` beside it.

**One deliberate divergence from `zcashd`:** the fingerprint is reported in its
ZIP 32 bech32m encoding (`zip32seedfp1…`), matching Zallet's own
`z_listaccounts`, whereas `zcashd` reported the `uint256` hex form.
`parse_seedfp` accepts both on input, so this only affects what a caller reads.
Say if you would rather match `zcashd` exactly.

## Scope

This does not close #620. `walletversion`, `txcount`, `keypoololdest`,
`keypoolsize` and the balance fields are still placeholders, and item 1 of that
issue — dropping the balance fields so callers fail loudly rather than reading
zeros — is a design decision rather than a mechanical change.

Also updates the `getwalletinfo` row in the `zcashd` status matrix, which
claimed only `unlocked_until` was meaningful.
