### PR TITLE
Add `zallet import-address` CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,9 @@ be considered breaking changes.
 ### Changed
 
 - MSRV updated to 1.95.
+- Opening the wallet database now applies a schema migration adding support
+  for watch-only transparent addresses imported without key material.
+  Downgrading to an earlier Zallet release afterwards is not supported.
 - `zallet rpc help` is now answered locally instead of being sent to the
   wallet's JSON-RPC server, so it no longer requires a config file, an
   initialized wallet, or a running `zallet start`. The command argument may

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ be considered breaking changes.
 
 ### Added
 
+- `zallet import-address` CLI command for importing a transparent address as
+  watch-only, given the bare address string, its hex-encoded public key
+  (P2PKH), or its redeem script (P2SH). A bare-address import stores no key
+  material; importing the corresponding public key or redeem script later
+  upgrades it in place. The address is imported into the legacy `zcashd`
+  account (per `features.legacy_pool_seed_fingerprint`) unless `--account`
+  names another account. By default the command queues a rescan from the
+  account's birthday so the next `zallet start` discovers the address's
+  history; `--no-rescan` skips this and does not require the chain backend to
+  be reachable. This encompasses the behavior of `zcashd`'s `importaddress`
+  and of the `z_importaddress` JSON-RPC method. Funds received by an address
+  imported without key material contribute to account balances but are never
+  selected for spending.
 - A global sync lock that blocks wallet usage while Zallet’s view of the chain
   is not trustworthy. The balance and spend RPC methods (`z_getbalances`,
   `z_getbalanceforaccount`, `z_gettotalbalance`, `z_listunspent`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,8 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1375,8 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3175,9 +3173,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+version = "0.9.2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3197,7 +3194,7 @@ dependencies = [
  "serde_with",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -5822,7 +5819,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_spec",
  "zcash_transparent 0.10.0",
@@ -5848,22 +5845,20 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ace878c125814bb9e82228d3661499124c6f2936e60fc1df3c6876eb54624"
+version = "0.24.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5906,7 +5901,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zip32",
@@ -5915,9 +5910,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a789c0038359968f93bfe3952d2b942e3bae5582f79c2f31137c6fd736a225"
+version = "0.22.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5933,6 +5927,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard 0.15.3",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -5957,7 +5952,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_pool_migration",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zewif",
@@ -6009,8 +6004,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6034,7 +6028,7 @@ dependencies = [
  "tracing",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_transparent 0.10.0",
  "zeroize",
  "zip32",
@@ -6055,10 +6049,10 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9010904169a92805128b3a8eab0dd4ff79fd164dd416af68aaeac5c7ebbd2522"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -6070,7 +6064,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zip32",
 ]
 
@@ -6107,8 +6101,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6130,7 +6123,7 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -6138,8 +6131,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6173,9 +6165,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f074493fff337207e28bcfa5bbdf0e2a125c4203a4bdd07e72067eea81e9e7b"
+version = "0.10.4"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "corez",
  "document-features",
@@ -6238,8 +6229,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bip32",
  "bs58",
@@ -6254,7 +6244,7 @@ dependencies = [
  "subtle",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -6418,14 +6408,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address 0.13.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,8 +158,8 @@ schemerz-rusqlite = "0.370.0"
 shardtree = "0.7"
 time = "0.3"
 uuid = "1"
-zcash_client_backend = "=0.24.0-rc.6"
-zcash_client_sqlite = "=0.22.0-rc.6"
+zcash_client_backend = "=0.24.0-rc.7"
+zcash_client_sqlite = "=0.22.0-rc.7"
 zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
@@ -175,3 +175,24 @@ tonic = "0.14"
 
 [profile.release]
 debug = "line-tables-only"
+
+[patch.crates-io]
+# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
+# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
+# which `zallet import-address` uses to track watch-only transparent addresses
+# imported without key material. The full in-repo dependency closure of the two
+# client crates is patched to the same rev so the whole cohort resolves from a
+# single source. Repoint at crates.io once the change lands in a release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1523,8 +1523,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1560,8 +1559,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3689,9 +3687,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+version = "0.9.2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3711,7 +3708,7 @@ dependencies = [
  "serde_with",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -6881,7 +6878,7 @@ dependencies = [
  "zcash_address 0.13.0",
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-rpc",
@@ -6970,7 +6967,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_spec",
  "zcash_transparent 0.10.0",
@@ -7001,7 +6998,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-rpc",
@@ -7025,22 +7022,20 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ace878c125814bb9e82228d3661499124c6f2936e60fc1df3c6876eb54624"
+version = "0.24.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7083,7 +7078,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zip32",
@@ -7092,9 +7087,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a789c0038359968f93bfe3952d2b942e3bae5582f79c2f31137c6fd736a225"
+version = "0.22.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7110,6 +7104,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard 0.15.3",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -7134,7 +7129,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_pool_migration",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zewif",
@@ -7197,8 +7192,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7222,7 +7216,7 @@ dependencies = [
  "tracing",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_transparent 0.10.0",
  "zeroize",
  "zip32",
@@ -7243,10 +7237,10 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9010904169a92805128b3a8eab0dd4ff79fd164dd416af68aaeac5c7ebbd2522"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -7258,7 +7252,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zip32",
 ]
 
@@ -7295,8 +7289,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7318,7 +7311,7 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -7326,8 +7319,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7361,9 +7353,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f074493fff337207e28bcfa5bbdf0e2a125c4203a4bdd07e72067eea81e9e7b"
+version = "0.10.4"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "corez",
  "document-features",
@@ -7426,8 +7417,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bip32",
  "bs58",
@@ -7442,7 +7432,7 @@ dependencies = [
  "subtle",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7507,7 +7497,7 @@ dependencies = [
  "zcash_history",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -7546,7 +7536,7 @@ dependencies = [
  "tracing-futures",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zebra-chain",
@@ -7659,7 +7649,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zebra-chain",
@@ -7881,14 +7871,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address 0.13.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
 ]
 
 [[package]]

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -34,7 +34,7 @@ transparent = { package = "zcash_transparent", version = "0.10.0" }
 zaino-common = "0.4"
 zaino-fetch = "0.4"
 zaino-state = "0.5"
-zcash_client_backend = "=0.24.0-rc.6"
+zcash_client_backend = "=0.24.0-rc.7"
 zcash_keys = { version = "0.16.0", features = ["unstable"] }
 zcash_primitives = "0.30.0"
 zcash_protocol = "0.10.0"
@@ -75,6 +75,26 @@ tempfile = "3"
 # Use libc++ when requested by the StageX musl builder. This upstream fix landed
 # after rocksdb 0.24.0 and can return to crates.io with the next release.
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
+
+# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
+# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
+# which `zallet import-address` uses to track watch-only transparent addresses
+# imported without key material. The full in-repo dependency closure of the two
+# client crates is patched to the same rev so the whole cohort resolves from a
+# single source. Repoint at crates.io once the change lands in a release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
 
 # TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
 # `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1429,8 +1429,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306286e8dcc39ab3dfceb74c792ce8baffdab90591321d3ffaae64829734c37f"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1466,8 +1465,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d42773cb15447644d170be20231a3268600e0c4cea8987d013b93ac973d3cf7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3519,9 +3517,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d4693dcb3d72f30064e0fdab122292d803bd9325a95b25df08679cf895452f"
+version = "0.9.2"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3541,7 +3538,7 @@ dependencies = [
  "serde_with",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -6569,7 +6566,7 @@ dependencies = [
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_spec",
  "zcash_transparent 0.10.0",
@@ -6603,7 +6600,7 @@ dependencies = [
  "zallet-core",
  "zcash_client_backend",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_transparent 0.10.0",
  "zebra-chain",
  "zebra-rpc",
@@ -6627,22 +6624,20 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a854b28c07dba372f4410ea8ad62b4bf7d5c2bf8be32fc4b31bc0db6521a975"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
  "corez",
  "f4jumble",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
 ]
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "832ace878c125814bb9e82228d3661499124c6f2936e60fc1df3c6876eb54624"
+version = "0.24.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6685,7 +6680,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zip32",
@@ -6694,9 +6689,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4a789c0038359968f93bfe3952d2b942e3bae5582f79c2f31137c6fd736a225"
+version = "0.22.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6712,6 +6706,7 @@ dependencies = [
  "maybe-rayon",
  "nonempty",
  "orchard 0.15.3",
+ "pczt",
  "prost",
  "rand 0.8.7",
  "rand_core 0.6.4",
@@ -6736,7 +6731,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_pool_migration",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zewif",
@@ -6799,8 +6794,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def800f128e459eedebc900f36f408eaf0687634128dcf64ecfeaeebc3e16c14"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6824,7 +6818,7 @@ dependencies = [
  "tracing",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_transparent 0.10.0",
  "zeroize",
  "zip32",
@@ -6845,10 +6839,10 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9010904169a92805128b3a8eab0dd4ff79fd164dd416af68aaeac5c7ebbd2522"
+version = "0.1.0-rc.6"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
+ "blake2b_simd",
  "corez",
  "getset",
  "incrementalmerkletree",
@@ -6860,7 +6854,7 @@ dependencies = [
  "zcash_client_backend",
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zip32",
 ]
 
@@ -6897,8 +6891,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ca4de11896f704ffe6319c2cd7bc8fc6ab31a55cec80d26def15c009d83678"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6920,7 +6913,7 @@ dependencies = [
  "sha2 0.10.9",
  "zcash_encoding",
  "zcash_note_encryption",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -6928,8 +6921,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea125021aaa749e966989c7f7aaa18afe2f89474573f5f0dfac8b98083a6d095"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6963,9 +6955,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f074493fff337207e28bcfa5bbdf0e2a125c4203a4bdd07e72067eea81e9e7b"
+version = "0.10.4"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "corez",
  "document-features",
@@ -7028,8 +7019,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "547c012778bae17f58007731af074d638aa146ab0ecfc120adebf23d049aff6c"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "bip32",
  "bs58",
@@ -7044,7 +7034,7 @@ dependencies = [
  "subtle",
  "zcash_address 0.13.0",
  "zcash_encoding",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_spec",
  "zip32",
@@ -7109,7 +7099,7 @@ dependencies = [
  "zcash_history",
  "zcash_note_encryption",
  "zcash_primitives 0.30.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
 ]
@@ -7148,7 +7138,7 @@ dependencies = [
  "tracing-futures",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zebra-chain",
@@ -7261,7 +7251,7 @@ dependencies = [
  "zcash_keys 0.16.1",
  "zcash_primitives 0.30.0",
  "zcash_proofs",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
  "zcash_script",
  "zcash_transparent 0.10.0",
  "zebra-chain",
@@ -7483,14 +7473,13 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb464491970d9b61889e4f2b7b00fb9f471a33692e5c0de3122fdc575d8067ab"
+source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",
  "percent-encoding",
  "zcash_address 0.13.0",
- "zcash_protocol 0.10.3",
+ "zcash_protocol 0.10.4",
 ]
 
 [[package]]

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -43,7 +43,7 @@ jsonrpsee-http-client = { version = "0.24", default-features = false }
 tokio = { version = "1", features = ["net", "rt-multi-thread"] }
 tower = { version = "0.4", features = ["timeout"] }
 transparent = { package = "zcash_transparent", version = "0.10.0" }
-zcash_client_backend = "=0.24.0-rc.6"
+zcash_client_backend = "=0.24.0-rc.7"
 zcash_primitives = "0.30.0"
 zcash_protocol = "0.10.0"
 zebra-chain = "11"
@@ -78,6 +78,26 @@ tokio-console = ["zallet-core/tokio-console"]
 # Use libc++ when requested by the StageX musl builder. This upstream fix landed
 # after rocksdb 0.24.0 and can return to crates.io with the next release.
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
+
+# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
+# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
+# which `zallet import-address` uses to track watch-only transparent addresses
+# imported without key material. The full in-repo dependency closure of the two
+# client crates is patched to the same rev so the whole cohort resolves from a
+# single source. Repoint at crates.io once the change lands in a release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -32,6 +32,7 @@
   - [generate-mnemonic](cli/generate-mnemonic.md)
   - [import-mnemonic](cli/import-mnemonic.md)
   - [export-mnemonic](cli/export-mnemonic.md)
+  - [import-address](cli/import-address.md)
   - [add-rpc-user](cli/add-rpc-user.md)
   - [rpc](cli/rpc.md)
   - [repair](cli/repair/README.md)

--- a/book/src/cli/README.md
+++ b/book/src/cli/README.md
@@ -14,6 +14,7 @@ The following sections provide in-depth information on the different commands av
 - [`zallet generate-mnemonic`](generate-mnemonic.md)
 - [`zallet import-mnemonic`](import-mnemonic.md)
 - [`zallet export-mnemonic`](export-mnemonic.md)
+- [`zallet import-address`](import-address.md)
 - [`zallet add-rpc-user`](add-rpc-user.md)
 - [`zallet rpc`](rpc.md)
 - [`zallet repair` subcommands](repair/README.md)

--- a/book/src/cli/import-address.md
+++ b/book/src/cli/import-address.md
@@ -1,0 +1,45 @@
+# The `import-address` command
+
+`zallet import-address` imports a transparent address into a Zallet wallet as
+watch-only. The wallet will track transactions involving the address, but will
+not have spending authority. It covers the roles of both the `importaddress`
+and (in part) `importpubkey` RPC methods of `zcashd`.
+
+The command takes the address in one of three forms:
+
+- the bare transparent address string,
+- the hex-encoded public key, for a P2PKH address, or
+- the hex-encoded redeem script, for a P2SH address.
+
+A bare address import watches for the address's outputs but stores no key
+material. An import by public key or redeem script tracks the same
+transactions, and additionally allows the address to be upgraded to spending
+capability if the corresponding private key material is imported later;
+importing key material for a previously bare-imported address upgrades it in
+place.
+
+By default the address is imported into the account holding the legacy
+`zcashd` pool of funds, as named by the `features.legacy_pool_seed_fingerprint`
+option in the Zallet config file (whose value `zallet migrate-zcashd-wallet`
+prints on import). Pass `--account <UUID>` to import into a different account;
+account UUIDs can be obtained from a running Zallet wallet with
+`zallet rpc z_listaccounts`.
+
+By default the command connects to the configured chain backend and queues a
+rescan from the account's birthday, so that the next `zallet start` discovers
+the address's existing history. Pass `--no-rescan` to import without the chain
+backend being available; only transactions in blocks scanned after the import
+will then be detected.
+
+The imported address is printed on success:
+
+```
+$ zallet import-address t1SRgDBrpcd4LNMUhGbBfh8S8rs7G335v6R
+t1SRgDBrpcd4LNMUhGbBfh8S8rs7G335v6R
+$ zallet import-address --account 514ab5f4-62bd-4d8c-94b5-23fa8d8d38c2 \
+    03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2
+t1SRgDBrpcd4LNMUhGbBfh8S8rs7G335v6R
+```
+
+The public-key and redeem-script forms are also available on a running wallet
+via the `z_importaddress` JSON-RPC method.

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -32,7 +32,7 @@ Statuses:
 | `gettransaction` | Not planned | Superseded by `z_viewtransaction`, which now includes its top-level fields ([altered semantics](json_rpc.md#z_viewtransaction)); `gettransaction` cannot represent partially-shielded transactions correctly |
 | `getunconfirmedbalance` | Not yet implemented | [#54](https://github.com/zcash/zallet/issues/54) |
 | `getwalletinfo` | Implemented (partial) | Balance fields will not be populated — use dedicated balance methods ([#55](https://github.com/zcash/zallet/issues/55)); most other fields are currently placeholders, and only `unlocked_until` is meaningful |
-| `importaddress` | Not yet implemented | Planned to import into the legacy transparent account ([#56](https://github.com/zcash/zallet/issues/56)); if you have the public key or redeem script, `z_importaddress` covers this today |
+| `importaddress` | Omitted | Use the [`zallet import-address`](../cli/import-address.md) CLI command ([#56](https://github.com/zcash/zallet/issues/56)), which accepts a bare address, a public key, or a redeem script, and imports into the legacy transparent account by default; `z_importaddress` covers the public-key and redeem-script forms over RPC |
 | `importprivkey` | Not yet implemented | [#57](https://github.com/zcash/zallet/issues/57) |
 | `importpubkey` | Omitted | Use `z_importaddress` |
 | `importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md); a CLI import may be considered ([#81](https://github.com/zcash/zallet/issues/81)) |

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -21,6 +21,13 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- `ChainRuntime::run_import_address` (in wallet builds with the
+  `transparent-key-import` feature), running the chain-dependent body of the
+  new `zallet import-address` CLI command. Backend crates receive it through
+  the blanket impl over `ChainFactory` and need no changes.
+
 ### Changed
 
 - Migrated to `zcash_client_backend`/`zcash_client_sqlite` 0.24.0-rc.7 /

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -23,12 +23,17 @@ should be considered breaking changes.
 
 ### Changed
 
-- Migrated to `zcash_client_backend`/`zcash_client_sqlite` 0.24.0-rc.5 /
-  0.22.0-rc.5, which extract output-locking (`lock_outputs`, `unlock_output`,
-  `clear_locked_outputs`, `get_locked_outputs`) off `WalletWrite` into a new
-  `OutputLockStore` supertrait. Internal `DbConnection` now implements
-  `OutputLockStore` directly, alongside its existing `WalletRead`,
-  `InputSource`, `WalletWrite`, and `WalletCommitmentTrees` impls.
+- Migrated to `zcash_client_backend`/`zcash_client_sqlite` 0.24.0-rc.7 /
+  0.22.0-rc.7 (as of rc.5, output-locking — `lock_outputs`, `unlock_output`,
+  `clear_locked_outputs`, `get_locked_outputs` — is extracted off `WalletWrite`
+  into a new `OutputLockStore` supertrait; internal `DbConnection` now
+  implements `OutputLockStore` directly, alongside its existing `WalletRead`,
+  `InputSource`, `WalletWrite`, and `WalletCommitmentTrees` impls). The
+  wallet-critical librustzcash crates are temporarily consumed via a
+  `[patch.crates-io]` git pin (see the workspace `Cargo.toml`) that adds
+  `WalletWrite::import_standalone_transparent_address`
+  (zcash/librustzcash#2941); a backend workspace must carry the same patch
+  so the cohort resolves to a single source.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -22,8 +22,10 @@
 -allow-warnings = --allow-warnings
 -allow-beta-example = --this-is-beta-code-and-you-will-need-to-recreate-the-example-later
 -allow-beta-migration = --this-is-beta-code-and-you-will-need-to-redo-the-migration-later
+-account = --account
 -allow-multiple-wallet-imports = --allow-multiple-wallet-imports
 -datadir = --datadir
+-no-rescan = --no-rescan
 -db_dump = db_dump
 -zcashd-install-dir = --zcashd-install-dir
 
@@ -207,6 +209,34 @@ err-wallet-locked = Wallet is locked
 
 err-account-not-found = Account does not exist
 err-account-no-payment-source = Account has no payment source.
+
+err-legacy-pool-disabled =
+    The legacy pool of funds is disabled. To enable it, set
+    '{-legacy_pool_seed_fingerprint}' in the Zallet config file to the seed
+    fingerprint of the {-zcashd} wallet migrated into this wallet.
+err-legacy-pool-not-found =
+    This wallet holds no legacy account for seed fingerprint {$seed_fp}. Check
+    that '{-legacy_pool_seed_fingerprint}' names a {-zcashd} wallet migrated
+    into it.
+
+## `import-address` command errors
+
+err-import-address-unrecognized =
+    Import data is not a transparent address, a hex-encoded public key, or a
+    hex-encoded redeem script.
+err-import-address-not-key-or-script =
+    Import data is not a valid public key or redeem script.
+err-import-address-legacy-disabled =
+    No legacy {-zcashd} account is configured for this wallet. Pass '{-account}' to
+    name the target account, or set '{-legacy_pool_seed_fingerprint}' in the Zallet
+    config file to the seed fingerprint of the {-zcashd} wallet migrated into it.
+err-import-address-legacy-not-found =
+    This wallet holds no legacy account for seed fingerprint {$seed_fp}. Pass
+    '{-account}' to name the target account, or check that
+    '{-legacy_pool_seed_fingerprint}' names a {-zcashd} wallet migrated into it.
+err-import-address-no-chain-state =
+    The chain state needed to queue a rescan is unavailable. Retry once the chain
+    backend has synced, or pass '{-no-rescan}' to import without a rescan.
 
 ## Transaction verification errors
 

--- a/zallet-core/src/application.rs
+++ b/zallet-core/src/application.rs
@@ -226,6 +226,15 @@ mod tests {
         ) -> BoxFuture<'a, Result<(), Error>> {
             Box::pin(async { Ok(()) })
         }
+
+        #[cfg(all(zallet_build = "wallet", feature = "transparent-key-import"))]
+        #[allow(private_interfaces)]
+        fn run_import_address<'a>(
+            &'a self,
+            _cmd: &'a crate::cli::ImportAddressCmd,
+        ) -> BoxFuture<'a, Result<(), Error>> {
+            Box::pin(async { Ok(()) })
+        }
     }
 
     /// Registration hands back the registered backend through `chain_runtime`.

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -83,6 +83,10 @@ pub(crate) enum ZalletCmd {
     #[cfg(zallet_build = "wallet")]
     ExportMnemonic(ExportMnemonicCmd),
 
+    /// Import a transparent address into the wallet as watch-only.
+    #[cfg(all(zallet_build = "wallet", feature = "transparent-key-import"))]
+    ImportAddress(ImportAddressCmd),
+
     /// Adds a user authorization for the JSON-RPC interface.
     AddRpcUser(AddRpcUserCmd),
 
@@ -266,6 +270,39 @@ pub(crate) struct ExportMnemonicCmd {
 
     /// The UUID of the account from which to export.
     pub(crate) account_uuid: Uuid,
+}
+
+/// `import-address` subcommand
+#[cfg(all(zallet_build = "wallet", feature = "transparent-key-import"))]
+#[derive(Debug, Parser)]
+#[cfg_attr(outside_buildscript, derive(Command))]
+pub(crate) struct ImportAddressCmd {
+    /// The transparent address to watch, or the hex-encoded public key (for a
+    /// P2PKH address) or redeem script (for a P2SH address) of the address.
+    ///
+    /// An address imported by its public key or redeem script tracks the same
+    /// transactions as one imported by the bare address, and additionally allows
+    /// the wallet to be upgraded to spending capability if the corresponding
+    /// private key material is imported later.
+    pub(crate) data: String,
+
+    /// The UUID of the account to import the address into.
+    ///
+    /// By default, the address is imported into the account holding the legacy
+    /// `zcashd` pool of funds, as named by the `features.legacy_pool_seed_fingerprint`
+    /// option in the Zallet config file.
+    #[arg(short, long)]
+    pub(crate) account: Option<Uuid>,
+
+    /// Skip the rescan for the imported address's history.
+    ///
+    /// By default the command connects to the chain backend and queues a rescan
+    /// from the account's birthday, so that the next `zallet start` discovers
+    /// existing transactions involving the imported address. With this flag the
+    /// chain backend is not needed, but only transactions in blocks scanned
+    /// after the import will be detected.
+    #[arg(long)]
+    pub(crate) no_rescan: bool,
 }
 
 /// `add-rpc-user` subcommand

--- a/zallet-core/src/commands.rs
+++ b/zallet-core/src/commands.rs
@@ -32,6 +32,8 @@ mod export_mnemonic;
 mod generate_encryption_identity;
 #[cfg(zallet_build = "wallet")]
 mod generate_mnemonic;
+#[cfg(all(zallet_build = "wallet", feature = "transparent-key-import"))]
+mod import_address;
 #[cfg(zallet_build = "wallet")]
 mod import_mnemonic;
 #[cfg(zallet_build = "wallet")]

--- a/zallet-core/src/commands/import_address.rs
+++ b/zallet-core/src/commands/import_address.rs
@@ -1,0 +1,159 @@
+use std::collections::HashSet;
+
+use abscissa_core::Runnable;
+use transparent::address::TransparentAddress;
+use zcash_client_backend::data_api::{Account as _, WalletRead, WalletWrite};
+use zcash_client_sqlite::AccountUuid;
+use zcash_keys::encoding::AddressCodec as _;
+
+use crate::{
+    cli::ImportAddressCmd,
+    commands::AsyncRunnable,
+    components::{
+        chain::{Chain, ChainFactory, ChainView},
+        database::Database,
+        json_rpc::{
+            methods::z_import_address::{ParseImportError, ParsedImport, ResultType, parse_import},
+            payments::{LegacyPoolError, legacy_pool_account},
+        },
+    },
+    error::{Error, ErrorKind},
+    fl,
+    prelude::*,
+};
+
+impl ImportAddressCmd {
+    /// Runs the address import against the chain backend produced by `factory`.
+    pub(crate) async fn run_with<F: ChainFactory>(&self, factory: &F) -> Result<(), Error> {
+        let config = APP.config();
+        let _lock = config.lock_datadir()?;
+
+        let db = Database::open(&config).await?;
+        let mut wallet = db.handle().await?;
+
+        let account_id = match self.account {
+            Some(uuid) => {
+                let account_id = AccountUuid::from_uuid(uuid);
+                wallet
+                    .get_account(account_id)
+                    .map_err(|e| ErrorKind::Generic.context(e))?
+                    .ok_or_else(|| ErrorKind::Generic.context(fl!("err-account-not-found")))?;
+                account_id
+            }
+            None => legacy_pool_account(&wallet)
+                .map_err(|e| {
+                    ErrorKind::Generic.context(match e {
+                        LegacyPoolError::Disabled => fl!("err-import-address-legacy-disabled"),
+                        LegacyPoolError::NotFound(seed_fp) => fl!(
+                            "err-import-address-legacy-not-found",
+                            seed_fp = seed_fp.to_string(),
+                        ),
+                        LegacyPoolError::Db(msg) => msg,
+                    })
+                })?
+                .id(),
+        };
+
+        // A bare transparent address is imported as watch-only without key material; hex
+        // data is classified as a public key or redeem script, as in `z_importaddress`.
+        enum ImportData {
+            Address(TransparentAddress),
+            KeyMaterial(ParsedImport),
+        }
+        let parsed = match TransparentAddress::decode(wallet.params(), &self.data) {
+            Ok(addr) => ImportData::Address(addr),
+            Err(_) => {
+                ImportData::KeyMaterial(parse_import(wallet.params(), &self.data).map_err(|e| {
+                    ErrorKind::Generic.context(match e {
+                        ParseImportError::InvalidHex => fl!("err-import-address-unrecognized"),
+                        ParseImportError::NotKeyOrScript => {
+                            fl!("err-import-address-not-key-or-script")
+                        }
+                    })
+                })?)
+            }
+        };
+
+        // Connect to the chain before modifying the wallet, so that an unreachable
+        // chain backend fails the command without a partial effect.
+        let chain = if self.no_rescan {
+            None
+        } else {
+            Some(factory.build(&config).await?)
+        };
+
+        let result = match parsed {
+            ImportData::Address(addr) => {
+                wallet
+                    .import_standalone_transparent_address(account_id, addr)
+                    .map_err(|e| ErrorKind::Generic.context(e))?;
+                ResultType {
+                    kind: match addr {
+                        TransparentAddress::PublicKeyHash(_) => "p2pkh",
+                        TransparentAddress::ScriptHash(_) => "p2sh",
+                    },
+                    address: addr.encode(wallet.params()),
+                }
+            }
+            ImportData::KeyMaterial(ParsedImport::P2pkh { pubkey, result }) => {
+                wallet
+                    .import_standalone_transparent_pubkey(account_id, pubkey)
+                    .map_err(|e| ErrorKind::Generic.context(e))?;
+                result
+            }
+            ImportData::KeyMaterial(ParsedImport::P2sh { script, result }) => {
+                wallet
+                    .import_standalone_transparent_script(account_id, script)
+                    .map_err(|e| ErrorKind::Generic.context(e))?;
+                result
+            }
+        };
+        info!(
+            "Imported watch-only {} address {}",
+            result.kind, result.address,
+        );
+
+        if let Some((chain, _chain_indexer_task_handle)) = chain {
+            // Rewind the scan queue to the block before the account's birthday, so
+            // that the next `zallet start` re-scans the already-synced range with
+            // the newly imported address tracked. This mirrors `z_importaddress`;
+            // see its rationale for why no account birthday is reset.
+            let birthday = wallet
+                .get_account_birthday(account_id)
+                .map_err(|e| ErrorKind::Generic.context(e))?;
+            let chain_view = chain
+                .snapshot()
+                .await
+                .map_err(|e| ErrorKind::Chain.context(e))?;
+            let prior_chain_state = chain_view
+                .tree_state_as_of(birthday - 1)
+                .await
+                .map_err(|e| ErrorKind::Chain.context(e))?
+                .ok_or_else(|| {
+                    ErrorKind::Chain.context(fl!("err-import-address-no-chain-state"))
+                })?;
+            wallet
+                .rewind_to_chain_state(prior_chain_state, HashSet::new())
+                .map_err(|e| ErrorKind::Generic.context(e))?;
+            info!("Rescan queued from height {birthday}");
+        }
+
+        println!("{}", result.address);
+
+        Ok(())
+    }
+}
+
+impl AsyncRunnable for ImportAddressCmd {
+    async fn run(&self) -> Result<(), Error> {
+        crate::application::chain_runtime()
+            .run_import_address(self)
+            .await
+    }
+}
+
+impl Runnable for ImportAddressCmd {
+    fn run(&self) {
+        self.run_on_runtime();
+    }
+}

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -93,6 +93,17 @@ pub trait ChainRuntime: Send + Sync {
         &'a self,
         cmd: &'a crate::cli::MigrateZcashdWalletCmd,
     ) -> BoxFuture<'a, Result<(), Error>>;
+
+    /// Runs the chain-dependent body of `zallet import-address`.
+    ///
+    /// The command type is crate-private for the same reason as
+    /// [`Self::run_migrate_zcashd_wallet`]'s.
+    #[cfg(all(zallet_build = "wallet", feature = "transparent-key-import"))]
+    #[allow(private_interfaces)]
+    fn run_import_address<'a>(
+        &'a self,
+        cmd: &'a crate::cli::ImportAddressCmd,
+    ) -> BoxFuture<'a, Result<(), Error>>;
 }
 
 impl<F: ChainFactory> ChainRuntime for F {
@@ -109,6 +120,15 @@ impl<F: ChainFactory> ChainRuntime for F {
     fn run_migrate_zcashd_wallet<'a>(
         &'a self,
         cmd: &'a crate::cli::MigrateZcashdWalletCmd,
+    ) -> BoxFuture<'a, Result<(), Error>> {
+        Box::pin(cmd.run_with(self))
+    }
+
+    #[cfg(all(zallet_build = "wallet", feature = "transparent-key-import"))]
+    #[allow(private_interfaces)]
+    fn run_import_address<'a>(
+        &'a self,
+        cmd: &'a crate::cli::ImportAddressCmd,
     ) -> BoxFuture<'a, Result<(), Error>> {
         Box::pin(cmd.run_with(self))
     }

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -643,6 +643,15 @@ impl WalletWrite for DbConnection {
     }
 
     #[cfg(feature = "transparent-key-import")]
+    fn import_standalone_transparent_address(
+        &mut self,
+        account: <Self as WalletRead>::AccountId,
+        address: TransparentAddress,
+    ) -> Result<(), <Self as WalletRead>::Error> {
+        self.with_mut(|mut db_data| db_data.import_standalone_transparent_address(account, address))
+    }
+
+    #[cfg(feature = "transparent-key-import")]
     fn import_standalone_transparent_pubkey(
         &mut self,
         account: <Self as WalletRead>::AccountId,

--- a/zallet-core/src/components/json_rpc.rs
+++ b/zallet-core/src/components/json_rpc.rs
@@ -27,7 +27,7 @@ mod asyncop;
 mod fund_source;
 pub(crate) mod methods;
 #[cfg(zallet_build = "wallet")]
-mod payments;
+pub(crate) mod payments;
 pub(crate) mod server;
 pub(crate) mod utils;
 

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -84,7 +84,7 @@ mod z_get_balance_for_account;
 #[cfg(zallet_build = "wallet")]
 mod z_get_total_balance;
 #[cfg(zallet_build = "wallet")]
-mod z_import_address;
+pub(crate) mod z_import_address;
 #[cfg(zallet_build = "wallet")]
 mod z_send_from_account;
 #[cfg(zallet_build = "wallet")]

--- a/zallet-core/src/components/json_rpc/methods/z_import_address.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_import_address.rs
@@ -9,7 +9,7 @@ use crate::components::{chain::Chain, database::DbConnection, json_rpc::server::
 use {
     crate::components::chain::ChainView,
     crate::network::Network,
-    jsonrpsee::types::ErrorCode as RpcErrorCode,
+    jsonrpsee::types::{ErrorCode as RpcErrorCode, ErrorObjectOwned},
     secp256k1::PublicKey,
     std::collections::HashSet,
     transparent::{address::TransparentAddress, util::hash160},
@@ -27,9 +27,9 @@ pub(crate) type Response = RpcResult<ResultType>;
 pub(crate) struct ResultType {
     /// The type of address imported: "p2pkh" or "p2sh".
     #[serde(rename = "type")]
-    kind: &'static str,
+    pub(crate) kind: &'static str,
     /// The transparent address corresponding to the imported data.
-    address: String,
+    pub(crate) address: String,
 }
 
 pub(super) const PARAM_ACCOUNT_DESC: &str = "The account UUID to import the address into.";
@@ -52,7 +52,9 @@ pub(crate) async fn call<C: Chain>(
         .map_err(|_| RpcErrorCode::InvalidParams)?;
 
     // Parse the address import data, and call the appropriate import handler
-    let result = match parse_import(wallet.params(), hex_data)? {
+    let parsed =
+        parse_import(wallet.params(), hex_data).map_err(|e| parse_import_rpc_error(e, hex_data))?;
+    let result = match parsed {
         ParsedImport::P2pkh { pubkey, result } => {
             wallet
                 .import_standalone_transparent_pubkey(account_id, pubkey)
@@ -114,7 +116,7 @@ pub(crate) async fn call<C: Chain>(
 
 /// Intermediate result of parsing hex-encoded import data.
 #[cfg(feature = "transparent-key-import")]
-enum ParsedImport {
+pub(crate) enum ParsedImport {
     /// A compressed or uncompressed public key (P2PKH import).
     P2pkh {
         pubkey: PublicKey,
@@ -124,12 +126,37 @@ enum ParsedImport {
     P2sh { script: Redeem, result: ResultType },
 }
 
+/// The ways in which hex-encoded import data can fail to parse.
+#[cfg(feature = "transparent-key-import")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ParseImportError {
+    /// The import data is not valid hex.
+    InvalidHex,
+    /// The import data is neither a valid public key nor a valid redeem script.
+    NotKeyOrScript,
+}
+
+/// Maps a parse failure to the corresponding `z_importaddress` RPC error.
+#[cfg(feature = "transparent-key-import")]
+fn parse_import_rpc_error(err: ParseImportError, hex_data: &str) -> ErrorObjectOwned {
+    match err {
+        ParseImportError::InvalidHex => {
+            LegacyCode::InvalidParameter.with_static("Invalid hex encoding")
+        }
+        ParseImportError::NotKeyOrScript => LegacyCode::InvalidParameter.with_message(format!(
+            "Unrecognized input (not a valid pubkey or redeem script): {hex_data}"
+        )),
+    }
+}
+
 /// Parses hex-encoded data and classifies it as a public key (P2PKH) or redeem
 /// script (P2SH), computing the corresponding transparent address.
 #[cfg(feature = "transparent-key-import")]
-fn parse_import(params: &Network, hex_data: &str) -> RpcResult<ParsedImport> {
-    let bytes = hex::decode(hex_data)
-        .map_err(|_| LegacyCode::InvalidParameter.with_static("Invalid hex encoding"))?;
+pub(crate) fn parse_import(
+    params: &Network,
+    hex_data: &str,
+) -> Result<ParsedImport, ParseImportError> {
+    let bytes = hex::decode(hex_data).map_err(|_| ParseImportError::InvalidHex)?;
 
     // Try to parse as a public key (P2PKH import).
     if let Ok(pubkey) = PublicKey::from_slice(&bytes) {
@@ -145,11 +172,7 @@ fn parse_import(params: &Network, hex_data: &str) -> RpcResult<ParsedImport> {
         // Otherwise treat as a redeem script (P2SH import).
         let address = TransparentAddress::ScriptHash(hash160::hash(&bytes)).encode(params);
         let code = Code(bytes);
-        let script = Redeem::parse(&code).map_err(|_| {
-            LegacyCode::InvalidParameter.with_message(format!(
-                "Unrecognized input (not a valid pubkey or redeem script): {hex_data}"
-            ))
-        })?;
+        let script = Redeem::parse(&code).map_err(|_| ParseImportError::NotKeyOrScript)?;
         Ok(ParsedImport::P2sh {
             script,
             result: ResultType {
@@ -280,8 +303,10 @@ mod tests {
         let Err(err) = parse_import(&mainnet(), "not_valid_hex") else {
             panic!("Expected error for invalid hex");
         };
-        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
-        assert_eq!(err.message(), "Invalid hex encoding");
+        assert_eq!(err, ParseImportError::InvalidHex);
+        let rpc_err = parse_import_rpc_error(err, "not_valid_hex");
+        assert_eq!(rpc_err.code(), LegacyCode::InvalidParameter as i32);
+        assert_eq!(rpc_err.message(), "Invalid hex encoding");
     }
 
     #[test]
@@ -289,7 +314,16 @@ mod tests {
         let Err(err) = parse_import(&mainnet(), "abc") else {
             panic!("Expected error for odd-length hex");
         };
-        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
-        assert_eq!(err.message(), "Invalid hex encoding");
+        assert_eq!(err, ParseImportError::InvalidHex);
+    }
+
+    #[test]
+    fn unrecognized_input_error_names_the_input() {
+        let rpc_err = parse_import_rpc_error(ParseImportError::NotKeyOrScript, "abcd");
+        assert_eq!(rpc_err.code(), LegacyCode::InvalidParameter as i32);
+        assert_eq!(
+            rpc_err.message(),
+            "Unrecognized input (not a valid pubkey or redeem script): abcd",
+        );
     }
 }

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -1098,29 +1098,49 @@ fn is_legacy_pool_account(
 /// option unset, this wallet has no legacy pool and callers that ask to spend from it are
 /// rejected.
 pub(super) fn get_legacy_pool_account(wallet: &DbConnection) -> RpcResult<Account> {
+    legacy_pool_account(wallet).map_err(|e| match e {
+        LegacyPoolError::Disabled => {
+            LegacyCode::WalletAccountsUnsupported.with_message(fl!("err-legacy-pool-disabled"))
+        }
+        LegacyPoolError::NotFound(legacy_seed_fp) => LegacyCode::Wallet.with_message(fl!(
+            "err-legacy-pool-not-found",
+            seed_fp = legacy_seed_fp.to_string(),
+        )),
+        LegacyPoolError::Db(msg) => LegacyCode::Database.with_message(msg),
+    })
+}
+
+/// The ways in which resolving the legacy `zcashd` pool account can fail.
+pub(crate) enum LegacyPoolError {
+    /// `features.legacy_pool_seed_fingerprint` is not set in the Zallet config.
+    Disabled,
+    /// No account of the wallet is the legacy account of the configured seed.
+    NotFound(SeedFingerprint),
+    /// A wallet database error occurred.
+    Db(String),
+}
+
+/// Returns the account holding the legacy `zcashd` pool of funds. See
+/// [`get_legacy_pool_account`] for the semantics; this is the transport-neutral core shared
+/// with the CLI command layer.
+pub(crate) fn legacy_pool_account(wallet: &DbConnection) -> Result<Account, LegacyPoolError> {
     let legacy_seed_fp = APP
         .config()
         .features
         .legacy_pool_seed_fingerprint
-        .ok_or_else(|| {
-            LegacyCode::WalletAccountsUnsupported.with_static(
-                "The legacy pool of funds is disabled. To enable it, set \
-                 `features.legacy_pool_seed_fingerprint` in the Zallet config file to the \
-                 seed fingerprint of the `zcashd` wallet migrated into this wallet.",
-            )
-        })?;
+        .ok_or(LegacyPoolError::Disabled)?;
 
     // TODO: Make this more efficient with a `WalletRead` method.
     //       https://github.com/zcash/librustzcash/issues/1944
     for account_id in wallet
         .get_account_ids()
-        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .map_err(|e| LegacyPoolError::Db(e.to_string()))?
     {
         let account = wallet
             .get_account(account_id)
-            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .map_err(|e| LegacyPoolError::Db(e.to_string()))?
             // This would be a race condition between this and account deletion.
-            .ok_or_else(|| LegacyCode::Database.with_static("Account vanished mid-call"))?;
+            .ok_or_else(|| LegacyPoolError::Db("Account vanished mid-call".into()))?;
 
         // Accounts imported from a UFVK have no ZIP 32 derivation, and cannot be the legacy
         // pool: `zcashd` derived the pool from the wallet's seed.
@@ -1135,10 +1155,7 @@ pub(super) fn get_legacy_pool_account(wallet: &DbConnection) -> RpcResult<Accoun
         }
     }
 
-    Err(LegacyCode::Wallet.with_message(format!(
-        "This wallet holds no legacy account for seed fingerprint {legacy_seed_fp}. Check that \
-         `features.legacy_pool_seed_fingerprint` names a `zcashd` wallet migrated into it.",
-    )))
+    Err(LegacyPoolError::NotFound(legacy_seed_fp))
 }
 
 /// Why a transparent output of a built transaction failed verification against the

--- a/zallet-core/src/components/json_rpc/utils.rs
+++ b/zallet-core/src/components/json_rpc/utils.rs
@@ -88,6 +88,9 @@ pub(super) async fn collect_standalone_transparent_keys<NoteRef>(
         .filter_map(|(addr, metadata)| match metadata.source() {
             TransparentAddressSource::StandalonePubkey(_)
             | TransparentAddressSource::StandaloneScript(_) => Some(addr),
+            // No key material exists for an address-only import, so there is no
+            // standalone key to collect; spends from it are rejected upstream.
+            TransparentAddressSource::StandaloneAddress => None,
             TransparentAddressSource::Derived { .. } => None,
         })
         .collect();


### PR DESCRIPTION
Depends on https://github.com/zcash/librustzcash/pull/2944

Implements the CLI counterpart of `z_importaddress` for importing a transparent address into an account as watch-only, given its hex-encoded public key (P2PKH) or redeem script (P2SH). This resolves the `importaddress` gap (zcash/zallet#56) per the decision to provide it as a CLI command rather than a JSON-RPC method.

By default the command connects to the chain backend and queues a rescan from the account's birthday, mirroring `z_importaddress`, so the next `zallet start` discovers the address's history; `--no-rescan` performs the import without chain access. The hex-data parsing is shared with `z_importaddress`: its parse errors become backend-neutral, and each surface maps them to its own error style.

Closes zcash/zallet#56.