### PR TITLE
rpc: Bind the signing key to the account record before signing (#642 item 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,16 @@ be considered breaking changes.
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
 
+### Changed
+
+- `z_sendmany`, `z_shieldcoinbase` and `z_sendfromaccount` now verify, after
+  decrypting the account's seed and before deriving the key they sign with, that
+  the seed actually derives the viewing key the wallet has recorded for that
+  account. Input selection runs against the account record while signing uses a
+  seed-derived key; a modified record could previously have the wallet select
+  one key's notes and sign with another's. A mismatch is reported as wallet
+  database corruption or tampering, and no transaction is created.
+
 ### Fixed
 
 - The queue of asynchronous RPC operations (`z_sendmany`, `z_shieldcoinbase`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,16 @@ be considered breaking changes.
   (`zip32seedfp1…`), as `z_listaccounts` already does, whereas `zcashd` reported
   the `uint256` hex form.
 
+### Changed
+
+- `z_sendmany`, `z_shieldcoinbase` and `z_sendfromaccount` now verify, after
+  decrypting the account's seed and before deriving the key they sign with, that
+  the seed actually derives the viewing key the wallet has recorded for that
+  account. Input selection runs against the account record while signing uses a
+  seed-derived key; a modified record could previously have the wallet select
+  one key's notes and sign with another's. A mismatch is reported as wallet
+  database corruption or tampering, and no transaction is created.
+
 ### Fixed
 
 - `migrate-zcashd-wallet` now marks the addresses of imported standalone

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -206,6 +206,10 @@ err-account-no-payment-source = Account has no payment source.
 
 ## Transaction verification errors
 
+err-account-seed-mismatch =
+    The seed held for account {$account} does not derive the viewing key the wallet has
+    recorded for it. The wallet database is corrupted or has been tampered with. No
+    transaction has been created.
 err-transparent-output-not-wallet-derived =
     The built transaction pays a transparent output ({$output}) that is neither a requested
     payment nor an address derived from the account's own key. The wallet database is

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -314,6 +314,10 @@ err-import-address-no-chain-state =
 
 ## Transaction verification errors
 
+err-account-seed-mismatch =
+    The seed held for account {$account} does not derive the viewing key the wallet has
+    recorded for it. The wallet database is corrupted or has been tampered with. No
+    transaction has been created.
 err-transparent-output-not-wallet-derived =
     The built transaction pays a transparent output ({$output}) that is neither a requested
     payment nor an address derived from the account's own key. The wallet database is

--- a/zallet-core/src/components/database/tests.rs
+++ b/zallet-core/src/components/database/tests.rs
@@ -330,7 +330,10 @@ fn validate_seed_accepts_only_the_accounts_own_seed() {
             );
 
             // A different seed derives a different key, so it must not validate against
-            // this account — this is the substitution the check exists to catch.
+            // this account. This pins that `validate_seed` returns `Ok(false)` for an
+            // unrelated seed, which is the semantics the spend path depends on. The
+            // actual substitution attack (same seed, swapped ufvk row) is exercised in
+            // `payments::spending_key_tests::spending_key_for_account_rejects_tampered_uivk`.
             assert!(
                 !handle.validate_seed(account_id, &other_seed).unwrap(),
                 "a seed that does not derive the account's key must be rejected",

--- a/zallet-core/src/components/database/tests.rs
+++ b/zallet-core/src/components/database/tests.rs
@@ -285,6 +285,59 @@ fn db_connection_forwards_ironwood_reads_and_tree_ops() {
         });
 }
 
+/// The spend paths bind the signing key to the account record by calling
+/// `validate_seed` between decrypting the seed and deriving the spending key (see
+/// `payments::spending_key_for_account`). That check is only meaningful if
+/// `validate_seed` answers "does this seed derive the key this account records" — so pin
+/// the semantics here rather than assuming them of the upstream crate.
+#[test]
+fn validate_seed_accepts_only_the_accounts_own_seed() {
+    crate::i18n::load_languages(&[]);
+
+    let datadir = tempdir().unwrap();
+    let config = test_config(datadir.path(), NetworkType::Test);
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(async {
+            use secrecy::SecretVec;
+            use zcash_client_backend::data_api::{AccountBirthday, WalletWrite, chain::ChainState};
+            use zcash_primitives::block::BlockHash;
+            use zcash_protocol::consensus::BlockHeight;
+
+            let db = database::Database::open(&config).await.unwrap();
+            let mut handle = db.handle().await.unwrap();
+
+            let seed = SecretVec::new(vec![0x5a; 32]);
+            let other_seed = SecretVec::new(vec![0xa5; 32]);
+
+            // Genesis birthday: no block precedes it, so an empty chain state anchored at
+            // the conventional all-zeros parent hash is correct (see
+            // `json_rpc::utils::fetch_account_birthday`).
+            let birthday = AccountBirthday::from_parts(
+                ChainState::empty(BlockHeight::from_u32(0), BlockHash([0; 32])),
+                None,
+            );
+            let (account_id, _) = handle
+                .create_account("test", &seed, &birthday, None)
+                .expect("creates a seed-derived account");
+
+            assert!(
+                handle.validate_seed(account_id, &seed).unwrap(),
+                "the seed the account was derived from must validate",
+            );
+
+            // A different seed derives a different key, so it must not validate against
+            // this account — this is the substitution the check exists to catch.
+            assert!(
+                !handle.validate_seed(account_id, &other_seed).unwrap(),
+                "a seed that does not derive the account's key must be rejected",
+            );
+        });
+}
+
 fn test_config(datadir: &std::path::Path, network_type: NetworkType) -> ZalletConfig {
     ZalletConfig {
         datadir: Some(datadir.to_path_buf()),

--- a/zallet-core/src/components/json_rpc/methods/pczt_sign.rs
+++ b/zallet-core/src/components/json_rpc/methods/pczt_sign.rs
@@ -228,6 +228,11 @@ pub(crate) async fn call(
     // seed (other than the wallet being locked) means this wallet does not hold
     // it — the multi-party case — and is treated like an absent hint rather
     // than a server fault.
+    //
+    // The seed is not bound to an account record here, as it is on the account-based
+    // spend paths (see `payments::spending_key_for_account`): the key is named by the
+    // PCZT's hints rather than by an account, so there is no record to bind it to.
+    // `z_sendfromaccount` binds before it drives this method over its own PCZT.
     let usk = match &hints {
         None => None,
         Some(hints) => match keystore.decrypt_seed(&hints.seed_fp).await {

--- a/zallet-core/src/components/json_rpc/methods/z_send_from_account.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_from_account.rs
@@ -7,10 +7,8 @@
 //! that flow only in doing it in one call and broadcasting the result.
 
 use jsonrpsee::core::{JsonValue, RpcResult};
-use secrecy::ExposeSecret;
 use zcash_client_backend::data_api::{Account, WalletRead};
 use zcash_encoding::ReverseHex;
-use zcash_keys::keys::UnifiedSpendingKey;
 use zcash_protocol::TxId;
 
 use super::pczt_common::encode_pczt_base64;
@@ -23,7 +21,7 @@ use crate::{
             fund_source::FundSource,
             payments::{
                 AmountParameter, SendResult, build_request, confirmations_policy_for_minconf,
-                parse_privacy_policy, verify_and_broadcast_transactions,
+                parse_privacy_policy, spending_key_for_account, verify_and_broadcast_transactions,
             },
             server::LegacyCode,
             utils::parse_account_parameter,
@@ -108,24 +106,9 @@ pub(crate) async fn call<C: Chain>(
         LegacyCode::InvalidAddressOrKey.with_message(fl!("err-account-no-payment-source"))
     })?;
 
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            // TODO: Improve internal error types.
-            //       https://github.com/zcash/zallet/issues/256
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
-        })?;
-    let ufvk = UnifiedSpendingKey::from_seed(
-        handle.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?
-    .to_unified_full_viewing_key();
+    let ufvk = spending_key_for_account(handle.as_ref(), &keystore, account.id(), derivation)
+        .await?
+        .to_unified_full_viewing_key();
 
     // The remaining steps acquire their own wallet handles; do not hold this
     // one across them.

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -3,7 +3,6 @@ use std::convert::Infallible;
 use abscissa_core::Application;
 
 use jsonrpsee::core::{JsonValue, RpcResult};
-use secrecy::ExposeSecret;
 use serde_json::json;
 use zcash_client_backend::data_api::wallet::SpendingKeys;
 use zcash_client_backend::proposal::Proposal;
@@ -19,10 +18,7 @@ use zcash_client_backend::{
     wallet::OvkPolicy,
 };
 use zcash_client_sqlite::{AccountUuid, ReceivedNoteId};
-use zcash_keys::{
-    address::Address,
-    keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
-};
+use zcash_keys::{address::Address, keys::UnifiedFullViewingKey};
 use zcash_proofs::prover::LocalTxProver;
 
 use crate::{
@@ -34,7 +30,8 @@ use crate::{
             payments::{
                 AmountParameter, SendResult, build_request, confirmations_policy_for_minconf,
                 get_account_for_address, get_legacy_pool_account, parse_privacy_policy,
-                propose_and_check, spend_policy_for, verify_and_broadcast_transactions,
+                propose_and_check, spend_policy_for, spending_key_for_account,
+                verify_and_broadcast_transactions,
             },
             server::LegacyCode,
         },
@@ -164,23 +161,8 @@ pub(crate) async fn call<C: Chain>(
     })?;
 
     // Fetch spending key last, to avoid a keystore decryption if unnecessary.
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            // TODO: Improve internal error types.
-            //       https://github.com/zcash/zallet/issues/256
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
-        })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+    let usk =
+        spending_key_for_account(wallet.as_ref(), &keystore, account.id(), derivation).await?;
 
     #[cfg(feature = "zcashd-import")]
     let standalone_keys =

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -6,7 +6,6 @@ use std::future::Future;
 use documented::Documented;
 use jsonrpsee::core::{JsonValue, RpcResult};
 use schemars::JsonSchema;
-use secrecy::ExposeSecret;
 use serde::Serialize;
 use transparent::address::TransparentAddress;
 use uuid::Uuid;
@@ -25,10 +24,7 @@ use zcash_client_backend::{
     wallet::OvkPolicy,
 };
 use zcash_client_sqlite::AccountUuid;
-use zcash_keys::{
-    address::Address,
-    keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
-};
+use zcash_keys::{address::Address, keys::UnifiedFullViewingKey};
 use zcash_proofs::prover::LocalTxProver;
 use zcash_protocol::{PoolType, value::Zatoshis};
 
@@ -39,7 +35,10 @@ use crate::{
         database::{DbConnection, DbHandle},
         json_rpc::{
             asyncop::{ContextInfo, OperationId},
-            payments::{PrivacyPolicy, SendResult, parse_memo, verify_and_broadcast_transactions},
+            payments::{
+                PrivacyPolicy, SendResult, parse_memo, spending_key_for_account,
+                verify_and_broadcast_transactions,
+            },
             server::LegacyCode,
             utils::{JsonZec, value_from_zatoshis},
         },
@@ -311,21 +310,7 @@ pub(crate) async fn call<C: Chain>(
             account_id.expose_uuid(),
         ))
     })?;
-    let seed = keystore
-        .decrypt_seed(derivation.seed_fingerprint())
-        .await
-        .map_err(|e| match e.kind() {
-            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
-                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
-            }
-            _ => LegacyCode::Database.with_message(e.to_string()),
-        })?;
-    let usk = UnifiedSpendingKey::from_seed(
-        wallet.params(),
-        seed.expose_secret(),
-        derivation.account_index(),
-    )
-    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))?;
+    let usk = spending_key_for_account(wallet.as_ref(), &keystore, account_id, derivation).await?;
 
     #[cfg(feature = "zcashd-import")]
     let standalone_keys =

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -25,7 +25,7 @@ use zcash_client_backend::{
     wallet::TransparentAddressSource,
     zip321::{Payment, TransactionRequest},
 };
-use zcash_client_sqlite::{AccountUuid, ReceivedNoteId, wallet::Account};
+use zcash_client_sqlite::{AccountUuid, ReceivedNoteId, error::SqliteClientError, wallet::Account};
 use zcash_keys::{
     address::Address,
     keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
@@ -168,11 +168,18 @@ pub(super) fn confirmations_policy_for_minconf(
 /// that gap by checking the recorded viewing key against the one this seed derives, and
 /// fails closed.
 ///
-/// `validate_seed` returns `Ok(false)` for a seed that does not derive the recorded key,
-/// and `Err(CorruptedData)` when the seed fingerprint matches but the viewing key does
-/// not (the real substitution attack: same seed, swapped ufvk row). Both are treated as
-/// corruption or tampering: the operation is refused with `err-account-seed-mismatch`
-/// and no spending key is derived.
+/// `validate_seed` reports a mismatch in two different ways and both must be caught.
+/// `Ok(false)` is neither the recorded seed fingerprint nor the recorded viewing key
+/// matching this seed; `Err(CorruptedData)` is exactly one of them matching. The
+/// substitution attack lands in the latter: `derivation` is read from the same account
+/// row being checked, so the seed is decrypted under that row's own fingerprint and the
+/// fingerprint always agrees, leaving a swapped `ufvk` as the sole disagreement. Both
+/// refuse the operation with `err-account-seed-mismatch`.
+///
+/// Any other error means the check could not be performed — a busy or unreadable
+/// database, a seed of unusable length — which is not evidence of tampering and is not
+/// reported as such. It still fails closed: a spending key is derived only if the check
+/// affirmatively passed.
 ///
 /// The check is free at every call site: the seed is decrypted here anyway, so no
 /// operation loads a secret it did not already load, and a locked wallet still fails at
@@ -197,11 +204,22 @@ pub(super) async fn spending_key_for_account(
 
     match wallet.validate_seed(account_id, &seed) {
         Ok(true) => {}
-        Ok(false) | Err(_) => {
+        Ok(false) | Err(SqliteClientError::CorruptedData(_)) => {
             return Err(LegacyCode::Wallet.with_message(fl!(
                 "err-account-seed-mismatch",
                 account = account_id.expose_uuid().to_string(),
             )));
+        }
+        Err(e) => {
+            // The seed could not be checked against the account. Report it as what it is
+            // rather than as tampering, but still refuse to sign: `CorruptedData` is the
+            // only error that means "the recorded key disagrees", so every other error
+            // leaves the binding unverified.
+            tracing::error!(
+                "Could not validate the seed for account {}: {e}",
+                account_id.expose_uuid(),
+            );
+            return Err(LegacyCode::Database.with_message(e.to_string()));
         }
     }
 

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -4,12 +4,13 @@ use abscissa_core::Application;
 use jsonrpsee::core::JsonValue;
 use jsonrpsee::{core::RpcResult, types::ErrorObjectOwned};
 use schemars::JsonSchema;
+use secrecy::ExposeSecret;
 use serde::{Deserialize, Serialize};
 use transparent::{address::TransparentAddress, keys::AccountPubKey};
 use zcash_address::{ZcashAddress, unified};
 use zcash_client_backend::{
     data_api::{
-        Account as _, WalletRead,
+        Account as _, WalletRead, Zip32Derivation,
         wallet::{
             ConfirmationsPolicy,
             input_selection::{GreedyInputSelector, SpendPolicy, TransparentSpendPolicy},
@@ -25,7 +26,10 @@ use zcash_client_backend::{
     zip321::{Payment, TransactionRequest},
 };
 use zcash_client_sqlite::{AccountUuid, ReceivedNoteId, wallet::Account};
-use zcash_keys::{address::Address, keys::UnifiedFullViewingKey};
+use zcash_keys::{
+    address::Address,
+    keys::{UnifiedFullViewingKey, UnifiedSpendingKey},
+};
 use zcash_protocol::{
     PoolType, ShieldedPool, TxId,
     memo::MemoBytes,
@@ -34,7 +38,7 @@ use zcash_protocol::{
 use zip32::{AccountId, fingerprint::SeedFingerprint};
 
 use crate::{
-    components::{chain::Chain, database::DbConnection},
+    components::{chain::Chain, database::DbConnection, keystore::KeyStore},
     fl,
     network::Network,
     prelude::APP,
@@ -152,6 +156,55 @@ pub(super) fn confirmations_policy_for_minconf(
             })
         }
     }
+}
+
+/// Decrypts the seed behind `derivation` and derives the spending key for `account_id`,
+/// requiring that the seed actually corresponds to the account it was fetched for.
+///
+/// Input selection runs against the account record in the wallet database, but signing
+/// uses a key derived from the seed. Those are the same key only if that record is intact,
+/// and it is not integrity-protected: a substituted `accounts.ufvk` would have the wallet
+/// select one key's notes and sign with another's. [`WalletRead::validate_seed`] closes
+/// that gap by checking the recorded viewing key against the one this seed derives, and
+/// fails closed.
+///
+/// The check is free at every call site: the seed is decrypted here anyway, so no
+/// operation loads a secret it did not already load, and a locked wallet still fails at
+/// the decryption step rather than at this one.
+pub(super) async fn spending_key_for_account(
+    wallet: &DbConnection,
+    keystore: &KeyStore,
+    account_id: AccountUuid,
+    derivation: &Zip32Derivation,
+) -> RpcResult<UnifiedSpendingKey> {
+    let seed = keystore
+        .decrypt_seed(derivation.seed_fingerprint())
+        .await
+        .map_err(|e| match e.kind() {
+            // TODO: Improve internal error types.
+            //       https://github.com/zcash/zallet/issues/256
+            crate::error::ErrorKind::Generic if e.to_string() == "Wallet is locked" => {
+                LegacyCode::WalletUnlockNeeded.with_message(e.to_string())
+            }
+            _ => LegacyCode::Database.with_message(e.to_string()),
+        })?;
+
+    if !wallet
+        .validate_seed(account_id, &seed)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+    {
+        return Err(LegacyCode::Wallet.with_message(fl!(
+            "err-account-seed-mismatch",
+            account = account_id.expose_uuid().to_string(),
+        )));
+    }
+
+    UnifiedSpendingKey::from_seed(
+        wallet.params(),
+        seed.expose_secret(),
+        derivation.account_index(),
+    )
+    .map_err(|e| LegacyCode::InvalidAddressOrKey.with_message(e.to_string()))
 }
 
 /// The sources of funds a transfer from `source` may draw upon.

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -168,6 +168,12 @@ pub(super) fn confirmations_policy_for_minconf(
 /// that gap by checking the recorded viewing key against the one this seed derives, and
 /// fails closed.
 ///
+/// `validate_seed` returns `Ok(false)` for a seed that does not derive the recorded key,
+/// and `Err(CorruptedData)` when the seed fingerprint matches but the viewing key does
+/// not (the real substitution attack: same seed, swapped ufvk row). Both are treated as
+/// corruption or tampering: the operation is refused with `err-account-seed-mismatch`
+/// and no spending key is derived.
+///
 /// The check is free at every call site: the seed is decrypted here anyway, so no
 /// operation loads a secret it did not already load, and a locked wallet still fails at
 /// the decryption step rather than at this one.
@@ -189,14 +195,14 @@ pub(super) async fn spending_key_for_account(
             _ => LegacyCode::Database.with_message(e.to_string()),
         })?;
 
-    if !wallet
-        .validate_seed(account_id, &seed)
-        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
-    {
-        return Err(LegacyCode::Wallet.with_message(fl!(
-            "err-account-seed-mismatch",
-            account = account_id.expose_uuid().to_string(),
-        )));
+    match wallet.validate_seed(account_id, &seed) {
+        Ok(true) => {}
+        Ok(false) | Err(_) => {
+            return Err(LegacyCode::Wallet.with_message(fl!(
+                "err-account-seed-mismatch",
+                account = account_id.expose_uuid().to_string(),
+            )));
+        }
     }
 
     UnifiedSpendingKey::from_seed(

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -2493,21 +2493,25 @@ mod spending_key_tests {
     use crate::config::ZalletConfig;
     use tempfile::tempdir;
     use zcash_client_backend::data_api::{
-        Account as _, WalletRead, WalletWrite, chain::ChainState,
+        Account as _, AccountBirthday, WalletRead, WalletWrite, chain::ChainState,
     };
+    use zcash_client_sqlite::error::SqliteClientError;
+    use zcash_keys::keys::UnifiedSpendingKey;
     use zcash_primitives::block::BlockHash;
     use zcash_protocol::consensus::{BlockHeight, NetworkType};
 
-    /// The real attack this check exists to catch: an attacker who can write to `wallet.db`
-    /// swaps the `ufvk` column of an account row to a different key's ufvk, while leaving the
-    /// `hd_seed_fingerprint` unchanged. Input selection reads the substituted ufvk and
-    /// selects notes the attacker chose; signing derives the USK from the real seed. Without
-    /// the check the wallet would spend the victim's notes under a key the attacker controls.
+    /// The attack this check exists to catch: someone who can write to `wallet.db` replaces
+    /// the `ufvk` column of an account row with a key they control, leaving
+    /// `hd_seed_fingerprint` untouched. Input selection then runs against the substituted
+    /// key while signing derives the USK from the real seed, so the wallet would spend under
+    /// a key the account does not name.
     ///
-    /// Upstream `validate_seed` returns `Err(CorruptedData)` for this case (seed fingerprint
-    /// matches but the derived viewing key does not match the recorded one), not `Ok(false)`.
-    /// This test proves the helper surfaces that as `err-account-seed-mismatch` rather than
-    /// a generic database error, and that no spending key is derived.
+    /// Leaving the fingerprint intact is what makes this the interesting case.
+    /// `spending_key_for_account` decrypts the seed under that same fingerprint, so the
+    /// fingerprint always agrees and the viewing key is the only disagreement — which
+    /// upstream `validate_seed` reports as `Err(CorruptedData)`, never `Ok(false)`. Both
+    /// halves are pinned here: that upstream still answers this way, and that the helper
+    /// turns that answer into `err-account-seed-mismatch` rather than a database error.
     #[test]
     fn spending_key_for_account_rejects_tampered_uivk() {
         crate::i18n::load_languages(&[]);
@@ -2517,21 +2521,12 @@ mod spending_key_tests {
         ks_testing::run_async(|| async {
             let keystore = ks_testing::keystore(&datadir).await;
 
-            // Account 1: seed derived from mnemonic A.
-            let seed_fp_a = keystore
+            let seed_fp = keystore
                 .encrypt_and_store_mnemonic(ks_testing::phrase([0x5a; 32]), BackupStatus::Confirmed)
                 .await
                 .unwrap();
-            let seed_a = keystore.decrypt_seed(&seed_fp_a).await.unwrap();
+            let seed = keystore.decrypt_seed(&seed_fp).await.unwrap();
 
-            // Account 2: seed derived from mnemonic B.
-            let seed_fp_b = keystore
-                .encrypt_and_store_mnemonic(ks_testing::phrase([0xa5; 32]), BackupStatus::Confirmed)
-                .await
-                .unwrap();
-            let seed_b = keystore.decrypt_seed(&seed_fp_b).await.unwrap();
-
-            // Open a separate connection to the same wallet DB for the spend-path call.
             let config = ZalletConfig {
                 datadir: Some(datadir.path().to_path_buf()),
                 consensus: crate::config::ConsensusSection {
@@ -2549,95 +2544,65 @@ mod spending_key_tests {
                 .unwrap();
             let mut handle = db.handle().await.unwrap();
 
-            let birthday = zcash_client_backend::data_api::AccountBirthday::from_parts(
+            // Genesis birthday, as in `database::tests`: no block precedes it.
+            let birthday = AccountBirthday::from_parts(
                 ChainState::empty(BlockHeight::from_u32(0), BlockHash([0; 32])),
                 None,
             );
+            let (account_id, _) = handle
+                .create_account("account", &seed, &birthday, None)
+                .expect("creates a seed-derived account");
 
-            let (account_id_a, _) = handle
-                .create_account("account_a", &seed_a, &birthday, None)
-                .expect("creates account A");
-            let (account_id_b, _) = handle
-                .create_account("account_b", &seed_b, &birthday, None)
-                .expect("creates account B");
-
-            // Derivation for account A (the real seed fingerprint + account index).
-            let account_a = handle.get_account(account_id_a).unwrap().unwrap();
-            let derivation = account_a
+            let account = handle.get_account(account_id).unwrap().unwrap();
+            let derivation = account
                 .source()
                 .key_derivation()
-                .expect("account A is seed-derived")
+                .expect("the account is seed-derived")
                 .clone();
 
-            // Positive case: the intact account validates and returns a spending key.
-            let usk =
-                spending_key_for_account(handle.as_ref(), &keystore, account_id_a, &derivation)
-                    .await;
-            assert!(usk.is_ok(), "an intact account must yield a spending key");
+            // Intact: the account validates and the spend path yields a key.
+            spending_key_for_account(handle.as_ref(), &keystore, account_id, &derivation)
+                .await
+                .expect("an intact account must yield a spending key");
 
-            // Tamper: replace account A's ufvk with account B's, leaving the seed
-            // fingerprint unchanged. This is the real attack: same seed, swapped viewing
-            // key row. `parse_account_row` reads `ufvk` first (falling back to `uivk` only
-            // when `ufvk` is NULL), so the UFVK is the column that drives the comparison in
-            // `validate_seed`. Account B is deleted first to avoid the ufvk UNIQUE
-            // constraint.
-            //
-            // Drop the handle first so the pool connection is released, then tamper on
-            // a fresh connection and re-acquire a handle so the pool sees the change.
-            drop(handle);
+            // Tamper, on the pooled connection the spend path itself reads through: overwrite
+            // `ufvk` with a key derived from an unrelated seed at the same account index, and
+            // leave `hd_seed_fingerprint` alone. `parse_account_row` prefers `ufvk` and falls
+            // back to `uivk` only when `ufvk` is NULL, so this is the column that drives the
+            // comparison in `validate_seed`.
+            handle.as_ref().with_raw_mut(|conn, params| {
+                let foreign_ufvk =
+                    UnifiedSpendingKey::from_seed(params, &[0xa5; 32], derivation.account_index())
+                        .expect("derives a key from an unrelated seed")
+                        .to_unified_full_viewing_key()
+                        .encode(params);
 
-            let db_path = config.wallet_db_path();
-            let tamper_conn = rusqlite::Connection::open(&db_path).unwrap();
-
-            let ufvk_b: String = tamper_conn
-                .query_row(
-                    "SELECT ufvk FROM accounts WHERE uuid = ?",
-                    [&account_id_b.expose_uuid()],
-                    |row| row.get(0),
-                )
-                .unwrap();
-
-            tamper_conn
-                .execute(
-                    "DELETE FROM accounts WHERE uuid = ?",
-                    [&account_id_b.expose_uuid()],
-                )
-                .unwrap();
-            tamper_conn
-                .execute(
+                conn.execute(
                     "UPDATE accounts SET ufvk = ? WHERE uuid = ?",
-                    rusqlite::params![ufvk_b, account_id_a.expose_uuid()],
+                    rusqlite::params![foreign_ufvk, account_id.expose_uuid()],
                 )
-                .unwrap();
-            drop(tamper_conn);
-
-            let handle = db.handle().await.unwrap();
-
-            // Verify the tamper is visible to the pool connection.
-            let visible_ufvk: String = handle.as_ref().with_raw(|conn, _| {
-                conn.query_row(
-                    "SELECT ufvk FROM accounts WHERE uuid = ?",
-                    [&account_id_a.expose_uuid()],
-                    |row| row.get(0),
-                )
-                .unwrap()
+                .expect("substitutes the account's recorded viewing key");
             });
+
+            // Upstream must still classify this as corruption rather than `Ok(false)`; the
+            // helper's mapping is written against that classification.
             assert!(
-                visible_ufvk == ufvk_b,
-                "tamper not visible: expected account A's ufvk to be B's, got {visible_ufvk}",
+                matches!(
+                    handle.as_ref().validate_seed(account_id, &seed),
+                    Err(SqliteClientError::CorruptedData(_)),
+                ),
+                "a swapped ufvk over an intact seed fingerprint must report corruption",
             );
 
-            // The tampered account must be rejected with the tamper message, not a generic
-            // database error.
-            let err =
-                spending_key_for_account(handle.as_ref(), &keystore, account_id_a, &derivation)
-                    .await
-                    .expect_err("a tampered ufvk must be rejected");
+            // And the spend path must surface it as tampering, not as a database error.
+            let err = spending_key_for_account(handle.as_ref(), &keystore, account_id, &derivation)
+                .await
+                .expect_err("a tampered ufvk must be rejected");
 
-            let msg = err.message();
             assert!(
-                msg.contains("does not derive the viewing key"),
-                "expected the tamper message, got: {msg}",
+                err.message().contains("does not derive the viewing key"),
+                "expected the tamper message, got: {}",
+                err.message(),
             );
         });
     }

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -2467,3 +2467,160 @@ mod proposal_policy_tests {
         assert_eq!(check_shielded_action_limits(&proposal, 2), Ok(()));
     }
 }
+
+#[cfg(all(test, zallet_build = "wallet"))]
+mod spending_key_tests {
+    use super::spending_key_for_account;
+    use crate::components::keystore::{BackupStatus, testing as ks_testing};
+    use crate::config::ZalletConfig;
+    use tempfile::tempdir;
+    use zcash_client_backend::data_api::{
+        Account as _, WalletRead, WalletWrite, chain::ChainState,
+    };
+    use zcash_primitives::block::BlockHash;
+    use zcash_protocol::consensus::{BlockHeight, NetworkType};
+
+    /// The real attack this check exists to catch: an attacker who can write to `wallet.db`
+    /// swaps the `ufvk` column of an account row to a different key's ufvk, while leaving the
+    /// `hd_seed_fingerprint` unchanged. Input selection reads the substituted ufvk and
+    /// selects notes the attacker chose; signing derives the USK from the real seed. Without
+    /// the check the wallet would spend the victim's notes under a key the attacker controls.
+    ///
+    /// Upstream `validate_seed` returns `Err(CorruptedData)` for this case (seed fingerprint
+    /// matches but the derived viewing key does not match the recorded one), not `Ok(false)`.
+    /// This test proves the helper surfaces that as `err-account-seed-mismatch` rather than
+    /// a generic database error, and that no spending key is derived.
+    #[test]
+    fn spending_key_for_account_rejects_tampered_uivk() {
+        crate::i18n::load_languages(&[]);
+
+        let datadir = tempdir().unwrap();
+
+        ks_testing::run_async(|| async {
+            let keystore = ks_testing::keystore(&datadir).await;
+
+            // Account 1: seed derived from mnemonic A.
+            let seed_fp_a = keystore
+                .encrypt_and_store_mnemonic(ks_testing::phrase([0x5a; 32]), BackupStatus::Confirmed)
+                .await
+                .unwrap();
+            let seed_a = keystore.decrypt_seed(&seed_fp_a).await.unwrap();
+
+            // Account 2: seed derived from mnemonic B.
+            let seed_fp_b = keystore
+                .encrypt_and_store_mnemonic(ks_testing::phrase([0xa5; 32]), BackupStatus::Confirmed)
+                .await
+                .unwrap();
+            let seed_b = keystore.decrypt_seed(&seed_fp_b).await.unwrap();
+
+            // Open a separate connection to the same wallet DB for the spend-path call.
+            let config = ZalletConfig {
+                datadir: Some(datadir.path().to_path_buf()),
+                consensus: crate::config::ConsensusSection {
+                    network: NetworkType::Test,
+                    ..Default::default()
+                },
+                keystore: crate::config::KeyStoreSection {
+                    encryption_identity: Some(datadir.path().join("encryption-identity.txt")),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let db = crate::components::database::Database::open(&config)
+                .await
+                .unwrap();
+            let mut handle = db.handle().await.unwrap();
+
+            let birthday = zcash_client_backend::data_api::AccountBirthday::from_parts(
+                ChainState::empty(BlockHeight::from_u32(0), BlockHash([0; 32])),
+                None,
+            );
+
+            let (account_id_a, _) = handle
+                .create_account("account_a", &seed_a, &birthday, None)
+                .expect("creates account A");
+            let (account_id_b, _) = handle
+                .create_account("account_b", &seed_b, &birthday, None)
+                .expect("creates account B");
+
+            // Derivation for account A (the real seed fingerprint + account index).
+            let account_a = handle.get_account(account_id_a).unwrap().unwrap();
+            let derivation = account_a
+                .source()
+                .key_derivation()
+                .expect("account A is seed-derived")
+                .clone();
+
+            // Positive case: the intact account validates and returns a spending key.
+            let usk =
+                spending_key_for_account(handle.as_ref(), &keystore, account_id_a, &derivation)
+                    .await;
+            assert!(usk.is_ok(), "an intact account must yield a spending key");
+
+            // Tamper: replace account A's ufvk with account B's, leaving the seed
+            // fingerprint unchanged. This is the real attack: same seed, swapped viewing
+            // key row. `parse_account_row` reads `ufvk` first (falling back to `uivk` only
+            // when `ufvk` is NULL), so the UFVK is the column that drives the comparison in
+            // `validate_seed`. Account B is deleted first to avoid the ufvk UNIQUE
+            // constraint.
+            //
+            // Drop the handle first so the pool connection is released, then tamper on
+            // a fresh connection and re-acquire a handle so the pool sees the change.
+            drop(handle);
+
+            let db_path = config.wallet_db_path();
+            let tamper_conn = rusqlite::Connection::open(&db_path).unwrap();
+
+            let ufvk_b: String = tamper_conn
+                .query_row(
+                    "SELECT ufvk FROM accounts WHERE uuid = ?",
+                    [&account_id_b.expose_uuid()],
+                    |row| row.get(0),
+                )
+                .unwrap();
+
+            tamper_conn
+                .execute(
+                    "DELETE FROM accounts WHERE uuid = ?",
+                    [&account_id_b.expose_uuid()],
+                )
+                .unwrap();
+            tamper_conn
+                .execute(
+                    "UPDATE accounts SET ufvk = ? WHERE uuid = ?",
+                    rusqlite::params![ufvk_b, account_id_a.expose_uuid()],
+                )
+                .unwrap();
+            drop(tamper_conn);
+
+            let handle = db.handle().await.unwrap();
+
+            // Verify the tamper is visible to the pool connection.
+            let visible_ufvk: String = handle.as_ref().with_raw(|conn, _| {
+                conn.query_row(
+                    "SELECT ufvk FROM accounts WHERE uuid = ?",
+                    [&account_id_a.expose_uuid()],
+                    |row| row.get(0),
+                )
+                .unwrap()
+            });
+            assert!(
+                visible_ufvk == ufvk_b,
+                "tamper not visible: expected account A's ufvk to be B's, got {visible_ufvk}",
+            );
+
+            // The tampered account must be rejected with the tamper message, not a generic
+            // database error.
+            let err =
+                spending_key_for_account(handle.as_ref(), &keystore, account_id_a, &derivation)
+                    .await
+                    .expect_err("a tampered ufvk must be rejected");
+
+            let msg = err.message();
+            assert!(
+                msg.contains("does not derive the viewing key"),
+                "expected the tamper message, got: {msg}",
+            );
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Implements **item 2 of #642**, which was closed by #643 after landing only items 1 and 3.

Input selection runs against the account record in `wallet.db`; signing uses a key derived from the decrypted seed. Those are the same key only if that record is intact, and it is not integrity-protected — a modified `accounts.ufvk` would have the wallet select one key's notes and sign with another's, and nothing checks.

`WalletRead::validate_seed` exists for precisely this and was never wired up: on `main` it is reachable only as a trait-forwarding shim on `DbConnection` (`connection.rs:223-228`) called from nowhere. This calls it between decrypting the seed and deriving the spending key, and fails closed.

## What changed

All three account-based spend paths repeated the same block — resolve the derivation, decrypt the seed, derive the USK — with slightly different error mapping. That is now `payments::spending_key_for_account`, with the check in one place:

- `z_sendmany` (`z_send_many.rs`)
- `z_shieldcoinbase` (`z_shieldcoinbase.rs`)
- `z_sendfromaccount` (`z_send_from_account.rs`)

Net effect on those three files is −16, −18 and −15 lines respectively; the shared helper is the only place the check can be forgotten.

## How a mismatch is reported

Upstream `validate_seed` signals a mismatch in two different shapes, and getting this wrong makes the check silently useless:

- `Ok(false)` — neither the recorded seed fingerprint nor the recorded viewing key matches the seed.
- `Err(CorruptedData)` — **exactly one** of them matches.

The substitution attack always lands in the second. `derivation` is read from the same account row being validated, so the seed is decrypted under that row's own `hd_seed_fingerprint`; the fingerprint therefore always agrees, leaving a swapped `ufvk` as the sole disagreement. An earlier revision of this PR only handled `Ok(false)` and mapped the error arm to `LegacyCode::Database`, which meant `err-account-seed-mismatch` was effectively unreachable on the real attack path — the operator saw `Data DB is corrupted: Seed fingerprint match: true, uivk match: false` instead.

Both shapes now report `err-account-seed-mismatch`, phrased like the existing tamper-detection errors: *"The wallet database is corrupted or has been tampered with. No transaction has been created."*

Every other error — a busy or unreadable database, a seed of unusable length — is **not** treated as tampering, since that message opens by asserting the recorded key disagrees, which in those cases is untrue. Those surface as `LegacyCode::Database` and are logged. The check still fails closed either way: `CorruptedData` is the only error meaning "the recorded key disagrees", so anything else leaves the binding unverified and no spending key is derived.

## Why `pczt_sign` is excluded

`pczt_sign` resolves its key from the PCZT's signing hints (`hints.seed_fp`, `hints.account_idx`), not from an account — there is no account record to bind the seed to, so `validate_seed` has no applicable argument. It also deliberately tolerates "this wallet does not hold that seed" as the multi-party co-signing case, which a naive check would break.

`z_sendfromaccount` drives `pczt_sign` over its own PCZT and binds before doing so, so the one-shot path is covered. A comment at the hint-resolution site records this.

## Cost

None at any call site. The seed is already decrypted at each one, so no operation loads a secret it did not already load — the constraint #642 set for these checks. A locked wallet still fails at the decryption step, not at this one. View-only and imported accounts are unaffected: they hard-fail earlier at `key_derivation()`.

## Testing

Two tests, pinning the two halves of the behaviour the helper depends on:

- `validate_seed_accepts_only_the_accounts_own_seed` (`components/database/tests.rs`) pins the `Ok(false)` semantics for an unrelated seed, so the fail-closed branch is the one that runs.
- `spending_key_for_account_rejects_tampered_uivk` (`components/json_rpc/payments.rs`) exercises the actual attack: it overwrites an account's `ufvk` with a key derived from an unrelated seed at the same account index, leaving `hd_seed_fingerprint` intact. It asserts both that upstream still classifies this as `Err(CorruptedData)` and that the spend path surfaces it as the tamper message rather than a generic database error.

Together these catch an upstream change of meaning rather than letting it silently turn the check into a no-op.

- `cargo test -p zallet-core --lib --all-features` — 422 passed, 0 failed
- `cargo fmt --check` and `cargo clippy --all-targets` clean
- Test build clean under both `zallet_build = "wallet"` and `zallet_build = "merchant_terminal"`

## Note on #642

#642 is closed but items **2** (this PR) and **4** (the age recipient set) were never implemented. Item 4 remains open after this lands; the issue is worth reopening or splitting so the remaining item is tracked somewhere visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qug9tBVf49c97BX6JbQwk4
