### PR TITLE
rpc: Enforce a maximum size when buffering JSON-RPC request bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,14 @@ be considered breaking changes.
 - A regtest wallet's transactions mined under NU6.3 (Ironwood) no longer fail
   to import with "Consensus branch ID not known". Bumped `zewif-zcashd` to
   0.1.0-rc.5, which includes NU6.3 in the regtest activation schedule.
+- The JSON-RPC server now rejects HTTP request bodies larger than 10 MiB (the
+  request-size limit the RPC server already enforced after parsing) with
+  `413 Payload Too Large` before buffering them (GHSA-m539-482m-q66j).
+  Previously the version-compatibility middleware buffered the complete
+  request body into memory without a size limit, allowing an authenticated
+  caller to exhaust wallet memory with a single oversized request. A request
+  body that cannot be read now yields `400 Bad Request` instead of killing
+  the connection task.
 - `example-config` and `migrate-zcash-conf` no longer panic when `-o/--output`
   is omitted. As their documentation already stated, they now write to the
   default Zallet config file path (`zallet.toml` in the datadir), matching the

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -96,6 +96,11 @@ pub(crate) async fn spawn<C: Chain>(
 
     let server_instance = Server::builder()
         .http_only()
+        // Keep the server's parse limit equal to what the compatibility middleware
+        // will buffer, so neither can drift into accepting a body the other rejects.
+        .max_request_body_size(
+            http_request_compatibility::HttpRequestMiddleware::<()>::MAX_REQUEST_BODY_SIZE,
+        )
         .set_http_middleware(http_middleware)
         .set_rpc_middleware(rpc_middleware)
         .build(listen_addr)

--- a/zallet-core/src/components/json_rpc/server/http_request_compatibility.rs
+++ b/zallet-core/src/components/json_rpc/server/http_request_compatibility.rs
@@ -6,10 +6,10 @@ use std::future::Future;
 use std::pin::Pin;
 
 use futures::FutureExt;
-use http_body_util::BodyExt;
+use http_body_util::{BodyExt, LengthLimitError, Limited};
 use hyper::{StatusCode, header};
 use jsonrpsee::{
-    core::BoxError,
+    core::{BoxError, TEN_MB_SIZE_BYTES},
     server::{HttpBody, HttpRequest, HttpResponse},
     types::{ErrorCode, ErrorObject},
 };
@@ -96,16 +96,46 @@ impl<S> HttpRequestMiddleware<S> {
         }
     }
 
+    /// The maximum HTTP request body size this middleware will buffer.
+    ///
+    /// This middleware buffers the complete body before `jsonrpsee` parses the
+    /// request, so `jsonrpsee`'s own limit cannot protect the buffering here; an
+    /// authenticated caller could otherwise stream an arbitrarily large body into
+    /// memory.
+    ///
+    /// This must not exceed the limit `jsonrpsee` applies to the requests it parses,
+    /// or the middleware would buffer bodies the server then rejects — the memory
+    /// exhaustion this exists to prevent. Rather than duplicating `jsonrpsee`'s
+    /// default and hoping the two stay in step, [`super::spawn`] configures the
+    /// server from this same constant, so there is one value to change.
+    pub(super) const MAX_REQUEST_BODY_SIZE: u32 = TEN_MB_SIZE_BYTES;
+
     /// Maps whatever JSON-RPC version the client is using to JSON-RPC 2.0.
+    ///
+    /// Returns an error response to send back instead, if the request body could not
+    /// be buffered: `413 Payload Too Large` if it exceeds
+    /// [`Self::MAX_REQUEST_BODY_SIZE`], or `400 Bad Request` if reading it failed.
     async fn request_to_json_rpc_2(
         request: HttpRequest<HttpBody>,
-    ) -> (JsonRpcVersion, HttpRequest<HttpBody>) {
+    ) -> Result<(JsonRpcVersion, HttpRequest<HttpBody>), HttpResponse> {
         let (parts, body) = request.into_parts();
-        let bytes = body
+        let bytes = match Limited::new(body, Self::MAX_REQUEST_BODY_SIZE as usize)
             .collect()
             .await
-            .expect("Failed to collect body data")
-            .to_bytes();
+        {
+            Ok(collected) => collected.to_bytes(),
+            Err(e) => {
+                let status = if e.is::<LengthLimitError>() {
+                    StatusCode::PAYLOAD_TOO_LARGE
+                } else {
+                    StatusCode::BAD_REQUEST
+                };
+                return Err(HttpResponse::builder()
+                    .status(status)
+                    .body(HttpBody::empty())
+                    .expect("status and empty body are always valid"));
+            }
+        };
 
         let (version, bytes) = match serde_json::from_slice::<'_, JsonRpcRequest>(bytes.as_ref()) {
             Ok(request) => {
@@ -122,10 +152,10 @@ impl<S> HttpRequestMiddleware<S> {
             _ => (JsonRpcVersion::Unknown, bytes),
         };
 
-        (
+        Ok((
             version,
             HttpRequest::from_parts(parts, HttpBody::from(bytes.as_ref().to_vec())),
-        )
+        ))
     }
 
     /// Maps JSON-2.0 to whatever JSON-RPC version the client is using.
@@ -217,7 +247,10 @@ where
         let mut service = self.service.clone();
 
         async move {
-            let (version, request) = Self::request_to_json_rpc_2(request).await;
+            let (version, request) = match Self::request_to_json_rpc_2(request).await {
+                Ok(mapped) => mapped,
+                Err(error_response) => return Ok(error_response),
+            };
             let response = service.call(request).await.map_err(Into::into)?;
             Ok(Self::response_from_json_rpc_2(version, response).await)
         }
@@ -272,6 +305,80 @@ impl JsonRpcRequest {
     fn into_2(mut self) -> Self {
         self.jsonrpc = Some("2.0".into());
         self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The middleware is generic over the wrapped service, but the request mapping
+    /// never touches it, so any type parameter works for exercising it.
+    type Middleware = HttpRequestMiddleware<()>;
+
+    fn request_with_body(body: Vec<u8>) -> HttpRequest<HttpBody> {
+        HttpRequest::builder()
+            .body(HttpBody::from(body))
+            .expect("valid request")
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn oversized_body_is_rejected_not_buffered() {
+        let body = vec![b'0'; Middleware::MAX_REQUEST_BODY_SIZE as usize + 1];
+        let response = Middleware::request_to_json_rpc_2(request_with_body(body))
+            .await
+            .expect_err("a body over the limit must be rejected");
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn body_at_the_limit_is_accepted() {
+        // Not valid JSON-RPC, so the mapping passes it through untouched for
+        // `jsonrpsee` to reject; what matters here is that buffering succeeds.
+        let body = vec![b'0'; Middleware::MAX_REQUEST_BODY_SIZE as usize];
+        let (version, _request) = Middleware::request_to_json_rpc_2(request_with_body(body))
+            .await
+            .expect("a body at the limit must be buffered");
+        assert!(matches!(version, JsonRpcVersion::Unknown));
+    }
+
+    /// A body whose stream fails for a reason other than the size limit maps to
+    /// `400 Bad Request`, not the `413` reserved for oversized bodies.
+    #[tokio::test(flavor = "multi_thread")]
+    async fn unreadable_body_is_a_bad_request() {
+        // A stream that yields an error rather than data: the read fails without ever
+        // reaching the length limit.
+        let failing = HttpBody::new(http_body_util::StreamBody::new(futures::stream::once(
+            async {
+                Err(Box::<dyn std::error::Error + Send + Sync>::from(
+                    "peer went away mid-body",
+                ))
+            },
+        )));
+        let request = HttpRequest::builder().body(failing).expect("valid request");
+
+        let response = Middleware::request_to_json_rpc_2(request)
+            .await
+            .expect_err("an unreadable body must be rejected");
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn small_request_is_mapped_to_json_rpc_2() {
+        let body = br#"{"method":"getinfo","params":[],"id":1}"#.to_vec();
+        let (version, request) = Middleware::request_to_json_rpc_2(request_with_body(body))
+            .await
+            .expect("a small body must be buffered");
+        assert!(matches!(version, JsonRpcVersion::Bitcoind));
+
+        let bytes = request
+            .into_body()
+            .collect()
+            .await
+            .expect("body was buffered")
+            .to_bytes();
+        let mapped: JsonRpcRequest = serde_json::from_slice(&bytes).expect("valid JSON");
+        assert_eq!(mapped.jsonrpc.as_deref(), Some("2.0"));
     }
 }
 


### PR DESCRIPTION
Closes #753.

> **Stacked PR** on #752 (`feature/cor-1671`) → #750 → #748; only the last commit is new here. Merge the stack bottom-up and retarget.

## Motivation

The HTTP compatibility middleware buffered the complete request body into memory (`body.collect()`) before jsonrpsee's own `max_request_body_size` could apply, so an authenticated caller could exhaust wallet memory with a single oversized request.

Fixes the finding tracked as:
- GHSA-m539-482m-q66j ("RPC middleware buffers the entire request body with no size limit")
- Least Authority ZCG Zallet Initial Audit Report (24 Jul 2026), Suggestion 8
- Linear: [COR-1670](https://linear.app/zodl/issue/COR-1670)

## Solution

Wrap the body in `http_body_util::Limited` before collecting, capped at `jsonrpsee::core::TEN_MB_SIZE_BYTES` — the same server-default limit jsonrpsee applies to the requests it parses, reused rather than re-derived. Over-limit bodies get `413 Payload Too Large`; a body that cannot be read gets `400 Bad Request` (previously an `expect()` panicked the connection task).

## Test evidence

- New unit tests: a body one byte over the limit is rejected with 413 without being buffered; a body exactly at the limit is accepted; a small Bitcoin-flavoured request is still mapped to JSON-RPC 2.0.
- `cargo test -p zallet-core`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)