### PR TITLE
Stop an unreadable note commitment tree from silently corrupting the wallet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,26 @@ be considered breaking changes.
 
 ### Fixed
 
+- Fixed a wallet corruption that made sync fail permanently with a note
+  commitment tree conflict, reported as
+  `PutBlocksCommitmentTree { .. Insert(Conflict(..)) }`. Once a wallet reached
+  this state it exited on every start and could only be recovered by rewinding
+  it manually with `zallet repair truncate-wallet`.
+
+  The cause was a chain backend reporting no note commitment tree for a block at
+  or after a shielded pool's activation height, which Zallet accepted as an
+  empty tree and stored. Nothing detected the bad data at the time it was
+  written, so the wallet's tree silently diverged from the chain's and only
+  failed later, when a correct tree state disagreed with what had been stored —
+  potentially thousands of blocks after the damage was done. Backends now report
+  such reads as a temporary failure and sync retries, rather than storing a
+  placeholder. This was most likely to affect `zallet-zebra` users whose wallets
+  crossed the NU6.3 activation height, where the Ironwood pool's tree is new.
+
+  Wallets already in this state still need `zallet repair truncate-wallet` to
+  recover; this release prevents the corruption from occurring, and does not
+  repair a wallet that has already diverged.
+
 - `init-wallet-encryption` now canonicalizes the age recipients derived from
   the identity file before storing them, and validates that the resulting set
   is non-empty and parseable. Previously every line of the internally generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ be considered breaking changes.
   (default 100).
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
+- The `zallet repair check-witnesses` command, which reports the block ranges
+  that must be rescanned to rebuild missing witness data for the wallet's
+  spendable notes, and can queue them for rescanning with `--queue-rescan`.
+  Note it only examines notes the wallet holds, so a clean result does not prove
+  the wallet's note commitment trees agree with the chain's.
 - `migrate-zcashd-wallet --allow-partial-import` flag, permitting a migration
   to complete even when some accounts or transparent spending keys in the
   `zcashd` wallet could not be imported. The skipped items are reported as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,17 @@ be considered breaking changes.
 
 ### Fixed
 
+- A note commitment tree conflict during sync no longer shuts the wallet down
+  permanently. Zallet now rolls the wallet back to a progressively older point
+  and rescans, up to a bounded number of attempts and never below the wallet's
+  birthday. If that does not resolve it, Zallet still exits, but now says so
+  explicitly and suggests the `zallet repair truncate-wallet` height range to
+  try — rather than repeating the same conflict on every start with no
+  indication of what to do about it.
+
+  While recovering, the wallet is in its recovering state and balance and spend
+  methods are unavailable, as during a reorganization.
+
 - After a chain reorganization, the wallet now resumes scanning from the height
   it actually rewound to, rather than from the fork point it asked for. Rewinding
   the wallet can only stop at a height that is a checkpoint in every shielded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,18 @@ be considered breaking changes.
 
 ### Fixed
 
+- After a chain reorganization, the wallet now resumes scanning from the height
+  it actually rewound to, rather than from the fork point it asked for. Rewinding
+  the wallet can only stop at a height that is a checkpoint in every shielded
+  pool's note commitment tree, and older checkpoints are pruned, so a rollback
+  deeper than a hundred or so blocks could land well below the fork point.
+  Zallet then resumed just above the fork point regardless, skipping the blocks
+  in between and applying the rest onto a stale tree state — silently diverging
+  the wallet's note commitment tree from the chain's, which surfaced later as an
+  unrecoverable conflict. Deep reorganizations will now rescan somewhat more
+  than before, and the wallet stays in its recovering state (during which
+  balance and spend methods are unavailable) for correspondingly longer.
+
 - Fixed a wallet corruption that made sync fail permanently with a note
   commitment tree conflict, reported as
   `PutBlocksCommitmentTree { .. Insert(Conflict(..)) }`. Once a wallet reached

--- a/backends/zaino/CHANGELOG.md
+++ b/backends/zaino/CHANGELOG.md
@@ -20,6 +20,20 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- The chain view no longer substitutes an empty note commitment tree when the
+  validator reports no treestate for a pool at or after that pool's activation
+  height. Previously any such read — for Sapling, Orchard, or Ironwood — was
+  treated as "this pool is not active yet, so its tree is empty", which stored a
+  placeholder frontier that nothing validates and that only surfaced later, as
+  an unrecoverable `shardtree` conflict, once a correct frontier disagreed with
+  it. Such reads are now reported as a transient chain error so sync retries.
+  Reads below a pool's activation height are unaffected.
+
+  This backend was not implicated in the reports that prompted the fix, which
+  were all on `zallet-zebra`; the same unguarded fallback existed here.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Changed

--- a/backends/zaino/src/chain.rs
+++ b/backends/zaino/src/chain.rs
@@ -55,7 +55,7 @@ use crate::read_state::{AbortOnDrop, init_read_state_service, network_to_zebra};
 use zallet_core::components::chain::SpendStatus;
 use zallet_core::components::chain::{
     BlockLocator, Chain, ChainBlock, ChainError, ChainFactory, ChainTx, ChainView, ReportedUpgrade,
-    UpgradeStatus,
+    TreePool, UpgradeStatus, empty_tree_is_legitimate,
 };
 
 /// Classifies a block-fetch error, distinguishing transient reorg-window failures from
@@ -477,8 +477,26 @@ impl ChainView for ZainoChainView {
                 .await
                 .map_err(ChainError::backend)?;
 
+            // The validator reports a pool's treestate only from that pool's activation
+            // height onward; before then it is `None` and the final tree is empty. At or
+            // after activation, `None` means the validator could not serve it. Substituting
+            // an empty frontier there silently corrupts the wallet's note commitment tree
+            // (see `ChainView::tree_state_as_of`): nothing validates the frontier, so the
+            // bad data is stored and only surfaces later, potentially thousands of blocks
+            // on, as an unrecoverable `shardtree` conflict. Report it as unavailable so the
+            // sync engine retries instead.
+            let missing_tree = |pool: TreePool| -> ChainError {
+                ChainError::unavailable(format!(
+                    "the validator reported no {pool} treestate at height {height}, at or \
+                     after that pool's activation; refusing to substitute an empty frontier"
+                ))
+            };
+            let absent_tree_is_empty =
+                |pool: TreePool| empty_tree_is_legitimate(&self.params, pool, height);
+
             let final_sapling_tree = match sapling_treestate {
-                None => CommitmentTree::empty(),
+                None if absent_tree_is_empty(TreePool::Sapling) => CommitmentTree::empty(),
+                None => return Err(missing_tree(TreePool::Sapling)),
                 Some(sapling_treestate) => read_commitment_tree::<
                     sapling::Node,
                     _,
@@ -489,7 +507,8 @@ impl ChainView for ZainoChainView {
             .to_frontier();
 
             let final_orchard_tree = match orchard_treestate {
-                None => CommitmentTree::empty(),
+                None if absent_tree_is_empty(TreePool::Orchard) => CommitmentTree::empty(),
+                None => return Err(missing_tree(TreePool::Orchard)),
                 Some(orchard_treestate) => read_commitment_tree::<
                     orchard::tree::MerkleHashOrchard,
                     _,
@@ -499,15 +518,13 @@ impl ChainView for ZainoChainView {
             }
             .to_frontier();
 
-            // Ironwood shares the Orchard tree's shape. The validator reports an
-            // Ironwood treestate only from NU6.3 activation onward; before then it is
-            // `None` and the final tree is empty. Reading the real frontier (rather than
-            // always using an empty tree) is required once Ironwood notes exist,
-            // otherwise the wallet's advancing Ironwood commitment tree conflicts with
-            // the empty checkpoint frontier and `put_blocks` fails with a
-            // `CheckpointConflict`.
+            // Ironwood shares the Orchard tree's shape. Reading the real frontier (rather
+            // than always using an empty tree) is required once Ironwood notes exist,
+            // otherwise the wallet's advancing Ironwood commitment tree conflicts with the
+            // empty checkpoint frontier and `put_blocks` fails with a `CheckpointConflict`.
             let final_ironwood_tree = match ironwood_treestate {
-                None => CommitmentTree::empty(),
+                None if absent_tree_is_empty(TreePool::Ironwood) => CommitmentTree::empty(),
+                None => return Err(missing_tree(TreePool::Ironwood)),
                 Some(ironwood_treestate) => read_commitment_tree::<
                     orchard::tree::MerkleHashOrchard,
                     _,

--- a/backends/zebra/CHANGELOG.md
+++ b/backends/zebra/CHANGELOG.md
@@ -20,6 +20,33 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- The chain view no longer substitutes an empty note commitment tree when
+  `zebrad` reports no treestate for a finalized block at or after the pool's
+  activation height. Previously any such read — for Sapling, Orchard, or
+  Ironwood — was silently treated as "this pool is not active yet, so its tree
+  is empty".
+
+  That placeholder frontier was then committed to the wallet's note commitment
+  tree. Nothing catches it: `put_blocks` appears to validate the chain state it
+  is handed, but the scanned block's final tree size is itself derived from that
+  chain state, so the check is circular and a wrong frontier of any size passes.
+  The damage only surfaced later, when a correct frontier disagreed with what
+  had been stored, as an `Insert(Conflict(..))` from `shardtree` — reported as
+  `PutBlocksCommitmentTree`. Because `put_blocks` is transactional, the failing
+  write rolled back and every subsequent start hit the same conflict, leaving
+  the wallet crash-looping until it was manually rewound with
+  `zallet repair truncate-wallet`.
+
+  `zebrad` treats a missing post-activation tree as an invariant violation
+  rather than an empty tree, but only on its by-height lookup path; this backend
+  reads by block hash, which resolves the hash to a height first and reports no
+  tree if that resolution fails, bypassing the check. Such reads are now
+  reported as a transient chain error, so sync retries instead of corrupting the
+  wallet. Reads below a pool's activation height, where an absent tree genuinely
+  means the empty tree, are unaffected.
+
 ## [0.1.0-beta.2] - 2026-07-28
 
 ### Changed

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -349,8 +349,9 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
                 ChainError::unavailable(format!("pinned {pool} treestate reorged away"))
             }
         };
-        let absent_tree_is_empty =
-            |pool: TreePool| pinned_finalized && empty_tree_is_legitimate(&self.params, pool, height);
+        let absent_tree_is_empty = |pool: TreePool| {
+            pinned_finalized && empty_tree_is_legitimate(&self.params, pool, height)
+        };
 
         let final_sapling_tree = match self.reader.sapling_tree_bytes(hash).await? {
             Some(bytes) => {
@@ -769,7 +770,12 @@ mod tests {
         floor: u32,
         calls: Arc<AtomicU32>,
     ) -> ZebraChainView<MockChainReader> {
-        test_view_with_params(tip_height, floor, calls, Network::from_type(NetworkType::Main, &[]))
+        test_view_with_params(
+            tip_height,
+            floor,
+            calls,
+            Network::from_type(NetworkType::Main, &[]),
+        )
     }
 
     fn test_view_with_params(

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -34,6 +34,7 @@ use transparent::bundle::OutPoint;
 use zallet_core::components::chain::SpendStatus;
 use zallet_core::components::chain::{
     BlockLocator, Chain, ChainBlock, ChainError, ChainFactory, ChainTx, ChainView, ReportedUpgrade,
+    TreePool, empty_tree_is_legitimate,
 };
 use zallet_core::{
     components::TaskHandle,
@@ -325,10 +326,31 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
         let Some(hash) = self.resolve(height).await? else {
             return Ok(None);
         };
-        // For a finalized pinned hash, `None` tree bytes mean the pool was not yet active
-        // at that height (empty tree). For a non-finalized pinned hash (best-chain-only
-        // treestate lookups), `None` means the hash reorged off the best chain.
+        // For a non-finalized pinned hash (best-chain-only treestate lookups), `None` means
+        // the hash reorged off the best chain. For a finalized pinned hash, `None` means the
+        // pool was not yet active at that height — but *only* below the pool's activation
+        // height. At or above it, a missing tree is an invariant violation, and substituting
+        // an empty frontier silently corrupts the wallet's shardtree (see
+        // `ChainView::tree_state_as_of`); it must be reported as unavailable so the sync
+        // engine retries.
+        //
+        // Zebra cannot be relied on to catch this for us. `ironwood_tree_by_height` does
+        // treat a missing post-NU6.3 tree as a panic rather than masking it, but we read by
+        // *hash*, and `ironwood_tree_by_hash_or_height` resolves hash -> height first and
+        // returns `None` on failure — short-circuiting before that check ever runs.
         let pinned_finalized = height <= self.finalized_floor;
+        let missing_tree = |pool: TreePool| -> ChainError {
+            if pinned_finalized {
+                ChainError::unavailable(format!(
+                    "zebra reported no {pool} treestate at finalized height {height}, at or \
+                     after that pool's activation; refusing to substitute an empty frontier"
+                ))
+            } else {
+                ChainError::unavailable(format!("pinned {pool} treestate reorged away"))
+            }
+        };
+        let absent_tree_is_empty =
+            |pool: TreePool| pinned_finalized && empty_tree_is_legitimate(&self.params, pool, height);
 
         let final_sapling_tree = match self.reader.sapling_tree_bytes(hash).await? {
             Some(bytes) => {
@@ -337,12 +359,8 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
                 )
                 .map_err(ChainError::invalid_data)?
             }
-            None if pinned_finalized => CommitmentTree::empty(),
-            None => {
-                return Err(ChainError::unavailable(
-                    "pinned sapling treestate reorged away",
-                ));
-            }
+            None if absent_tree_is_empty(TreePool::Sapling) => CommitmentTree::empty(),
+            None => return Err(missing_tree(TreePool::Sapling)),
         }
         .to_frontier();
 
@@ -353,17 +371,12 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
                 { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
             >(&bytes[..])
             .map_err(ChainError::invalid_data)?,
-            None if pinned_finalized => CommitmentTree::empty(),
-            None => {
-                return Err(ChainError::unavailable(
-                    "pinned orchard treestate reorged away",
-                ));
-            }
+            None if absent_tree_is_empty(TreePool::Orchard) => CommitmentTree::empty(),
+            None => return Err(missing_tree(TreePool::Orchard)),
         }
         .to_frontier();
 
-        // Ironwood (NU6.3) shares the Orchard tree's shape. Zebra returns `None` for
-        // heights before NU6.3 activation, where the pool (and so its tree) is empty.
+        // Ironwood (NU6.3) shares the Orchard tree's shape.
         let final_ironwood_tree = match self.reader.ironwood_tree_bytes(hash).await? {
             Some(bytes) => read_commitment_tree::<
                 orchard::tree::MerkleHashOrchard,
@@ -371,12 +384,8 @@ impl<R: ChainReader> ChainView for ZebraChainView<R> {
                 { orchard::NOTE_COMMITMENT_TREE_DEPTH as u8 },
             >(&bytes[..])
             .map_err(ChainError::invalid_data)?,
-            None if pinned_finalized => CommitmentTree::empty(),
-            None => {
-                return Err(ChainError::unavailable(
-                    "pinned ironwood treestate reorged away",
-                ));
-            }
+            None if absent_tree_is_empty(TreePool::Ironwood) => CommitmentTree::empty(),
+            None => return Err(missing_tree(TreePool::Ironwood)),
         }
         .to_frontier();
 
@@ -760,6 +769,15 @@ mod tests {
         floor: u32,
         calls: Arc<AtomicU32>,
     ) -> ZebraChainView<MockChainReader> {
+        test_view_with_params(tip_height, floor, calls, Network::from_type(NetworkType::Main, &[]))
+    }
+
+    fn test_view_with_params(
+        tip_height: u32,
+        floor: u32,
+        calls: Arc<AtomicU32>,
+        params: Network,
+    ) -> ZebraChainView<MockChainReader> {
         let tip = ChainBlock::new(BlockHeight::from_u32(tip_height), h(tip_height));
         let mut cache = BTreeMap::new();
         cache.insert(tip.height(), tip.hash());
@@ -769,11 +787,27 @@ mod tests {
                 header_calls: calls,
             },
             validator_rpc: ValidatorRpcClient::new("127.0.0.1:1", "", "", None).unwrap(),
-            params: Network::from_type(NetworkType::Main, &[]),
+            params,
             tip,
             finalized_floor: BlockHeight::from_u32(floor),
             cache: Arc::new(Mutex::new(cache)),
         }
+    }
+
+    /// A regtest network activating NU6.3 at `height`, so the mock's small block heights can
+    /// straddle an activation boundary.
+    ///
+    /// Regtest carries an unspecified upgrade's height back from the next specified one, so
+    /// Sapling and NU5 activate at `height` too — every pool activates together. The mock
+    /// reader reports no tree bytes for any pool, so the guard trips on Sapling first; these
+    /// tests therefore prove the boundary behaviour, and
+    /// `zallet_core::components::chain::empty_tree_is_legitimate`'s own tests cover the
+    /// per-pool activation heights (including Ironwood on mainnet).
+    fn regtest_with_all_pools_at(height: u32) -> Network {
+        Network::from_type(
+            NetworkType::Regtest,
+            &[format!("37a5165b:{height}").try_into().unwrap()],
+        )
     }
 
     #[tokio::test]
@@ -814,11 +848,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tree_state_as_of_supplies_an_empty_ironwood_tree() {
-        // The mock reader returns no tree bytes, so for a finalized height every pool's
-        // final tree is empty. For Ironwood this pins the `None` fallback: Zebra returns no
-        // tree for finalized heights where the pool was not yet active (pre-NU6.3), and the
-        // chain view must map that to an empty frontier like the Sapling and Orchard reads.
+    async fn tree_state_as_of_supplies_an_empty_tree_before_activation() {
+        // The mock reader returns no tree bytes. Below a pool's activation height that is
+        // the correct answer -- the validator has no tree to report because the pool does
+        // not exist yet -- so the chain view maps it to an empty frontier. Mainnet height 3
+        // is below every pool's activation.
         let calls = Arc::new(AtomicU32::new(0));
         let view = test_view(10, 5, calls);
 
@@ -826,11 +860,63 @@ mod tests {
             .tree_state_as_of(BlockHeight::from_u32(3))
             .await
             .unwrap()
-            .expect("a finalized height with no tree bytes resolves to an empty chain state");
+            .expect("a pre-activation finalized height with no tree bytes resolves to an empty chain state");
 
         assert_eq!(state.block_height(), BlockHeight::from_u32(3));
         assert_eq!(state.final_sapling_tree().tree_size(), 0);
         assert_eq!(state.final_orchard_tree().tree_size(), 0);
         assert_eq!(state.final_ironwood_tree().tree_size(), 0);
+    }
+
+    #[tokio::test]
+    async fn tree_state_as_of_rejects_a_missing_tree_after_activation() {
+        // At or above activation a missing tree is an invariant violation, not an empty
+        // pool. Substituting an empty frontier here is what silently corrupts the wallet's
+        // shardtree: `put_blocks` cannot detect a wrong `from_state` (the scanned block's
+        // final tree size is derived from it), so the bad frontier is committed and only
+        // surfaces later as an unrecoverable `Conflict`. Report it as unavailable instead,
+        // which `is_retryable` treats as transient.
+        let calls = Arc::new(AtomicU32::new(0));
+        let view = test_view_with_params(10, 5, calls, regtest_with_all_pools_at(3));
+
+        let err = view
+            .tree_state_as_of(BlockHeight::from_u32(3))
+            .await
+            .expect_err("a missing post-activation tree must not resolve to an empty frontier");
+
+        assert!(
+            matches!(err, ChainError::Unavailable(_)),
+            "expected a retryable Unavailable error, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn tree_state_as_of_rejects_a_missing_tree_above_activation() {
+        // Guard against an off-by-one at the boundary: a height strictly above activation
+        // must be rejected too.
+        let calls = Arc::new(AtomicU32::new(0));
+        let view = test_view_with_params(10, 5, calls, regtest_with_all_pools_at(2));
+
+        let err = view
+            .tree_state_as_of(BlockHeight::from_u32(4))
+            .await
+            .expect_err("a missing post-activation tree must not resolve to an empty frontier");
+
+        assert!(matches!(err, ChainError::Unavailable(_)));
+    }
+
+    #[tokio::test]
+    async fn tree_state_as_of_still_reports_reorged_away_non_finalized_trees() {
+        // Above the finalized floor the pre-existing behaviour is unchanged: a missing tree
+        // means the pinned hash left the best chain, regardless of activation.
+        let calls = Arc::new(AtomicU32::new(0));
+        let view = test_view_with_params(10, 2, calls, regtest_with_all_pools_at(9));
+
+        let err = view
+            .tree_state_as_of(BlockHeight::from_u32(6))
+            .await
+            .expect_err("a non-finalized height with no tree bytes is unavailable");
+
+        assert!(matches!(err, ChainError::Unavailable(_)));
     }
 }

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -37,6 +37,7 @@
   - [rpc](cli/rpc.md)
   - [repair](cli/repair/README.md)
     - [truncate-wallet](cli/repair/truncate-wallet.md)
+    - [check-witnesses](cli/repair/check-witnesses.md)
 - [JSON-RPC methods](rpc/README.md)
 - [Migrating from `zcashd`](zcashd/README.md)
   - [JSON-RPC method status](zcashd/rpc_status.md)

--- a/book/src/cli/repair/README.md
+++ b/book/src/cli/repair/README.md
@@ -4,3 +4,4 @@ The `zallet` command-line tool comes bundled with a few commands that are specif
 investigating and repairing broken wallet states:
 
 - [`zallet repair truncate-wallet`](truncate-wallet.md)
+- [`zallet repair check-witnesses`](check-witnesses.md)

--- a/book/src/cli/repair/check-witnesses.md
+++ b/book/src/cli/repair/check-witnesses.md
@@ -1,0 +1,39 @@
+# The `repair check-witnesses` command
+
+Every note the wallet can spend needs a *witness*: a path proving the note's commitment is
+in the chain's note commitment tree. `zallet repair check-witnesses` tries to construct one
+for each note the wallet believes is currently spendable, and reports the block ranges that
+would have to be rescanned to rebuild the ones it could not.
+
+By default the command only reports. Each range is printed to standard output as
+`start..end`, with the end exclusive, and nothing is printed if every note has a witness:
+
+```
+$ zallet repair check-witnesses
+2999500..2999750
+3000100..3000200
+```
+
+Pass `--queue-rescan` to queue those ranges to be rescanned the next time the wallet syncs:
+
+```
+$ zallet repair check-witnesses --queue-rescan
+2999500..2999750
+```
+
+This is the only way the command modifies the wallet. Rescanning happens on the next
+`zallet start`, and only affects how the wallet reads the chain — no funds are at risk
+either way.
+
+## What this command cannot tell you
+
+It examines only notes the wallet holds. A wallet's note commitment tree can disagree with
+the chain's at positions where the wallet has no note of its own, and this command will not
+notice: it will report that every spendable note has a witness while the wallet is still
+broken.
+
+So a clean result here is not proof that the wallet's trees are sound. In particular, if
+`zallet start` is exiting with a note commitment tree conflict, this command is unlikely to
+find anything, and the tool you want is
+[`zallet repair truncate-wallet`](truncate-wallet.md) — roll the wallet back to before the
+conflicting data and let it rescan.

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -27,6 +27,20 @@ should be considered breaking changes.
   `transparent-key-import` feature), running the chain-dependent body of the
   new `zallet import-address` CLI command. Backend crates receive it through
   the blanket impl over `ChainFactory` and need no changes.
+- `components::chain::TreePool` and `components::chain::empty_tree_is_legitimate`,
+  for backends implementing `ChainView::tree_state_as_of`. Together they answer
+  whether a validator reporting *no* note commitment tree for a pool at a given
+  height legitimately means the empty tree (the pool has not activated yet) or is
+  a read failure that must be surfaced.
+
+  Backends must not substitute a placeholder frontier for one they could not
+  read. `ChainView::tree_state_as_of`'s documentation now spells out why: the
+  frontiers it returns are the wallet's only protection against note commitment
+  tree corruption, because `put_blocks`' apparent validation of them is circular
+  in Zallet's usage — the scanned block's final tree size is derived from the
+  same chain state the check compares it against. A wrong frontier is therefore
+  committed without complaint and only surfaces later as an unrecoverable
+  `shardtree` conflict.
 
 ### Changed
 

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -355,6 +355,26 @@ pub(crate) struct RpcCliCmd {
 #[cfg_attr(outside_buildscript, derive(Command, Runnable))]
 pub(crate) enum RepairCmd {
     TruncateWallet(TruncateWalletCmd),
+    CheckWitnesses(CheckWitnessesCmd),
+}
+
+/// Checks whether the wallet can construct a witness for each of its spendable notes.
+///
+/// Prints the block ranges that need rescanning to repair missing witness data, one
+/// `start..end` range per line, and prints nothing if there are none.
+///
+/// This only examines notes the wallet holds, so it cannot detect a note commitment tree that
+/// disagrees with the chain's at positions where the wallet has no note of its own. Finding
+/// nothing here does not prove the wallet's trees are sound; if `zallet start` is exiting with
+/// a note commitment tree conflict, rewind the wallet with `zallet repair truncate-wallet`.
+#[derive(Debug, Parser)]
+#[cfg_attr(outside_buildscript, derive(Command))]
+pub(crate) struct CheckWitnessesCmd {
+    /// Queue the reported ranges to be rescanned the next time the wallet syncs.
+    ///
+    /// Without this flag the command only reports, and does not modify the wallet.
+    #[arg(long)]
+    pub(crate) queue_rescan: bool,
 }
 
 /// Truncates the wallet database to at most the specified height.

--- a/zallet-core/src/commands/repair.rs
+++ b/zallet-core/src/commands/repair.rs
@@ -1,1 +1,2 @@
+mod check_witnesses;
 mod truncate_wallet;

--- a/zallet-core/src/commands/repair/check_witnesses.rs
+++ b/zallet-core/src/commands/repair/check_witnesses.rs
@@ -1,0 +1,54 @@
+use abscissa_core::Runnable;
+use nonempty::NonEmpty;
+use zcash_client_backend::data_api::scanning::ScanPriority;
+
+use crate::{
+    cli::CheckWitnessesCmd,
+    commands::AsyncRunnable,
+    components::database::Database,
+    error::{Error, ErrorKind},
+    prelude::*,
+};
+
+impl AsyncRunnable for CheckWitnessesCmd {
+    async fn run(&self) -> Result<(), Error> {
+        let config = APP.config();
+        let _lock = config.lock_datadir()?;
+
+        let db = Database::open(&config).await?;
+        let mut wallet = db.handle().await?;
+
+        let ranges = wallet
+            .check_witnesses()
+            .map_err(|e| ErrorKind::Generic.context(e))?;
+
+        for range in &ranges {
+            println!("{}..{}", range.start, range.end);
+        }
+
+        match NonEmpty::from_vec(ranges) {
+            None => info!("Every spendable note has a witness; nothing to rescan"),
+            Some(ranges) if self.queue_rescan => {
+                let count = ranges.len();
+                wallet
+                    // `Verify` is the priority the wallet uses for ranges it already scanned
+                    // but no longer trusts, which is exactly what these are.
+                    .queue_rescans(ranges, ScanPriority::Verify)
+                    .map_err(|e| ErrorKind::Generic.context(e))?;
+                info!("Queued {count} range(s) to be rescanned on the next sync");
+            }
+            Some(ranges) => info!(
+                "{} range(s) need rescanning; re-run with --queue-rescan to queue them",
+                ranges.len(),
+            ),
+        }
+
+        Ok(())
+    }
+}
+
+impl Runnable for CheckWitnessesCmd {
+    fn run(&self) {
+        self.run_on_runtime();
+    }
+}

--- a/zallet-core/src/components/chain.rs
+++ b/zallet-core/src/components/chain.rs
@@ -5,6 +5,7 @@
 //! modules, selected by cargo feature.
 
 use std::collections::{BTreeSet, HashMap};
+use std::fmt;
 use std::future::Future;
 use std::ops::Range;
 
@@ -514,6 +515,64 @@ pub(crate) async fn check_consensus_compatibility(
     }
 }
 
+/// A shielded pool with a note commitment tree that [`ChainView::tree_state_as_of`] reads.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TreePool {
+    /// The Sapling pool, active from the Sapling network upgrade.
+    Sapling,
+    /// The Orchard pool, active from NU5.
+    Orchard,
+    /// The Ironwood pool, active from NU6.3. Shares the Orchard tree's shape.
+    Ironwood,
+}
+
+impl TreePool {
+    /// The network upgrade that activates this pool. Before it, the pool's note commitment
+    /// tree is empty and validators legitimately report no tree at all.
+    fn activated_by(self) -> consensus::NetworkUpgrade {
+        match self {
+            TreePool::Sapling => consensus::NetworkUpgrade::Sapling,
+            TreePool::Orchard => consensus::NetworkUpgrade::Nu5,
+            TreePool::Ironwood => consensus::NetworkUpgrade::Nu6_3,
+        }
+    }
+}
+
+impl fmt::Display for TreePool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TreePool::Sapling => write!(f, "Sapling"),
+            TreePool::Orchard => write!(f, "Orchard"),
+            TreePool::Ironwood => write!(f, "Ironwood"),
+        }
+    }
+}
+
+/// Whether a validator reporting *no* note commitment tree for `pool` at `height` legitimately
+/// means "the empty tree", rather than "I could not read it".
+///
+/// A validator has no tree to report for heights before the pool activates, so there the empty
+/// tree is the correct answer. From activation onward a missing tree is an invariant violation
+/// — corruption, an interrupted format upgrade, or a block the validator cannot resolve — and
+/// substituting an empty frontier silently corrupts the wallet's shardtree (see
+/// [`ChainView::tree_state_as_of`]). `zebra-state` takes the same position internally, treating
+/// a missing post-activation tree as a panic rather than masking it.
+///
+/// Note this is deliberately a question about an *absent* tree, not an empty one: a tree that is
+/// present but empty is perfectly legitimate just after activation, and on networks where the
+/// pool has activated but no notes have been created yet.
+///
+/// Returns `true` when the pool has not activated at `height`, including on networks where the
+/// activating upgrade is not scheduled at all.
+pub fn empty_tree_is_legitimate(params: &Network, pool: TreePool, height: BlockHeight) -> bool {
+    use consensus::Parameters as _;
+
+    // Not scheduled at all, or scheduled above `height`: either way the pool is inactive here.
+    params
+        .activation_height(pool.activated_by())
+        .is_none_or(|activation| height < activation)
+}
+
 /// A consistent, reorg-immune view of the chain as of a fixed tip.
 ///
 /// A sequence of reads through one `ChainView` is mutually consistent.
@@ -531,6 +590,24 @@ pub trait ChainView: Clone + Send + Sync + 'static {
 
     /// Returns the final note commitment tree state for each shielded pool as of `height`,
     /// or `None` if `height` is above this view's tip.
+    ///
+    /// # Correctness
+    ///
+    /// The frontiers in the returned [`ChainState`] are the wallet's *only* protection
+    /// against note commitment tree corruption. `put_blocks` appears to validate them, but
+    /// in Zallet's usage that check is circular: the scanned block's final tree size is
+    /// derived from the same [`ChainState`] the check compares it against (Zallet builds
+    /// `BlockMetadata` from `from_state`, and `scanning::full::scan_block` derives
+    /// `*_final_tree_size` from that metadata). A wrong frontier of *any* size — including
+    /// an empty one — is therefore committed to the wallet's shardtree without complaint,
+    /// and only surfaces later as a `Conflict` when a correct frontier disagrees with it.
+    /// By then the wallet is unrecoverable without a manual rewind.
+    ///
+    /// Implementations must therefore never substitute a placeholder frontier for one they
+    /// could not read. Use [`empty_tree_is_legitimate`] to distinguish "this pool was not
+    /// active yet, so the empty tree is the right answer" from "I could not read this
+    /// tree", and report the latter as [`ChainError::Unavailable`] so the sync engine
+    /// retries instead of corrupting the wallet.
     fn tree_state_as_of(
         &self,
         height: BlockHeight,
@@ -1294,5 +1371,106 @@ mod tests {
             check_consensus_compatibility(&chain).await.unwrap(),
             Some(BlockHeight::from_u32(future)),
         );
+    }
+
+    mod empty_tree {
+        use super::super::{TreePool, empty_tree_is_legitimate};
+        use crate::network::Network as WalletNetwork;
+        use zcash_protocol::consensus::{BlockHeight, NetworkType};
+
+        fn mainnet() -> WalletNetwork {
+            WalletNetwork::from_type(NetworkType::Main, &[])
+        }
+
+        fn h(height: u32) -> BlockHeight {
+            BlockHeight::from_u32(height)
+        }
+
+        /// Mainnet activation heights, from `zcash_protocol`.
+        const SAPLING: u32 = 419_200;
+        const NU5: u32 = 1_687_104;
+        const NU6_3: u32 = 3_428_143;
+
+        #[test]
+        fn absent_tree_is_empty_below_activation() {
+            assert!(empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Ironwood,
+                h(NU6_3 - 1)
+            ));
+            assert!(empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Orchard,
+                h(NU5 - 1)
+            ));
+            assert!(empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Sapling,
+                h(SAPLING - 1)
+            ));
+        }
+
+        #[test]
+        fn absent_tree_is_an_error_at_activation() {
+            // The activation height itself is already "active": the pool's tree exists from
+            // this block onward, so a validator reporting none is wrong.
+            assert!(!empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Ironwood,
+                h(NU6_3)
+            ));
+            assert!(!empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Orchard,
+                h(NU5)
+            ));
+            assert!(!empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Sapling,
+                h(SAPLING)
+            ));
+        }
+
+        #[test]
+        fn absent_ironwood_tree_is_an_error_at_the_reported_failure_height() {
+            // The mainnet height from the beta.2 crash report: ~9.9k blocks past NU6.3, where
+            // substituting an empty Ironwood frontier corrupted the wallet's shardtree.
+            assert!(!empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Ironwood,
+                h(3_438_008)
+            ));
+        }
+
+        #[test]
+        fn pools_are_judged_independently() {
+            // Between NU5 and NU6.3, Orchard is active but Ironwood is not, so the same
+            // height gives opposite answers per pool. A guard that ignored the pool would
+            // either corrupt Orchard state or spuriously reject Ironwood reads.
+            let between = h(NU6_3 - 1);
+            assert!(!empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Orchard,
+                between
+            ));
+            assert!(empty_tree_is_legitimate(
+                &mainnet(),
+                TreePool::Ironwood,
+                between
+            ));
+        }
+
+        #[test]
+        fn absent_tree_is_empty_when_the_upgrade_is_not_scheduled() {
+            // Regtest with no nuparams schedules nothing, so no pool ever activates and an
+            // absent tree is always the empty tree. This is what keeps the guard from
+            // firing on networks where Ironwood is simply not in play.
+            let unscheduled = WalletNetwork::from_type(NetworkType::Regtest, &[]);
+            assert!(empty_tree_is_legitimate(
+                &unscheduled,
+                TreePool::Ironwood,
+                h(1_000_000)
+            ));
+        }
     }
 }

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -1,8 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::ops::Range;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 use std::time::SystemTime;
 
+use nonempty::NonEmpty;
 use rand::rngs::OsRng;
 use secrecy::SecretVec;
 use shardtree::{ShardTree, error::ShardTreeError};
@@ -26,7 +28,7 @@ use zcash_client_backend::{
         WalletTransparentOutput,
     },
 };
-use zcash_client_sqlite::{WalletDb, util::SystemClock};
+use zcash_client_sqlite::{WalletDb, error::SqliteClientError, util::SystemClock};
 use zcash_primitives::{block::BlockHash, transaction::Transaction};
 use zcash_protocol::{ShieldedPool, consensus::BlockHeight};
 use zip32::DiversifierIndex;
@@ -154,6 +156,26 @@ impl DbConnection {
             let _guard = self.lock.write().unwrap();
             f(self.inner.lock().unwrap().as_mut(), &self.params)
         })
+    }
+
+    /// Attempts to construct a witness for every note the wallet believes is currently
+    /// spendable, returning the block ranges that must be rescanned to repair missing witness
+    /// data.
+    ///
+    /// Note this only covers notes the wallet holds. It cannot detect a note commitment tree
+    /// that disagrees with the chain's at positions where the wallet has no note of its own,
+    /// so an empty result does not mean the tree is sound.
+    pub(crate) fn check_witnesses(&mut self) -> Result<Vec<Range<BlockHeight>>, SqliteClientError> {
+        self.with_mut(|mut db_data| db_data.check_witnesses())
+    }
+
+    /// Queues the given block ranges to be rescanned at the given priority.
+    pub(crate) fn queue_rescans(
+        &mut self,
+        rescan_ranges: NonEmpty<Range<BlockHeight>>,
+        priority: ScanPriority,
+    ) -> Result<(), SqliteClientError> {
+        self.with_mut(|mut db_data| db_data.queue_rescans(rescan_ranges, priority))
     }
 
     /// Imports the given pubkeys into the account without key derivation information, and

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -499,6 +499,70 @@ async fn locate_fork_point<V: ChainView>(
     .await
 }
 
+/// Resolves the block to resume scanning from after a rewind, given the height the wallet was
+/// asked to rewind to and the block it actually landed on.
+///
+/// Split out from [`truncate_to_wallet_checkpoint`] so the decision is testable without a
+/// database.
+fn resume_point(
+    requested: BlockHeight,
+    actual: Option<(BlockHeight, BlockHash)>,
+) -> Result<ChainBlock, SyncError> {
+    let (height, hash) = actual.ok_or_else(|| {
+        SyncError::Chain(ChainError::backend(format!(
+            "the wallet has no block recorded at {requested} after truncating to it",
+        )))
+    })?;
+
+    if height < requested {
+        warn!(
+            "Requested a rewind to {requested}, but the wallet could only rewind to {height} \
+             (older checkpoints have been pruned); resuming from {}",
+            height + 1,
+        );
+    }
+
+    Ok(ChainBlock::new(height, hash))
+}
+
+/// Truncates the wallet to `target`, returning the block the wallet actually ended up on.
+///
+/// [`WalletWrite::truncate_to_height`] snaps the request *down* to the highest height that is
+/// a checkpoint in every active pool's note commitment tree. Checkpoints are pruned beyond a
+/// bounded depth, retaining only periodic anchors below that, so for a rollback deeper than
+/// that window the wallet can land well below `target`.
+///
+/// Callers must resume scanning from the block this returns, not from `target`. Resuming from
+/// `target + 1` after landing lower leaves a gap in the wallet's history and applies the
+/// blocks above it onto a stale frontier, which silently diverges the wallet's note commitment
+/// tree from the chain's and only surfaces later as an unrecoverable `shardtree` conflict.
+fn truncate_to_wallet_checkpoint(
+    db_data: &mut DbConnection,
+    target: BlockHeight,
+) -> Result<ChainBlock, SyncError> {
+    let actual = match db_data.truncate_to_height(target) {
+        Ok(height) => height,
+        // No shared checkpoint at or below `target`, but the wallet told us the lowest height
+        // it can reach. Rewinding further than asked is always safe: it only means rescanning
+        // more. Rewinding *less* far is what corrupts the tree.
+        Err(SqliteClientError::RequestedRewindInvalid {
+            safe_rewind_height: Some(safe),
+            requested_height,
+        }) => {
+            warn!(
+                "The wallet cannot rewind to {requested_height}; rewinding to the lowest \
+                 available checkpoint {safe} instead",
+            );
+            db_data.truncate_to_height(safe)?
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    // `truncate_to_height` deletes `blocks` rows strictly above the height it returns, so the
+    // row at that height survives and its hash is the wallet's new tip.
+    resume_point(actual, db_data.get_block_hash(actual)?.map(|h| (actual, h)))
+}
+
 /// The next height to probe when walking back from `height` toward `birthday`, and whether
 /// that probe is the birthday floor (so the search must stop after it).
 fn rewind_step(height: BlockHeight, birthday: BlockHeight) -> (BlockHeight, bool) {
@@ -634,8 +698,11 @@ async fn steady_state<C: Chain>(
                     // Enter the recovering (safe-mode) state for the rewind and rescan;
                     // `steady_state_iteration` clears it once we reach the chain tip again.
                     status.begin_recovery(fork_point.height());
-                    db_data.truncate_to_height(fork_point.height())?;
-                    prev_tip = fork_point;
+                    // The wallet may only be able to rewind below the fork point, so resume
+                    // from wherever it actually landed.
+                    let resume_from = truncate_to_wallet_checkpoint(db_data, fork_point.height())?;
+                    status.begin_recovery(resume_from.height());
+                    prev_tip = resume_from;
                     continue;
                 }
                 return Err(error);
@@ -687,10 +754,6 @@ async fn steady_state_iteration<C: Chain>(
         let fork_point = locate_fork_point(&chain_view, db_data, *prev_tip).await?;
         assert!(fork_point.height() <= current_tip.height());
 
-        // Fetch blocks that need to be applied to the wallet.
-        let blocks_to_apply = chain_view.stream_blocks_to_tip(fork_point.height() + 1);
-        tokio::pin!(blocks_to_apply);
-
         // If the fork point is equal to `prev_tip` then no reorg has occurred.
         if fork_point != *prev_tip {
             // Ensured by `find_fork_point`.
@@ -707,9 +770,18 @@ async fn steady_state_iteration<C: Chain>(
             // Enter the recovering (safe-mode) state for the duration of the rewind and
             // rescan; it is cleared below once we reach the chain tip again.
             status.begin_recovery(fork_point.height());
-            db_data.truncate_to_height(fork_point.height())?;
-            *prev_tip = fork_point;
+            // The wallet may only be able to rewind below the fork point, so resume from
+            // wherever it actually landed rather than assuming the fork point.
+            let resume_from = truncate_to_wallet_checkpoint(db_data, fork_point.height())?;
+            status.begin_recovery(resume_from.height());
+            *prev_tip = resume_from;
         };
+
+        // Fetch blocks that need to be applied to the wallet. This must be built *after* any
+        // rewind above: the wallet can land below the fork point, and streaming from the fork
+        // point would skip the blocks in between, applying the rest onto a stale frontier.
+        let blocks_to_apply = chain_view.stream_blocks_to_tip(prev_tip.height() + 1);
+        tokio::pin!(blocks_to_apply);
 
         // Notify the wallet of block connections.
         while let Some(block) = blocks_to_apply.try_next().await.map_err(SyncError::Chain)? {
@@ -1128,8 +1200,8 @@ mod tests {
     use std::{sync::mpsc, time::Duration};
 
     use super::{
-        ChainError, PendingWalletSyncTasks, SyncError, WalletSync, is_retryable, rewind_step,
-        select_initial_scan_range, status, steady_state,
+        ChainError, PendingWalletSyncTasks, SyncError, WalletSync, is_retryable, resume_point,
+        rewind_step, select_initial_scan_range, status, steady_state,
     };
     use crate::{
         components::{
@@ -1176,6 +1248,39 @@ mod tests {
 
     fn h(height: u32) -> BlockHeight {
         BlockHeight::from_u32(height)
+    }
+
+    fn hash(seed: u8) -> BlockHash {
+        BlockHash([seed; 32])
+    }
+
+    // `truncate_to_height` snaps the requested height down to the highest height that is a
+    // checkpoint in every pool's tree, so the wallet can land below where it was asked to
+    // rewind to. Resuming from the requested height rather than the real one leaves a gap in
+    // the wallet's history and applies later blocks onto a stale frontier -- the silent
+    // divergence that only surfaces much later as an unrecoverable shardtree conflict.
+    #[test]
+    fn resume_point_uses_the_height_the_wallet_actually_reached() {
+        let resumed = resume_point(h(3_438_008), Some((h(3_434_976), hash(7)))).unwrap();
+        assert_eq!(resumed.height(), h(3_434_976));
+        assert_eq!(resumed.hash(), hash(7));
+    }
+
+    #[test]
+    fn resume_point_is_the_request_when_the_rewind_was_exact() {
+        let resumed = resume_point(h(500), Some((h(500), hash(1)))).unwrap();
+        assert_eq!(resumed.height(), h(500));
+        assert_eq!(resumed.hash(), hash(1));
+    }
+
+    // The wallet should always have a block at the height it truncated to, since truncation
+    // deletes only rows strictly above it. If it does not, resuming would fabricate a tip.
+    #[test]
+    fn resume_point_errors_when_the_wallet_has_no_block_there() {
+        assert!(matches!(
+            resume_point(h(500), None),
+            Err(SyncError::Chain(ChainError::Backend(_))),
+        ));
     }
 
     fn range(start: u32, end: u32, priority: ScanPriority) -> ScanRange {

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -376,12 +376,21 @@ async fn initialize<C: Chain>(
                         )
                         .await
                     };
-                    if let Err(e) = attempt.await {
-                        warn!(
+                    // Only transient failures may be swallowed here. `initialize` hands
+                    // `current_tip` to `steady_state` as its starting `prev_tip` whether or
+                    // not this scan committed anything, so ignoring a real error leaves
+                    // `steady_state` believing the wallet is at a block it never stored. The
+                    // next tip change then finds no wallet hash at that height, locates a
+                    // lower fork point, and misreads the situation as a reorg -- which is
+                    // one way the wallet's tree ends up diverging from the chain's.
+                    match attempt.await {
+                        Ok(_) => {}
+                        Err(e) if is_retryable(&e) => warn!(
                             "Best-effort tip scan during initialize failed; \
                              steady_state will populate metadata once the indexer \
                              catches up: {e}"
-                        );
+                        ),
+                        Err(e) => return Err(e),
                     }
                 }
                 break (current_tip, starting_boundary);
@@ -499,6 +508,122 @@ async fn locate_fork_point<V: ChainView>(
     .await
 }
 
+/// How far below the wallet's tip each successive note-commitment-tree recovery attempt rolls
+/// back, in blocks.
+///
+/// The rungs are: one block (a single bad checkpoint); the wallet's per-block checkpoint depth,
+/// which drops out of that window onto the retained periodic anchors; then anchor-interval
+/// multiples growing by 4x. The last rung reaches roughly two and a half weeks below the tip,
+/// which covers a divergence introduced well before it was noticed, without letting a
+/// misdiagnosis walk the wallet back to its birthday one attempt at a time.
+///
+/// These mirror `zcash_client_sqlite`'s pruning depth (100) and `zcash_client_backend`'s anchor
+/// retention interval (288). Both are crate-private upstream, so they are duplicated here; the
+/// exact values only affect how quickly recovery escalates, not its correctness.
+const TREE_RECOVERY_LADDER: &[u32] = &[1, 100, 288, 288 * 4, 288 * 16, 288 * 64];
+
+/// How many times [`recover_history`] re-attempts a scan that failed with a note commitment
+/// tree divergence before giving up, and the delay before each retry.
+///
+/// History recovery does not repair the tree itself; it waits for [`steady_state`], which owns
+/// that recovery, to rewind and re-queue the affected ranges underneath it. These bound how
+/// long it is willing to wait.
+const TREE_DIVERGENCE_RETRIES: u32 = 5;
+const TREE_DIVERGENCE_BACKOFF: &[Duration] = &[
+    Duration::from_secs(1),
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(15),
+    Duration::from_secs(30),
+];
+
+/// Whether an error means the wallet's note commitment tree disagrees with the chain's.
+///
+/// This is a different condition from [`SqliteClientError::BlockConflict`], which says the
+/// wallet is on a *different chain* at a known height and is resolved by the fork-point search.
+/// A tree conflict says the wallet's *tree* disagrees, which happens both after an undetected
+/// reorg and while the wallet is on the canonical chain — for instance when it stored a
+/// frontier that was wrong at the time and only now meets one that contradicts it. In the
+/// latter case the fork-point search finds nothing wrong and cannot help, so this class needs
+/// its own recovery.
+///
+/// All three variants are included because the same physical failure surfaces under different
+/// ones depending on which code path hit it.
+fn is_tree_divergence(error: &SyncError) -> bool {
+    match error {
+        SyncError::Tree(_) => true,
+        SyncError::Other(e) => matches!(
+            **e,
+            SqliteClientError::PutBlocksCommitmentTree { .. }
+                | SqliteClientError::CommitmentTree(_)
+                | SqliteClientError::TruncateCommitmentTree { .. }
+        ),
+        _ => false,
+    }
+}
+
+/// Bookkeeping for note-commitment-tree divergence recovery, carried across [`steady_state`]
+/// loop iterations.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TreeRecovery {
+    /// Rollback attempts made since the divergence was first observed.
+    attempts: usize,
+    /// The wallet tip at which the divergence was first observed.
+    ///
+    /// Recovery counts as successful, and `attempts` resets, only once the wallet climbs back
+    /// *above* this. Resetting on any successful scan instead would let a one-block rollback
+    /// followed by a one-block rescan cycle forever: each rescan would look like progress,
+    /// clear the counter, and hit the same conflict again with the ladder back at its first
+    /// rung.
+    high_water: Option<BlockHeight>,
+}
+
+impl TreeRecovery {
+    /// Records a divergence observed with the wallet at `wallet_tip`, returning how far below
+    /// it to roll back, or `None` once the attempt budget is exhausted.
+    fn next_depth(&mut self, wallet_tip: BlockHeight) -> Option<u32> {
+        self.high_water.get_or_insert(wallet_tip);
+        let depth = TREE_RECOVERY_LADDER.get(self.attempts).copied()?;
+        self.attempts += 1;
+        Some(depth)
+    }
+
+    /// Records that the wallet has scanned up to `wallet_tip`, returning whether this cleared
+    /// an in-progress recovery.
+    fn note_progress(&mut self, wallet_tip: BlockHeight) -> bool {
+        match self.high_water {
+            Some(high_water) if wallet_tip > high_water => {
+                *self = Self::default();
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// The tip at which the current divergence was first seen, for error reporting.
+    fn observed_at(&self, wallet_tip: BlockHeight) -> BlockHeight {
+        self.high_water.unwrap_or(wallet_tip)
+    }
+}
+
+/// The height to roll back to for a tree-divergence recovery attempt of the given `depth`,
+/// floored at the wallet's `birthday`.
+///
+/// Returns `None` when the floor leaves nowhere to go: rolling back to where the wallet already
+/// is cannot make progress, and retrying from there would spin.
+fn tree_recovery_target(
+    wallet_tip: BlockHeight,
+    depth: u32,
+    birthday: BlockHeight,
+) -> Option<BlockHeight> {
+    let target = BlockHeight::from_u32(
+        u32::from(wallet_tip)
+            .saturating_sub(depth)
+            .max(u32::from(birthday)),
+    );
+    (target < wallet_tip).then_some(target)
+}
+
 /// Resolves the block to resume scanning from after a rewind, given the height the wallet was
 /// asked to rewind to and the block it actually landed on.
 ///
@@ -561,6 +686,52 @@ fn truncate_to_wallet_checkpoint(
     // `truncate_to_height` deletes `blocks` rows strictly above the height it returns, so the
     // row at that height survives and its hash is the wallet's new tip.
     resume_point(actual, db_data.get_block_hash(actual)?.map(|h| (actual, h)))
+}
+
+/// Rolls the wallet back to recover from a note commitment tree divergence, returning the
+/// block to resume scanning from.
+///
+/// Each call rolls back further than the last (see [`TREE_RECOVERY_LADDER`]), because the
+/// conflicting data can be arbitrarily far below where the conflict was noticed: the wallet
+/// stores a bad frontier silently and only fails when a later, correct one contradicts it.
+/// Truncation removes tree data above the checkpoint it lands on, so a rollback only repairs
+/// the wallet if it reaches past the bad data.
+///
+/// Recovery is bounded, and gives up with [`SyncError::WalletTreeDiverged`] rather than
+/// rewinding indefinitely: past the ladder's reach the wallet is rescanning a lot of history
+/// on a guess, and the operator is better placed to choose.
+fn recover_from_tree_divergence(
+    db_data: &mut DbConnection,
+    prev_tip: &ChainBlock,
+    recovery: &mut TreeRecovery,
+) -> Result<ChainBlock, SyncError> {
+    let birthday = db_data
+        .get_wallet_birthday()?
+        .unwrap_or(BlockHeight::from_u32(0));
+    // Take the next rung first: it also records the high-water mark that `observed_at` reads.
+    let depth = recovery.next_depth(prev_tip.height());
+    let observed_at = recovery.observed_at(prev_tip.height());
+    let give_up = move |rolled_back_to| SyncError::WalletTreeDiverged {
+        observed_at,
+        rolled_back_to,
+        birthday,
+    };
+
+    let target = depth
+        .and_then(|depth| tree_recovery_target(prev_tip.height(), depth, birthday))
+        .ok_or_else(|| give_up(prev_tip.height()))?;
+
+    let resume_from = truncate_to_wallet_checkpoint(db_data, target)?;
+
+    // A rung that did not actually move the wallet down cannot break the conflict, and
+    // retrying from the same place would spin. This is reachable even with a target below
+    // `prev_tip`: truncation snaps to a checkpoint, and if the wallet is already sitting on
+    // the lowest one it has, it stays put.
+    if resume_from.height() >= prev_tip.height() {
+        return Err(give_up(resume_from.height()));
+    }
+
+    Ok(resume_from)
 }
 
 /// The next height to probe when walking back from `height` toward `birthday`, and whether
@@ -629,6 +800,8 @@ async fn steady_state<C: Chain>(
     // accumulated while the wallet was offline.
     tip_change_signal.notify_one();
 
+    let mut tree_recovery = TreeRecovery::default();
+
     loop {
         match steady_state_iteration(
             &chain,
@@ -643,7 +816,15 @@ async fn steady_state<C: Chain>(
         )
         .await
         {
-            Ok(ControlFlow::Continue(())) => (),
+            Ok(ControlFlow::Continue(())) => {
+                if tree_recovery.note_progress(prev_tip.height()) {
+                    info!(
+                        "Wallet recovered from the note commitment tree divergence; rescanned \
+                         past {}",
+                        prev_tip.height(),
+                    );
+                }
+            }
             // The chain reached a consensus-divergence height. Warn and end the task, which
             // triggers a graceful shutdown of the whole wallet. The iteration reports the
             // boundary height it stopped at, so we log that directly.
@@ -701,6 +882,27 @@ async fn steady_state<C: Chain>(
                     // The wallet may only be able to rewind below the fork point, so resume
                     // from wherever it actually landed.
                     let resume_from = truncate_to_wallet_checkpoint(db_data, fork_point.height())?;
+                    status.begin_recovery(resume_from.height());
+                    prev_tip = resume_from;
+                    continue;
+                }
+                // The wallet's note commitment tree disagrees with the chain's. Unlike a block
+                // conflict this is not necessarily a reorg, so the fork-point search cannot
+                // resolve it -- on the canonical chain it would find nothing wrong and rewind
+                // nowhere. `put_blocks` is transactional, so without recovery here the failing
+                // write rolls back, the task exits, and (since any sync-task exit shuts the
+                // process down) the wallet crash-loops on the same block forever. Roll back to
+                // a progressively older checkpoint and rescan instead.
+                if is_tree_divergence(&error) {
+                    warn!(
+                        "The wallet's note commitment tree diverges from the chain's at {}; \
+                         rolling back and rescanning (attempt {} of {}): {error}",
+                        prev_tip.height(),
+                        tree_recovery.attempts + 1,
+                        TREE_RECOVERY_LADDER.len(),
+                    );
+                    let resume_from =
+                        recover_from_tree_divergence(db_data, &prev_tip, &mut tree_recovery)?;
                     status.begin_recovery(resume_from.height());
                     prev_tip = resume_from;
                     continue;
@@ -933,18 +1135,43 @@ async fn recover_history<C: Chain>(
                 }
             })
         }) {
-            let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
-            if steps::scan_blocks(
-                chain_view,
-                db_data,
-                params,
-                &scan_range,
-                &decryptor,
-                shutdown_height,
-            )
-            .await?
-            .is_break()
-            {
+            // A note commitment tree divergence can surface here just as easily as in
+            // `steady_state`, but this task must not repair it: it holds its own database
+            // connection, so rolling back here would race `steady_state` doing the same.
+            // `steady_state` owns that recovery and re-queues the affected ranges, so wait
+            // for it rather than failing immediately -- an exit here shuts the whole wallet
+            // down.
+            let mut attempt = 0;
+            let outcome = loop {
+                let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
+                match steps::scan_blocks(
+                    chain_view,
+                    db_data,
+                    params,
+                    &scan_range,
+                    &decryptor,
+                    shutdown_height,
+                )
+                .await
+                {
+                    Ok(outcome) => break outcome,
+                    Err(error)
+                        if is_tree_divergence(&error) && attempt < TREE_DIVERGENCE_RETRIES =>
+                    {
+                        let backoff = TREE_DIVERGENCE_BACKOFF[attempt as usize];
+                        warn!(
+                            "History recovery hit a note commitment tree divergence scanning \
+                             {scan_range}; waiting {backoff:?} for steady-state sync to repair \
+                             it (attempt {} of {TREE_DIVERGENCE_RETRIES}): {error}",
+                            attempt + 1,
+                        );
+                        time::sleep(backoff).await;
+                        attempt += 1;
+                    }
+                    Err(error) => return Err(error),
+                }
+            };
+            if outcome.is_break() {
                 // Reached the consensus-divergence height. History recovery operates below
                 // the boundary in practice, so this is belt-and-suspenders; stop scanning
                 // this range and let the next loop re-evaluate.
@@ -1200,8 +1427,9 @@ mod tests {
     use std::{sync::mpsc, time::Duration};
 
     use super::{
-        ChainError, PendingWalletSyncTasks, SyncError, WalletSync, is_retryable, resume_point,
-        rewind_step, select_initial_scan_range, status, steady_state,
+        ChainError, PendingWalletSyncTasks, SyncError, TREE_RECOVERY_LADDER, TreeRecovery,
+        WalletSync, is_retryable, is_tree_divergence, resume_point, rewind_step,
+        select_initial_scan_range, status, steady_state, tree_recovery_target,
     };
     use crate::{
         components::{
@@ -1212,10 +1440,11 @@ mod tests {
         config::ZalletConfig,
         error::{Error, ErrorKind},
     };
+    use shardtree::error::{QueryError, ShardTreeError};
     use tokio::sync::Notify;
     use zcash_client_backend::data_api::scanning::{ScanPriority, ScanRange};
     use zcash_primitives::block::BlockHash;
-    use zcash_protocol::consensus::BlockHeight;
+    use zcash_protocol::{ShieldedPool, consensus::BlockHeight};
 
     struct TaskCancellationProbe(mpsc::Sender<()>);
 
@@ -1281,6 +1510,111 @@ mod tests {
             resume_point(h(500), None),
             Err(SyncError::Chain(ChainError::Backend(_))),
         ));
+    }
+
+    #[test]
+    fn tree_recovery_rolls_back_further_each_attempt() {
+        let mut recovery = TreeRecovery::default();
+        let depths: Vec<_> = std::iter::from_fn(|| recovery.next_depth(h(1_000_000))).collect();
+        assert_eq!(depths, TREE_RECOVERY_LADDER);
+        // Budget exhausted: the caller must give up rather than keep rewinding.
+        assert_eq!(recovery.next_depth(h(1_000_000)), None);
+    }
+
+    #[test]
+    fn tree_recovery_records_the_tip_where_the_divergence_was_first_seen() {
+        let mut recovery = TreeRecovery::default();
+        recovery.next_depth(h(1_000));
+        // Later attempts happen from lower tips as the wallet rolls back, but the reported
+        // origin stays where the problem was first noticed.
+        recovery.next_depth(h(900));
+        assert_eq!(recovery.observed_at(h(900)), h(1_000));
+    }
+
+    // The invariant that keeps recovery from spinning. Resetting on any successful scan would
+    // let "roll back one block, rescan one block, conflict again" repeat forever, because each
+    // rescan looks like progress and puts the ladder back on its first rung.
+    #[test]
+    fn tree_recovery_does_not_reset_below_the_high_water_mark() {
+        let mut recovery = TreeRecovery::default();
+        recovery.next_depth(h(1_000));
+        recovery.next_depth(h(999));
+        let attempts = recovery.attempts;
+
+        assert!(!recovery.note_progress(h(999)));
+        assert!(!recovery.note_progress(h(1_000)));
+        assert_eq!(recovery.attempts, attempts);
+        assert_eq!(recovery.observed_at(h(999)), h(1_000));
+    }
+
+    #[test]
+    fn tree_recovery_resets_once_resynced_past_the_high_water_mark() {
+        let mut recovery = TreeRecovery::default();
+        recovery.next_depth(h(1_000));
+
+        assert!(recovery.note_progress(h(1_001)));
+        assert_eq!(recovery, TreeRecovery::default());
+        // A fresh divergence starts the ladder over from the new tip.
+        assert_eq!(
+            recovery.next_depth(h(1_001)),
+            TREE_RECOVERY_LADDER.first().copied()
+        );
+    }
+
+    #[test]
+    fn tree_recovery_progress_is_a_no_op_when_no_recovery_is_underway() {
+        let mut recovery = TreeRecovery::default();
+        assert!(!recovery.note_progress(h(5_000)));
+        assert_eq!(recovery, TreeRecovery::default());
+    }
+
+    #[test]
+    fn tree_recovery_target_rolls_back_by_the_depth() {
+        assert_eq!(tree_recovery_target(h(1_000), 288, h(0)), Some(h(712)));
+    }
+
+    #[test]
+    fn tree_recovery_target_is_floored_at_the_birthday() {
+        assert_eq!(
+            tree_recovery_target(h(1_000), 100_000, h(950)),
+            Some(h(950))
+        );
+    }
+
+    // Once the birthday floor coincides with where the wallet already is, rolling back cannot
+    // make progress; recovery must give up rather than retry in place.
+    #[test]
+    fn tree_recovery_target_gives_up_at_the_birthday() {
+        assert_eq!(tree_recovery_target(h(950), 100_000, h(950)), None);
+        assert_eq!(tree_recovery_target(h(940), 100_000, h(950)), None);
+    }
+
+    #[test]
+    fn tree_conflicts_are_recognised_as_divergence() {
+        use zcash_client_sqlite::error::SqliteClientError;
+
+        assert!(is_tree_divergence(&SyncError::Other(Box::new(
+            SqliteClientError::TruncateCommitmentTree {
+                pool: ShieldedPool::Ironwood,
+                height: h(3_438_008),
+                error: ShardTreeError::Query(QueryError::CheckpointPruned),
+            }
+        ))));
+    }
+
+    #[test]
+    fn other_errors_are_not_tree_divergence() {
+        use zcash_client_sqlite::error::SqliteClientError;
+
+        // A block conflict is the wallet being on a different *chain*, which the fork-point
+        // search already handles; routing it into tree recovery would rewind unnecessarily.
+        assert!(!is_tree_divergence(&SyncError::Other(Box::new(
+            SqliteClientError::BlockConflict(h(3_438_008))
+        ))));
+        assert!(!is_tree_divergence(&SyncError::BatchDecryptorUnavailable));
+        assert!(!is_tree_divergence(&SyncError::Chain(
+            ChainError::unavailable("indexer is catching up")
+        )));
     }
 
     fn range(start: u32, end: u32, priority: ScanPriority) -> ScanRange {

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -878,7 +878,6 @@ async fn steady_state<C: Chain>(
                     let fork_point = locate_fork_point(&chain_view, db_data, candidate_tip).await?;
                     // Enter the recovering (safe-mode) state for the rewind and rescan;
                     // `steady_state_iteration` clears it once we reach the chain tip again.
-                    status.begin_recovery(fork_point.height());
                     // The wallet may only be able to rewind below the fork point, so resume
                     // from wherever it actually landed.
                     let resume_from = truncate_to_wallet_checkpoint(db_data, fork_point.height())?;
@@ -971,7 +970,6 @@ async fn steady_state_iteration<C: Chain>(
             );
             // Enter the recovering (safe-mode) state for the duration of the rewind and
             // rescan; it is cleared below once we reach the chain tip again.
-            status.begin_recovery(fork_point.height());
             // The wallet may only be able to rewind below the fork point, so resume from
             // wherever it actually landed rather than assuming the fork point.
             let resume_from = truncate_to_wallet_checkpoint(db_data, fork_point.height())?;

--- a/zallet-core/src/components/sync/error.rs
+++ b/zallet-core/src/components/sync/error.rs
@@ -20,6 +20,20 @@ pub(crate) enum SyncError {
     WalletDivergedBelowBirthday {
         birthday: BlockHeight,
     },
+    /// The wallet's note commitment tree disagrees with the chain's, and rolling the wallet
+    /// back to progressively older checkpoints did not resolve it.
+    ///
+    /// Automatic recovery is bounded so that a misdiagnosis cannot walk the wallet back to
+    /// its birthday one attempt at a time; past that bound it is a judgement call for the
+    /// operator, who may know something we do not (a bad validator, a restored backup).
+    WalletTreeDiverged {
+        /// The wallet tip at which the divergence was first observed.
+        observed_at: BlockHeight,
+        /// The height the wallet had been rolled back to when recovery gave up.
+        rolled_back_to: BlockHeight,
+        /// The wallet's birthday, the floor for any manual rewind.
+        birthday: BlockHeight,
+    },
 }
 
 impl fmt::Display for SyncError {
@@ -34,6 +48,18 @@ impl fmt::Display for SyncError {
                 f,
                 "the wallet's chain history diverges from the best chain below its birthday \
                  (height {birthday}); cannot continue syncing",
+            ),
+            SyncError::WalletTreeDiverged {
+                observed_at,
+                rolled_back_to,
+                birthday,
+            } => write!(
+                f,
+                "the wallet's note commitment tree diverges from the chain's (first seen at \
+                 height {observed_at}); rolling back as far as {rolled_back_to} did not \
+                 resolve it. Rewind the wallet further and let it rescan, with \
+                 `zallet repair truncate-wallet <height>` for a height between {birthday} \
+                 and {rolled_back_to}",
             ),
         }
     }


### PR DESCRIPTION
Closes #743

A user running v0.1.0-beta.2 with the zebra backend on mainnet hit
`PutBlocksCommitmentTree { pool: Ironwood, block_range: 3438008..3438010, error:
Insert(Conflict(Address { level: Level(3), index: 3660 })) }` and crash-looped on every
restart until they rewound the wallet by hand. #743 has the full decode; the short version is
that the address decodes to Ironwood note positions 29280..29287 and to the level-3 ommer of
the frontier at 3438008, so the wallet's tree was already wrong *before* the block it died on.

The core finding is that **nothing validates `from_state`**. `put_blocks` looks like it does —
it checks `from_state.tree_size() + commitments.len() == block.final_tree_size()` — but in
Zallet's usage both sides derive from the same value: `sync::steps` builds `BlockMetadata` from
`from_state`, and `scanning::full::scan_block` derives `*_final_tree_size` from that metadata.
The check is circular, so a wrong frontier of any size is committed to the wallet's shardtree
and only detonates later, when a correct frontier contradicts it.

## The commits

Each is independently reviewable and independently revertable.

**`5e0738e` — zebra: reject an empty frontier for an unreadable post-activation tree**

`tree_state_as_of` substituted `CommitmentTree::empty()` whenever the node reported no
treestate for a finalized block, for every pool. Below a pool's activation height that is
correct; at or above it, it silently corrupts the wallet.

zebra-state does guard this — `ironwood_tree_by_height` treats a missing post-NU6.3 tree as an
invariant violation rather than masking it — but only on the by-height path. We read by hash,
and `ironwood_tree_by_hash_or_height` resolves hash → height first and returns `None` if that
fails, short-circuiting before the check runs.

Adds `TreePool` / `empty_tree_is_legitimate` to zallet-core so both backends share one
definition, and documents the invariant on `ChainView::tree_state_as_of`. Failed reads at or
above activation now return `ChainError::Unavailable`, which `is_retryable` already treats as
transient, so sync stalls loudly instead of corrupting.

**`73fb61c` — zaino: the same guard.** Not implicated in any report, but it had the same
fallback in a wider form (no finalized/non-finalized distinction at all).

**`d09efc3` — sync: resume from the height the wallet actually rewound to**

`truncate_to_height` documents that it "may choose a lower block height … returns the height to
which the data store was actually truncated". Both call sites discarded that and set `prev_tip`
to the requested fork point, so a rollback deeper than the per-block checkpoint window could
leave a gap and apply later blocks onto a stale frontier — an independent route to the same
divergence. In `steady_state_iteration` the block stream was also built *before* the rewind, so
this reorders it.

**`e497c9a` — sync: recover from tree divergence instead of exiting**

Routing these into the existing `BlockConflict` arm would be *worse* than the crash loop: on the
canonical chain the locator head still matches, `find_fork_point` returns the wallet's own tip,
and truncating there is a no-op returning `Ok`, giving a tight retry loop instead of a clean
exit. So recovery gets its own driver: a fixed ladder of rollback depths, floored at the wallet
birthday and capped in attempts, failing with a `SyncError::WalletTreeDiverged` that names a
`repair truncate-wallet` height range.

The subtle part is `TreeRecovery::high_water`. Attempts reset only once the wallet climbs back
*above* where the divergence was first seen — resetting on any successful scan would let "roll
back one, rescan one, conflict again" repeat forever, since each rescan looks like progress and
returns the ladder to its first rung. There's a test pinning exactly that.

Also: `recover_history` gets bounded retry (it can raise the identical error and had no error
handling at all; it deliberately does *not* roll back itself, since it holds a separate DB
connection and would race `steady_state`), and `initialize`'s best-effort tip scan no longer
swallows non-retryable errors — it was handing `steady_state` a tip the wallet never stored,
which the next tip change misreads as a reorg.

**`86912e2` — repair: add `check-witnesses`**

Exposes `WalletDb::check_witnesses` as an operator tool. Deliberately **not** wired into the
recovery path: it only builds witnesses for notes the wallet holds, so a tree that disagrees
with the chain's where the wallet has no note of its own passes it cleanly — it would have
called this wallet healthy while it crash-looped. The CLI help and book page both say so.

## Testing

`zallet-core` 332 tests, zebra 8 unit + 9 acceptance, zaino 2 + 2. `cargo clippy --all-targets`
and `cargo fmt --check` clean in all three workspaces. New coverage: per-pool activation
boundaries (including Ironwood at the reported mainnet height 3,438,008), the zebra chain
view's pre/post-activation and non-finalized paths, `resume_point`, and the recovery ladder and
its anti-spin invariant.

The zebra chain-view tests use an all-`None` mock reader, and regtest activation heights carry
backward, so the guard trips on Sapling first there — the per-pool coverage lives in
zallet-core alongside the helper. That's called out in a comment rather than dressed up as
something more targeted than it is.

## What still needs checking

**This has not been run against mainnet.** The guard turns a silent-corruption path into a retry
stall, so if any backend legitimately returns no Ironwood tree for a post-activation *finalized*
block, those users would see sync stall rather than proceed. I don't expect it — zebra-state
treats that as an invariant violation itself — but it wants confirming against a synced mainnet
node past height 3,428,143 before this ships.

**The root cause is the best-supported hypothesis, not proven.** Confirming it needs the
reporter's pre-truncate `wallet.db` or their `ironwood_commitment_tree_size` values; #743 asks
for both. The main alternative is an undetected reorg leaving stale Ironwood leaves. These
changes are correct under either, which is why they're proposed without waiting for the answer.

Note this does **not** repair a wallet that has already diverged — those still need
`zallet repair truncate-wallet`. It prevents new corruption and stops the crash loop from being
permanent.

Unrelated to #587: that's the wallet failing to notice a *shrinking* tip after `invalidateblock`,
and nothing here unblocks `wallet_ironwood_reorg.py`.

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011NTkERgJYrU1oA7zKGDtPY
