### PR TITLE
migrate-zcashd-wallet: fail when the import leaves wallet material behind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ be considered breaking changes.
   (default 100).
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
+- `migrate-zcashd-wallet --allow-partial-import` flag, permitting a migration
+  to complete even when some accounts or transparent spending keys in the
+  `zcashd` wallet could not be imported. The skipped items are reported as
+  warnings; they remain accessible only via the original `wallet.dat` file.
 
 ### Fixed
 
@@ -59,6 +63,15 @@ be considered breaking changes.
   rejected while the queue is full of unfinished operations. Previously the
   queue was unbounded, allowing an authenticated caller to exhaust wallet
   memory by starting operations without collecting their results.
+- `migrate-zcashd-wallet` now fails instead of exiting successfully when the
+  import leaves wallet material behind. A migration that imports no accounts at
+  all from a wallet that contains some is always an error; a migration that
+  skips some accounts or transparent spending keys is an error unless the new
+  `--allow-partial-import` flag is passed. The partial-import error enumerates
+  what was left behind; both errors note that the skipped material exists only
+  in the original `wallet.dat` file. Previously these outcomes were logged as
+  warnings and the command exited 0, so a wallet that migrated nothing looked
+  like a success.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -53,6 +53,12 @@ Additional CLI arguments:
 - `--allow-warnings`: If set, Zallet will ignore errors in parsing transactions
   extracted from the `wallet.dat` file. This can enable the import of key data
   from wallets that have been used on consensus forks of the Zcash chain.
+- `--allow-partial-import`: If set, Zallet will complete a migration even when
+  some accounts or transparent spending keys in the `zcashd` wallet could not
+  be imported. The skipped items are reported as warnings; they remain
+  accessible only via the original `wallet.dat` file. Without this flag, such
+  a migration fails with an error enumerating what was left behind. A
+  migration that imports nothing at all is an error regardless of this flag.
 
 > For the Zallet beta releases, the command also currently takes another required flag
 > `--this-is-beta-code-and-you-will-need-to-redo-the-migration-later`.

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -23,6 +23,7 @@
 -allow-beta-example = --this-is-beta-code-and-you-will-need-to-recreate-the-example-later
 -allow-beta-migration = --this-is-beta-code-and-you-will-need-to-redo-the-migration-later
 -allow-multiple-wallet-imports = --allow-multiple-wallet-imports
+-allow-partial-import = --allow-partial-import
 -datadir = --datadir
 -db_dump = db_dump
 -zcashd-install-dir = --zcashd-install-dir
@@ -421,6 +422,40 @@ err-migrate-wallet-secret-store =
     An error occurred storing wallet secrets in the keystore: '{$err}'
 err-migrate-wallet-encrypted-secrets =
     The ZeWIF document's secret material is encrypted; decrypt it before import.
+err-migrate-wallet-nothing-imported =
+    None of the accounts in the {-zcashd} wallet (it contains {$account_count})
+    could be imported: NOTHING WAS MIGRATED, and your funds remain accessible only
+    through the original `wallet.dat` file, so keep it safe. See the preceding
+    log output for the reason each account was skipped. No accounts were
+    created in the {-zallet} wallet, although the keystore may now hold key
+    material that no account references; this is harmless, and it is safe to
+    re-run this migration after addressing the cause (secrets already present
+    in the keystore are stored idempotently).
+err-migrate-wallet-partial-import =
+    The migration could not import the following; each exists ONLY in the
+    original {-zcashd} `wallet.dat` file, so keep it safe:
+    {$skipped}
+    The accounts that were imported, and their key material, have already been
+    written to the {-zallet} wallet and keystore (the keystore may also hold
+    keys for the items listed above, unreferenced by any account), so re-running
+    this migration against the same {-zallet} wallet is not supported and will
+    fail. To accept a migration that leaves this material behind,
+    redo the migration against a fresh {-zallet} wallet with the
+    {-allow-partial-import} flag.
+migrate-wallet-skipped-account-sprout =
+    account '{$name}': its viewing capability is a Sprout viewing key, and
+    {-zallet} cannot represent the Sprout pool; move any Sprout funds using
+    {-zcashd} before migrating
+migrate-wallet-skipped-account-no-seed =
+    account '{$name}': a bare set of transparent addresses with no seed from
+    which its contents could be re-derived
+migrate-wallet-skipped-key-uncompressed =
+    a transparent spending key: the recorded public key is uncompressed, and
+    {-zallet} derives addresses only from compressed public keys
+migrate-wallet-skipped-key-no-account =
+    the transparent spending key for '{$address}': its address does not appear
+    under any imported account
+migrate-wallet-unknown-address = unknown address
 
 err-ux-A = Did {-zallet} not do what you expected? Could the error be more useful?
 err-ux-B = Tell us

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -196,6 +196,13 @@ pub(crate) struct MigrateZcashdWalletCmd {
     #[arg(long)]
     pub(crate) allow_warnings: bool,
 
+    /// Allow the migration to complete even when some accounts or transparent spending
+    /// keys in the `zcashd` wallet could not be imported. The skipped items are reported
+    /// as warnings; they remain accessible only via the original `wallet.dat` file. A
+    /// migration that imports nothing at all is an error regardless of this flag.
+    #[arg(long)]
+    pub(crate) allow_partial_import: bool,
+
     /// Skip chain scanning during migration. Keys, accounts, and transaction data are
     /// still imported, but block heights and tree state are not resolved from the chain.
     /// Useful when the corresponding chain data is not available.

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -10,7 +10,10 @@ use zcash_client_backend::data_api::{
     Account as _, AccountSource, WalletRead, WalletWrite as _, chain::ChainState,
 };
 use zcash_client_sqlite::error::SqliteClientError;
-use zcash_client_sqlite::zewif::{DiscardSecrets, SecretSink, ZewifImportError, ZewifImportReport};
+use zcash_client_sqlite::zewif::{
+    AccountSkipReason, DiscardSecrets, SecretSink, SkippedAccount, SkippedTransparentKey,
+    TransparentKeySkipReason, ZewifImportError, ZewifImportReport,
+};
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
 use zewif_zcashd::{BDBDump, EncryptedKeyPolicy, ZcashdDump, ZcashdParser, ZcashdWallet};
@@ -75,6 +78,7 @@ impl MigrateZcashdWalletCmd {
             chain,
             wallet,
             self.allow_multiple_wallet_imports,
+            self.allow_partial_import,
         )
         .await?;
 
@@ -206,6 +210,7 @@ impl MigrateZcashdWalletCmd {
         chain: Option<C>,
         wallet: ZcashdWallet,
         allow_multiple_wallet_imports: bool,
+        allow_partial_import: bool,
     ) -> Result<(), MigrateError> {
         let mut db_data = db.handle().await?;
         let network_params = *db_data.params();
@@ -554,6 +559,16 @@ impl MigrateZcashdWalletCmd {
             );
         }
 
+        // Evaluated only after the accounts that did import are fully set up
+        // (including the watch-only pubkey registration above), so that a failure
+        // here never leaves committed accounts in a half-configured state.
+        let document_account_count = document
+            .wallets()
+            .iter()
+            .map(|wallet| wallet.accounts().len())
+            .sum();
+        check_import_report(&report, document_account_count, allow_partial_import)?;
+
         print_backup_reminder();
 
         Ok(())
@@ -766,6 +781,77 @@ fn log_import_report(report: &ZewifImportReport) {
     }
 }
 
+/// Evaluates a ZeWIF import report against the number of accounts in the source
+/// document, failing the migration when accounts or spending material were left
+/// behind.
+///
+/// An import that creates no accounts from a document that contains some is
+/// always an error. Skipped accounts and unregistered transparent spending keys
+/// are errors unless partial imports are explicitly permitted; they concern
+/// spendable material that would otherwise silently remain only in the source
+/// `wallet.dat`. Representability limits that do not involve spendable key
+/// material (unrepresentable watch-only redeem scripts, transactions without
+/// raw data) remain warnings.
+fn check_import_report(
+    report: &ZewifImportReport,
+    document_account_count: usize,
+    allow_partial_import: bool,
+) -> Result<(), MigrateError> {
+    if document_account_count > 0 && report.imported_accounts.is_empty() {
+        return Err(MigrateError::NothingImported {
+            document_account_count,
+        });
+    }
+    let material_left_behind =
+        !report.skipped_accounts.is_empty() || !report.skipped_transparent_keys.is_empty();
+    if material_left_behind && !allow_partial_import {
+        return Err(MigrateError::PartialImport {
+            skipped_accounts: report.skipped_accounts.clone(),
+            skipped_transparent_keys: report.skipped_transparent_keys.clone(),
+        });
+    }
+    Ok(())
+}
+
+/// Renders the items a partial import left behind, one per line, for inclusion
+/// in the [`MigrateError::PartialImport`] message.
+fn describe_skipped_items(
+    skipped_accounts: &[SkippedAccount],
+    skipped_transparent_keys: &[SkippedTransparentKey],
+) -> String {
+    skipped_accounts
+        .iter()
+        .map(|skipped| match skipped.reason {
+            AccountSkipReason::SproutViewingKey => fl!(
+                "migrate-wallet-skipped-account-sprout",
+                name = skipped.name.as_str()
+            ),
+            AccountSkipReason::TransparentAddressSetWithoutSeed => fl!(
+                "migrate-wallet-skipped-account-no-seed",
+                name = skipped.name.as_str()
+            ),
+        })
+        .chain(
+            skipped_transparent_keys
+                .iter()
+                .map(|skipped| match skipped.reason {
+                    TransparentKeySkipReason::UncompressedPubKey => {
+                        fl!("migrate-wallet-skipped-key-uncompressed")
+                    }
+                    TransparentKeySkipReason::NoOwningAccount => fl!(
+                        "migrate-wallet-skipped-key-no-account",
+                        address = skipped
+                            .address
+                            .clone()
+                            .unwrap_or_else(|| fl!("migrate-wallet-unknown-address"))
+                    ),
+                }),
+        )
+        .map(|item| format!("  - {item}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 impl Runnable for MigrateZcashdWalletCmd {
     fn run(&self) {
         self.run_on_runtime();
@@ -798,6 +884,13 @@ pub(crate) enum MigrateError {
     Database(SqliteClientError),
     MultiImportDisabled,
     DuplicateImport(SeedFingerprint),
+    NothingImported {
+        document_account_count: usize,
+    },
+    PartialImport {
+        skipped_accounts: Vec<SkippedAccount>,
+        skipped_transparent_keys: Vec<SkippedTransparentKey>,
+    },
 }
 
 impl From<MigrateError> for Error {
@@ -867,6 +960,19 @@ impl From<MigrateError> for Error {
                     seed_fp = format!("{}", seed_fingerprint)
                 )))
             }
+            MigrateError::NothingImported {
+                document_account_count,
+            } => Error::from(ErrorKind::Generic.context(fl!(
+                "err-migrate-wallet-nothing-imported",
+                account_count = document_account_count.to_string()
+            ))),
+            MigrateError::PartialImport {
+                skipped_accounts,
+                skipped_transparent_keys,
+            } => Error::from(ErrorKind::Generic.context(fl!(
+                "err-migrate-wallet-partial-import",
+                skipped = describe_skipped_items(&skipped_accounts, &skipped_transparent_keys)
+            ))),
         }
     }
 }
@@ -899,11 +1005,18 @@ impl From<ChainError> for MigrateError {
 mod tests {
     use incrementalmerkletree::{Position, frontier::Frontier};
     use orchard::tree::MerkleHashOrchard;
+    use zcash_client_sqlite::{
+        AccountUuid,
+        zewif::{
+            AccountSkipReason, BirthdayBasis, ImportedAccount, SkippedAccount,
+            SkippedTransparentKey, TransparentKeySkipReason, ZewifImportReport,
+        },
+    };
     use zcash_protocol::consensus::{BlockHeight, NetworkType};
 
     use super::{
-        MigrateError, MigrateZcashdWalletCmd, ZCASHD_LEGACY_ACCOUNT_INDEX, enriched_document,
-        to_zewif_frontier,
+        MigrateError, MigrateZcashdWalletCmd, ZCASHD_LEGACY_ACCOUNT_INDEX, check_import_report,
+        describe_skipped_items, enriched_document, to_zewif_frontier,
     };
 
     fn node(byte: u8) -> MerkleHashOrchard {
@@ -959,6 +1072,137 @@ mod tests {
             }
             zewif::Frontier::Empty => panic!("frontier should be non-empty"),
         }
+    }
+
+    fn imported_account(name: &str) -> ImportedAccount {
+        ImportedAccount {
+            name: name.into(),
+            account_uuid: AccountUuid::from_uuid(uuid::Uuid::nil()),
+            birthday_basis: BirthdayBasis::ChainState,
+        }
+    }
+
+    fn skipped_account(name: &str) -> SkippedAccount {
+        SkippedAccount {
+            name: name.into(),
+            reason: AccountSkipReason::SproutViewingKey,
+        }
+    }
+
+    fn skipped_transparent_key() -> SkippedTransparentKey {
+        SkippedTransparentKey {
+            address: Some("t1ExampleAddress".into()),
+            reason: TransparentKeySkipReason::NoOwningAccount,
+        }
+    }
+
+    #[test]
+    fn empty_import_from_nonempty_document_is_a_hard_error() {
+        let report = ZewifImportReport::default();
+        for allow_partial_import in [false, true] {
+            assert!(matches!(
+                check_import_report(&report, 1, allow_partial_import),
+                Err(MigrateError::NothingImported {
+                    document_account_count: 1
+                })
+            ));
+        }
+    }
+
+    #[test]
+    fn empty_import_from_empty_document_is_not_an_error() {
+        assert!(check_import_report(&ZewifImportReport::default(), 0, false).is_ok());
+    }
+
+    #[test]
+    fn skipped_accounts_fail_without_allow_partial_import() {
+        let report = ZewifImportReport {
+            imported_accounts: vec![imported_account("imported")],
+            skipped_accounts: vec![skipped_account("sprout")],
+            ..Default::default()
+        };
+        assert!(matches!(
+            check_import_report(&report, 2, false),
+            Err(MigrateError::PartialImport { .. })
+        ));
+        assert!(check_import_report(&report, 2, true).is_ok());
+    }
+
+    #[test]
+    fn skipped_transparent_keys_fail_without_allow_partial_import() {
+        let report = ZewifImportReport {
+            imported_accounts: vec![imported_account("imported")],
+            skipped_transparent_keys: vec![skipped_transparent_key()],
+            ..Default::default()
+        };
+        assert!(matches!(
+            check_import_report(&report, 1, false),
+            Err(MigrateError::PartialImport { .. })
+        ));
+        assert!(check_import_report(&report, 1, true).is_ok());
+    }
+
+    #[test]
+    fn all_skipped_report_fails_hard_despite_allow_partial_import() {
+        let report = ZewifImportReport {
+            skipped_accounts: vec![skipped_account("sprout")],
+            ..Default::default()
+        };
+        assert!(matches!(
+            check_import_report(&report, 1, true),
+            Err(MigrateError::NothingImported {
+                document_account_count: 1
+            })
+        ));
+    }
+
+    #[test]
+    fn describe_skipped_items_renders_accounts_and_keys() {
+        crate::i18n::load_languages(&[]);
+        let skipped_accounts = vec![
+            SkippedAccount {
+                name: "sprout account".into(),
+                reason: AccountSkipReason::SproutViewingKey,
+            },
+            SkippedAccount {
+                name: "bare taddrs".into(),
+                reason: AccountSkipReason::TransparentAddressSetWithoutSeed,
+            },
+        ];
+        let skipped_transparent_keys = vec![
+            SkippedTransparentKey {
+                address: None,
+                reason: TransparentKeySkipReason::UncompressedPubKey,
+            },
+            SkippedTransparentKey {
+                address: Some("t1ExampleAddress".into()),
+                reason: TransparentKeySkipReason::NoOwningAccount,
+            },
+            SkippedTransparentKey {
+                address: None,
+                reason: TransparentKeySkipReason::NoOwningAccount,
+            },
+        ];
+        let rendered = describe_skipped_items(&skipped_accounts, &skipped_transparent_keys);
+        // One bulleted item per skipped account or key.
+        assert_eq!(rendered.matches("  - ").count(), 5);
+        assert!(rendered.starts_with("  - "));
+        assert!(rendered.contains("'sprout account'"));
+        assert!(rendered.contains("'bare taddrs'"));
+        assert!(rendered.contains("'t1ExampleAddress'"));
+        assert!(rendered.contains("unknown address"));
+    }
+
+    #[test]
+    fn clean_report_passes() {
+        let report = ZewifImportReport {
+            imported_accounts: vec![imported_account("imported")],
+            // Representability limits do not fail the migration.
+            redeem_scripts_not_representable: 2,
+            transactions_without_raw_data: 3,
+            ..Default::default()
+        };
+        assert!(check_import_report(&report, 1, false).is_ok());
     }
 
     fn test_document() -> (zewif::Zewif, zewif::SeedFingerprint, zewif::SeedFingerprint) {


### PR DESCRIPTION
Closes #740.

`import_wallet` reports — but does not error on — skipped accounts and unregistered
keys, and zallet logged those as warnings and exited 0. For a pre-Sapling seedless
wallet that meant a migration that "succeeded" while importing nothing.

The import report is now part of the command's success criteria, evaluated by a pure
function (`check_import_report`) right after the report is logged:

- Hard failure, no override: the document contained accounts but none imported —
  "nothing was migrated; your funds remain only in wallet.dat".
- Failure unless the new `--allow-partial-import` flag is passed: skipped accounts or
  unregistered transparent spending keys — both are spendable material silently
  stranded in wallet.dat. The error enumerates each item.
- Remain warnings: unrepresentable watch-only redeem scripts and transactions without
  raw data — representability limits, not loss of spendable key material.

Error wording is matched to what actually happens on failure: secrets are persisted to
the keystore before the DB import, so the nothing-imported message notes the orphaned
keystore material is harmless (all keystore inserts are idempotent) and a re-run after
fixing the cause is safe. The partial-import message does not claim that — the DB
import commits accounts before the report can be evaluated, so a re-run trips the
duplicate-import check; it says so, and that accepting a partial migration means
redoing it against a fresh wallet with the flag. Rolling back the committed import on
partial failure is future work that would make the flag a simple retry knob.

Unit tests cover all report shapes without a database; CLI docs and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S7s9MQzQ3Bmp42uabiSDbU

[COR-1780](https://linear.app/zodl/issue/COR-1780)