### PR TITLE
rpc: Report whether transactions were broadcast; warn on inert external settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,19 @@ be considered breaking changes.
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
 
+### Changed
+
+- The `z_sendmany`, `z_shieldcoinbase` and `z_sendfromaccount` operation results
+  now include a `broadcast` field reporting whether the transactions were
+  submitted to the network. It is `false` when `external.broadcast` is disabled:
+  the transactions are still built and recorded in the wallet (marking their
+  inputs pending-spent), but nothing else in the response distinguished that
+  from a completed send.
+- `zallet start` now warns that `external.export_dir` and `external.notify` are
+  set but not yet implemented, alongside the other not-yet-implemented options
+  it already reports. Both are accepted, documented, and migrated from `zcashd`
+  configuration, so a migrated wallet previously lost the behaviour silently.
+
 ### Fixed
 
 - The queue of asynchronous RPC operations (`z_sendmany`, `z_shieldcoinbase`)

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -156,6 +156,12 @@ Changes to parameters:
 Changes to response:
 - New `txids` array field in response.
 - `txid` field is omitted if `txids` has length greater than 1.
+- New `broadcast` boolean field, reporting whether the transactions were
+  submitted to the network. It is `false` when the `external.broadcast` config
+  option is disabled, in which case the transactions were built and recorded in
+  the wallet but never sent. `zcashd` had no equivalent setting, so a client
+  that treats a successful operation as "the payment is on its way" should check
+  this field.
 
 ## Omitted RPC methods
 

--- a/zallet-core/src/commands/start.rs
+++ b/zallet-core/src/commands/start.rs
@@ -43,6 +43,14 @@ impl StartCmd {
         if config.keystore.require_backup.is_some() {
             warn_unused("keystore.require_backup");
         }
+        // These are accepted, documented, and migrated from zcashd config, but nothing
+        // reads them at runtime, so a migrated wallet silently loses the behaviour.
+        if config.external.export_dir.is_some() {
+            warn_unused("external.export_dir");
+        }
+        if config.external.notify.is_some() {
+            warn_unused("external.notify");
+        }
 
         let db = Database::open(&config).await?;
         #[cfg(zallet_build = "wallet")]

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -1367,7 +1367,8 @@ pub(super) async fn verify_and_broadcast_transactions<C: Chain, FeeRuleT, NoteRe
         transactions.push(tx);
     }
 
-    if APP.config().external.broadcast() {
+    let broadcast = APP.config().external.broadcast();
+    if broadcast {
         for tx in &transactions {
             chain.broadcast_transaction(tx).await.map_err(|e| {
                 LegacyCode::Wallet
@@ -1376,7 +1377,7 @@ pub(super) async fn verify_and_broadcast_transactions<C: Chain, FeeRuleT, NoteRe
         }
     }
 
-    Ok(SendResult::new(txids))
+    Ok(SendResult::new(txids, broadcast))
 }
 
 /// The result of sending a payment.
@@ -1389,12 +1390,24 @@ pub(crate) struct SendResult {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     txid: Option<String>,
 
-    /// The IDs of the sent transactions resulting from the payment.
+    /// The IDs of the transactions resulting from the payment.
+    ///
+    /// These are created and recorded in the wallet regardless of whether they were
+    /// broadcast; see [`SendResult::broadcast`].
     txids: Vec<String>,
+
+    /// Whether the transactions were submitted to the network.
+    ///
+    /// `false` when the `external.broadcast` config option is disabled: the
+    /// transactions were built and recorded in the wallet, marking their inputs
+    /// pending-spent, but never sent. Nothing else in this response distinguishes that
+    /// from a completed send, so a client that treats a successful operation as "the
+    /// payment is on its way" must check this field.
+    broadcast: bool,
 }
 
 impl SendResult {
-    fn new(txids: Vec<TxId>) -> Self {
+    fn new(txids: Vec<TxId>, broadcast: bool) -> Self {
         let txids = txids
             .into_iter()
             .map(|txid| txid.to_string())
@@ -1403,6 +1416,7 @@ impl SendResult {
         Self {
             txid: (txids.len() == 1).then(|| txids.first().expect("present").clone()),
             txids,
+            broadcast,
         }
     }
 }


### PR DESCRIPTION
## Summary

Two places the wallet quietly did less than the operator asked for.

## 1. An unbroadcast transaction looked exactly like a sent one

When `external.broadcast` is disabled, `verify_and_broadcast_transactions` skips network submission but returns the same `SendResult` a completed send returns — same txids, same successful operation. The transactions *are* built and recorded in the wallet, so their inputs are marked pending-spent and the balance moves.

Nothing in the response distinguished the two states, and the `txids` field was documented as "the IDs of the **sent** transactions", which is untrue in this mode. An integration polling `z_getoperationresult` could reasonably conclude a payment was on its way when nothing had been submitted.

`SendResult` now carries a `broadcast: bool`, and the `txids` doc no longer claims they were sent.

```json
{ "txid": "abc…", "txids": ["abc…"], "broadcast": false }
```

Additive to the JSON, so clients that ignore unknown fields are unaffected. It applies to `z_sendmany`, `z_shieldcoinbase` and `z_sendfromaccount`, which share this result type. Documented in the `zcashd` compatibility page alongside the other `z_sendmany` response differences.

I made the field always present rather than only emitting it when `false`: `external.broadcast` defaults to `true`, so a sometimes-absent field would be missing in almost every response and easy to never notice — which defeats the point.

## 2. `external.export_dir` and `external.notify` are inert

Both are accepted by the config parser, documented, and **migrated from `zcashd` configuration** by `migrate-zcash-conf` — but no runtime code reads either. An operator migrating from `zcashd` loses the behaviour with no indication.

`start.rs` already has a `warn_unused` closure for exactly this, covering `builder.spend_zeroconf_change`, `builder.tx_expiry_delta` and `keystore.require_backup`. These two now join it.

## Testing

- `cargo test -p zallet-core --lib --all-features` — 331 passed, 0 failed
- `cargo test -p zallet-core --test book_rpc_reference` — passes; the generated RPC reference is unaffected by the new field
- `cargo fmt --check` and `cargo clippy` clean

Neither change alters transaction construction or any spend decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L2qGvpzxEM1Vk1XNEz7Xg1
