### PR TITLE
rpc: Require explicit opt-in to serve plaintext JSON-RPC beyond loopback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ be considered breaking changes.
   (default 100).
 - `getwalletstatus` now reports a `locked` field indicating whether the wallet
   is currently usable.
+- The `rpc.allow_insecure_remote_bind` config option (default `false`),
+  explicitly opting in to serving plaintext JSON-RPC on a non-loopback
+  `rpc.bind` address.
+
 - The `zallet repair check-witnesses` command, which reports the block ranges
   that must be rescanned to rebuild missing witness data for the wallet's
   spendable notes, and can queue them for rescanning with `--queue-rescan`.
@@ -118,6 +122,13 @@ be considered breaking changes.
   neither that nor an account UUID is given. Previously an account UUID was
   required, so a freshly generated mnemonic — one with no accounts derived from
   it yet — could not be exported at all.
+- `zallet start` now refuses to open the JSON-RPC endpoint on a non-loopback
+  `rpc.bind` address unless `rpc.allow_insecure_remote_bind` is enabled, and
+  logs a prominent security warning when it is. The RPC interface is served
+  over plaintext HTTP, so a non-loopback bind exposes RPC credentials and
+  wallet passphrases to the network path; remote access should instead go
+  through an authenticated, encrypted tunnel such as SSH port forwarding or a
+  VPN. Previously any bind address was accepted without a warning.
 
 ### Fixed
 

--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -369,9 +369,31 @@ as_of_version = "0.1.0-beta.2"
 #
 # # Security
 #
+# The JSON-RPC interface is served over plaintext HTTP: neither the HTTP Basic
+# authentication credentials nor request bodies (which can contain wallet
+# passphrases and spending keys) are encrypted in transit. Zallet therefore
+# refuses to start if this is set to a non-loopback address, unless
+# `allow_insecure_remote_bind` is also set.
+#
+# For remote access, keep this bound to a loopback address and use an
+# authenticated, encrypted tunnel such as SSH port forwarding or a VPN.
+#
 # If you bind Zallet's RPC port to a public IP address, anyone on the internet can
 # view your transactions and spend your funds.
 #bind = []
+
+# Whether to allow `bind` to contain non-loopback addresses, exposing the
+# JSON-RPC interface to the network.
+#
+# # Security
+#
+# This is unsafe: the JSON-RPC interface is served over plaintext HTTP, so
+# anyone on the network path can read the RPC credentials and any wallet
+# passphrase sent to `walletpassphrase`, and can replay them. Only enable this
+# if the network path is fully trusted or separately protected, and prefer a
+# loopback `bind` plus an authenticated, encrypted tunnel (SSH or VPN)
+# instead. Zallet logs a prominent warning at startup while this is enabled.
+#allow_insecure_remote_bind = false
 
 # Timeout (in seconds) during HTTP requests.
 #timeout = 30

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -45,6 +45,18 @@ zebra_state_path = "/path/to/zebrad/state/cache"
 bind = ["127.0.0.1:SOMEPORT"]
 ```
 
+> **Security note:** Zallet's own JSON-RPC interface is served over plaintext
+> HTTP. The HTTP Basic authentication it uses does not encrypt anything: an
+> observer on the network path can read the RPC credentials, as well as any
+> wallet passphrase sent to `walletpassphrase`, and replay them — including
+> against fund-moving methods such as `z_sendmany`. Always keep `rpc.bind` on a
+> loopback address (as in the example above). For remote access, use an
+> authenticated, encrypted tunnel to the wallet host, such as SSH port
+> forwarding (`ssh -L 28232:127.0.0.1:28232 wallet-host`) or a VPN. Zallet
+> refuses to start with a non-loopback `rpc.bind` unless you explicitly opt in
+> with `rpc.allow_insecure_remote_bind = true`, which is unsafe on any network
+> path you do not fully trust.
+
 In particular, you currently need to configure the `[indexer]` section to point
 at your full node's JSON-RPC endpoint. The relevant config options in that
 section are:

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -34,6 +34,7 @@
 -zallet_toml = zallet.toml
 
 -cfg-keystore-require-backup = keystore.require_backup
+-cfg-rpc-allow-insecure-remote-bind = rpc.allow_insecure_remote_bind
 -cfg-rpc-auth = rpc.auth
 -cfg-rpc-auth-password = rpc.auth.password
 -cfg-rpc-auth-pwhash = rpc.auth.pwhash
@@ -198,6 +199,19 @@ err-init-identity-not-passphrase-encrypted = {$path} is not encrypted with a pas
 err-init-path-not-utf8 = {$path} is not currently supported (not UTF-8)
 err-init-identity-not-usable = Identity file at {$path} is not usable: {$error}
 err-init-rpc-auth-invalid = Invalid '{-cfg-rpc-auth}' configuration
+err-init-rpc-bind-not-loopback =
+    Refusing to open the JSON-RPC endpoint on non-loopback address {$addr}: the RPC
+    interface is served over plaintext HTTP, so RPC credentials and wallet
+    passphrases would be readable by anyone on the network path. Bind to a loopback
+    address and use an authenticated, encrypted tunnel (such as SSH port forwarding
+    or a VPN) for remote access, or set '{-cfg-rpc-allow-insecure-remote-bind} = true'
+    to accept the risk.
+warn-init-rpc-bind-insecure-remote =
+    SECURITY WARNING: serving plaintext JSON-RPC on non-loopback address {$addr}
+    because '{-cfg-rpc-allow-insecure-remote-bind}' is enabled. RPC credentials and
+    wallet passphrases sent to this endpoint can be read and replayed by anyone on
+    the network path. Prefer a loopback bind plus an authenticated, encrypted tunnel
+    (such as SSH port forwarding or a VPN).
 err-config-file-not-found = Configuration file at {$path} does not exist.
 err-config-file-invalid = Failed to parse configuration file at {$path}: {$error}
 err-init-incompatible-consensus =

--- a/zallet-core/src/components/json_rpc.rs
+++ b/zallet-core/src/components/json_rpc.rs
@@ -6,12 +6,15 @@
 //! - Some methods have the same name but slightly different semantics.
 //! - Some methods from the `zcashd` wallet are unsupported.
 
+use std::net::SocketAddr;
+
 use abscissa_core::tracing::{info, warn};
 use jsonrpsee::tracing::Instrument;
 
 use crate::{
     config::ZalletConfig,
     error::{Error, ErrorKind},
+    fl,
 };
 
 use super::{TaskHandle, chain::Chain, database::Database, sync::SyncStatusReader};
@@ -30,6 +33,38 @@ pub(crate) mod methods;
 pub(crate) mod payments;
 pub(crate) mod server;
 pub(crate) mod utils;
+
+/// The transport-security posture of a configured RPC bind address.
+///
+/// The JSON-RPC interface is served over plaintext HTTP, so HTTP Basic credentials
+/// and request bodies (which can contain wallet passphrases and spending keys) are
+/// not protected in transit. Serving it beyond loopback therefore requires an
+/// explicit opt-in from the operator.
+#[derive(Debug, PartialEq, Eq)]
+enum BindPolicy {
+    /// The address is a loopback address; plaintext HTTP is confined to the local
+    /// host.
+    Loopback,
+    /// The address is reachable from the network, and the operator has explicitly
+    /// accepted the risk of serving plaintext RPC on it. A prominent warning is
+    /// logged at startup.
+    InsecureRemote,
+    /// The address is reachable from the network and the operator has not opted in;
+    /// startup is refused.
+    Refused,
+}
+
+impl BindPolicy {
+    fn for_addr(addr: &SocketAddr, allow_insecure_remote: bool) -> Self {
+        if addr.ip().is_loopback() {
+            BindPolicy::Loopback
+        } else if allow_insecure_remote {
+            BindPolicy::InsecureRemote
+        } else {
+            BindPolicy::Refused
+        }
+    }
+}
 
 #[derive(Debug)]
 pub(crate) struct JsonRpc {}
@@ -50,6 +85,24 @@ impl JsonRpc {
                 return Err(ErrorKind::Init
                     .context("Only one RPC bind address is supported (for now)")
                     .into());
+            }
+            match BindPolicy::for_addr(&rpc.bind[0], rpc.allow_insecure_remote_bind()) {
+                BindPolicy::Loopback => (),
+                BindPolicy::InsecureRemote => warn!(
+                    "{}",
+                    fl!(
+                        "warn-init-rpc-bind-insecure-remote",
+                        addr = rpc.bind[0].to_string()
+                    )
+                ),
+                BindPolicy::Refused => {
+                    return Err(ErrorKind::Init
+                        .context(fl!(
+                            "err-init-rpc-bind-not-loopback",
+                            addr = rpc.bind[0].to_string()
+                        ))
+                        .into());
+                }
             }
             info!("Spawning RPC server");
             info!("Trying to open RPC endpoint at {}...", rpc.bind[0]);
@@ -72,6 +125,46 @@ impl JsonRpc {
                 "No JSON-RPC",
                 std::future::pending().in_current_span()
             ))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::{IpAddr, SocketAddr};
+
+    use proptest::prelude::*;
+
+    use super::BindPolicy;
+
+    proptest! {
+        /// A loopback bind is always permitted, with or without the opt-in.
+        #[test]
+        fn loopback_is_always_permitted(port in any::<u16>(), allow in any::<bool>(), v6 in any::<bool>()) {
+            let ip: IpAddr = if v6 {
+                std::net::Ipv6Addr::LOCALHOST.into()
+            } else {
+                std::net::Ipv4Addr::LOCALHOST.into()
+            };
+            prop_assert_eq!(
+                BindPolicy::for_addr(&SocketAddr::new(ip, port), allow),
+                BindPolicy::Loopback
+            );
+        }
+
+        /// Any non-loopback bind — unspecified, private, or public — is refused
+        /// without the opt-in, and only warned about with it.
+        #[test]
+        fn non_loopback_requires_opt_in(addr in any::<SocketAddr>(), allow in any::<bool>()) {
+            prop_assume!(!addr.ip().is_loopback());
+            prop_assert_eq!(
+                BindPolicy::for_addr(&addr, allow),
+                if allow {
+                    BindPolicy::InsecureRemote
+                } else {
+                    BindPolicy::Refused
+                }
+            );
         }
     }
 }

--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -786,10 +786,32 @@ pub struct RpcSection {
     ///
     /// # Security
     ///
+    /// The JSON-RPC interface is served over plaintext HTTP: neither the HTTP Basic
+    /// authentication credentials nor request bodies (which can contain wallet
+    /// passphrases and spending keys) are encrypted in transit. Zallet therefore
+    /// refuses to start if this is set to a non-loopback address, unless
+    /// `allow_insecure_remote_bind` is also set.
+    ///
+    /// For remote access, keep this bound to a loopback address and use an
+    /// authenticated, encrypted tunnel such as SSH port forwarding or a VPN.
+    ///
     /// If you bind Zallet's RPC port to a public IP address, anyone on the internet can
     /// view your transactions and spend your funds.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub bind: Vec<SocketAddr>,
+
+    /// Whether to allow `bind` to contain non-loopback addresses, exposing the
+    /// JSON-RPC interface to the network.
+    ///
+    /// # Security
+    ///
+    /// This is unsafe: the JSON-RPC interface is served over plaintext HTTP, so
+    /// anyone on the network path can read the RPC credentials and any wallet
+    /// passphrase sent to `walletpassphrase`, and can replay them. Only enable this
+    /// if the network path is fully trusted or separately protected, and prefer a
+    /// loopback `bind` plus an authenticated, encrypted tunnel (SSH or VPN)
+    /// instead. Zallet logs a prominent warning at startup while this is enabled.
+    pub allow_insecure_remote_bind: Option<bool>,
 
     /// Timeout (in seconds) during HTTP requests.
     pub timeout: Option<u64>,
@@ -805,6 +827,14 @@ impl RpcSection {
     /// Default is 1000.
     pub fn async_operation_limit(&self) -> usize {
         self.async_operation_limit.unwrap_or(1000)
+    }
+
+    /// Whether to allow `bind` to contain non-loopback addresses, exposing the
+    /// JSON-RPC interface to the network.
+    ///
+    /// Default is `false`.
+    pub fn allow_insecure_remote_bind(&self) -> bool {
+        self.allow_insecure_remote_bind.unwrap_or(false)
     }
 
     /// Timeout during HTTP requests.
@@ -944,6 +974,10 @@ impl ZalletConfig {
                 conf.note_management.target_note_count(),
             ),
             rpc("async_operation_limit", conf.rpc.async_operation_limit()),
+            rpc(
+                "allow_insecure_remote_bind",
+                conf.rpc.allow_insecure_remote_bind(),
+            ),
             rpc("bind", &conf.rpc.bind),
             rpc("timeout", conf.rpc.timeout().as_secs()),
             sync("recover_batch_size", conf.sync.recover_batch_size()),


### PR DESCRIPTION
Closes #749.

> **Stacked PR** on #748 (`feature/cor-1656`); only the last commit is new here. Merge #748 first, then retarget this to `main`.

## Motivation

The JSON-RPC interface is served over plaintext HTTP: HTTP Basic credentials and request bodies (including the passphrase supplied to `walletpassphrase`, and spending keys) are not encrypted in transit, and a captured Basic header is replayable. Zallet nevertheless accepted any `rpc.bind` address without a runtime warning or opt-in.

Fixes the finding tracked as:
- Least Authority ZCG Zallet Initial Audit Report (24 Jul 2026), Issue N (Medium)
- Linear: [COR-1661](https://linear.app/zodl/issue/COR-1661)

## Solution

Implements the audit's stronger remediation (reject by default + explicit unsafe opt-in + runtime warning + docs):

- `zallet start` now refuses to open the JSON-RPC endpoint on a non-loopback `rpc.bind` address, with an error explaining the risk and the secure alternative (SSH port forwarding or VPN to a loopback bind).
- New `rpc.allow_insecure_remote_bind` config option (default `false`) explicitly opts in to plaintext non-loopback serving; a prominent `SECURITY WARNING` is logged at startup while it is enabled.
- The decision is a pure `BindPolicy` function on the bind address + opt-in flag.
- Docs: expanded `rpc.bind` config rustdoc (feeds `example-config` and the book's config reference; golden regenerated) and a security note with the SSH-tunnel pattern in the book's setup guide.

## Test evidence

- New proptests: any loopback bind (v4/v6, any port) is always permitted; any non-loopback `SocketAddr` is refused without the opt-in and warned-and-allowed with it.
- `TRYCMD` golden `example_config.out/zallet.toml` regenerated and `cli_tests` passes.
- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)