### PR TITLE
cli: Lock the data directory during zcashd wallet migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -261,6 +261,12 @@ be considered breaking changes.
   `generate-mnemonic`) rather than failing initialization. `@`-prefixed
   recipient entries are rejected, as indirection through external sources
   cannot be part of the wallet's stored recipient set.
+- `migrate-zcashd-wallet` now acquires the data directory lock for the duration
+  of the migration. It writes accounts and transparent key material into the
+  same wallet database `zallet start` uses, so running the two concurrently
+  could interleave writes; the command now reports that Zallet is already
+  running instead.
+
 - The queue of asynchronous RPC operations (`z_sendmany`, `z_shieldcoinbase`)
   is now bounded (GHSA-3wr9-v982-59fj). Finished operations are still retained
   until collected with `z_getoperationresult`, but once the queue reaches its

--- a/zallet-core/src/commands.rs
+++ b/zallet-core/src/commands.rs
@@ -361,4 +361,60 @@ mod tests {
             PathBuf::from("/etc/zallet/zallet.toml"),
         );
     }
+
+    /// The lock is exclusive while its guard is alive, and released once the guard is
+    /// dropped. Commands bind it as `let _lock = ...` for exactly this reason; binding
+    /// it as `let _ = ...` would drop it immediately and silently lock nothing.
+    #[test]
+    fn datadir_lock_is_released_when_its_guard_is_dropped() {
+        let datadir = tempfile::tempdir().expect("creates tempdir");
+
+        let guard = lock_datadir(datadir.path()).expect("locks an unlocked datadir");
+        assert!(
+            lock_datadir(datadir.path()).is_err(),
+            "the datadir must not be lockable while a guard is held",
+        );
+
+        drop(guard);
+        lock_datadir(datadir.path()).expect("the datadir is lockable again once released");
+    }
+
+    /// A command that takes the lock and then fails must not leave the datadir locked;
+    /// `migrate-zcashd-wallet` returns early on several paths (e.g. the beta-code guard)
+    /// after acquiring it.
+    #[test]
+    fn datadir_lock_is_released_when_its_holder_returns_early() {
+        let datadir = tempfile::tempdir().expect("creates tempdir");
+
+        fn locks_then_fails(datadir: &Path) -> Result<(), Error> {
+            let _lock = lock_datadir(datadir)?;
+            Err(ErrorKind::Generic
+                .context("simulated command failure".to_owned())
+                .into())
+        }
+
+        assert!(locks_then_fails(datadir.path()).is_err());
+        lock_datadir(datadir.path()).expect("the early return released the lock");
+    }
+
+    /// Dropping a cancelled future drops the locals it is holding, so a command
+    /// interrupted mid-migration (Ctrl-C, runtime shutdown) releases the lock too.
+    #[tokio::test]
+    async fn datadir_lock_is_released_when_its_holding_future_is_cancelled() {
+        let datadir = tempfile::tempdir().expect("creates tempdir");
+
+        let holds_lock_forever = async {
+            let _lock = lock_datadir(datadir.path()).expect("locks an unlocked datadir");
+            std::future::pending::<()>().await;
+        };
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), holds_lock_forever)
+                .await
+                .is_err(),
+            "the future must still be holding the lock when it is cancelled",
+        );
+
+        lock_datadir(datadir.path()).expect("cancelling the holder released the lock");
+    }
 }

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -58,6 +58,12 @@ impl MigrateZcashdWalletCmd {
     pub(crate) async fn run_with<F: ChainFactory>(&self, factory: &F) -> Result<(), Error> {
         let config = APP.config();
 
+        // Hold the data directory lock for the whole migration. This command writes
+        // accounts, transparent key material and exposure information into the same
+        // wallet database that `zallet start` uses, so running the two concurrently
+        // would interleave writes into a wallet neither had exclusive use of.
+        let _lock = config.lock_datadir()?;
+
         if !self.this_is_beta_code_and_you_will_need_to_redo_the_migration_later {
             return Err(ErrorKind::Generic.context(fl!("migrate-beta-code")).into());
         }


### PR DESCRIPTION
## Summary

`migrate-zcashd-wallet` was the only command that writes to the wallet database without holding the data directory lock.

Every other mutating command takes it — `start` (`start.rs:28`), `generate-mnemonic`, `import-mnemonic`, `export-mnemonic`, `init-wallet-encryption` — but the migration, which writes accounts, transparent key material and exposure information into that same database, did not. Running it alongside a live `zallet start` interleaved writes into a database neither process had exclusive use of.

## Change

One `config.lock_datadir()?` at the top of `MigrateZcashdWalletCmd::run_with`, bound for the whole function so the lock is held for the entire migration rather than just the opening.

## Notes

- **Behaviour change:** running the migration while another Zallet instance holds the datadir now fails with the existing `err-init-zallet-already-running` message instead of proceeding. That is the intent — it is the same guard every other wallet-writing command already applies.
- No double-lock risk: `run_with` is reached only via `AsyncRunnable::run` → `chain_runtime().run_migrate_zcashd_wallet()`, and nothing on that path takes the lock. It is the only `lock_datadir` call in the file.
- `lock_datadir` also restricts the datadir to `0700`, so a migration into a fresh datadir now gets the same permissions as one created by any other command.

## Testing

`cargo test -p zallet-core --lib --all-features` — 331 passed, 0 failed. `cargo fmt --check` and `cargo clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2qGvpzxEM1Vk1XNEz7Xg1
