### PR TITLE
rpc: Restrict spend input selection to the source address's receiver pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,14 @@ be considered breaking changes.
 - A regtest wallet's transactions mined under NU6.3 (Ironwood) no longer fail
   to import with "Consensus branch ID not known". Bumped `zewif-zcashd` to
   0.1.0-rc.5, which includes NU6.3 in the regtest activation schedule.
+- `z_sendmany` and `pczt_create` now select inputs only from the value pools
+  named by the `fromaddress`'s receivers, as the `z_sendmany` documentation
+  already promised: a bare Sapling address or Sapling-only unified address no
+  longer draws on the account's Orchard notes, and an Orchard-only unified
+  address no longer draws on its Sapling notes. (An Orchard receiver permits
+  both the Orchard and Ironwood pools, since payments to Orchard receivers are
+  accounted to the Ironwood pool once it is active.) Previously any shielded
+  `fromaddress` permitted selection from all of the account's shielded pools.
 - The JSON-RPC server now rejects HTTP request bodies larger than 10 MiB (the
   request-size limit the RPC server already enforced after parsing) with
   `413 Payload Too Large` before buffering them (GHSA-m539-482m-q66j).

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -261,6 +261,8 @@ async fn run<C: Chain>(
 #[cfg(test)]
 mod tests {
     use proptest::prelude::*;
+    use std::collections::BTreeSet;
+
     use zcash_client_backend::{
         data_api::wallet::input_selection::{CoinbasePolicy, TransparentSource},
         fees::TransparentChangePolicy,
@@ -269,7 +271,7 @@ mod tests {
         address::{Address, UnifiedAddress},
         keys::{UnifiedAddressRequest, UnifiedSpendingKey},
     };
-    use zcash_protocol::consensus::Network;
+    use zcash_protocol::{ShieldedPool, consensus::Network};
     use zip32::AccountId;
 
     use super::{SpendPolicy, legacy_pool_spend_policy};
@@ -395,6 +397,10 @@ mod tests {
             account in arb_account(),
         ) {
             let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            // Some seeds derive an address without every shielded receiver; those
+            // receiver-restricted cases are covered by
+            // `unified_source_spends_only_its_receivers_pools`.
+            prop_assume!(ua.orchard().is_some() && ua.sapling().is_some());
 
             let policy = spend_policy_for(&Address::Unified(ua));
 
@@ -403,11 +409,94 @@ mod tests {
                 "a shielded source must not permit transparent spending",
             );
 
-            // Shielded selection is left exactly as it was before transparent spending
-            // existed. Comparing against the default's pool set keeps that true for any
-            // pool added later, rather than pinning today's three.
+            // The address carries every shielded receiver type, so its permitted pools
+            // are exactly the full set. Comparing against the default's pool set keeps
+            // that true for any pool added later, rather than pinning today's three.
             let unchanged = SpendPolicy::default();
             prop_assert_eq!(policy.shielded(), unchanged.shielded());
+        }
+
+        /// A bare Sapling source draws only on the Sapling pool, never on the account's
+        /// Orchard or Ironwood notes, and on no transparent UTXO.
+        #[test]
+        fn sapling_source_spends_only_the_sapling_pool(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let Some(saddr) = ua.sapling().cloned() else { return Ok(()) };
+
+            let policy = spend_policy_for(&Address::Sapling(saddr));
+
+            prop_assert_eq!(
+                policy.shielded(),
+                &BTreeSet::from([ShieldedPool::Sapling]),
+                "a Sapling source must draw only on the Sapling pool",
+            );
+            prop_assert!(
+                policy.transparent().is_none(),
+                "a shielded source must not permit transparent spending",
+            );
+        }
+
+        /// A receiver-restricted unified address selects inputs only from the value pools
+        /// its receivers name, as the `z_sendmany` documentation promises. An Orchard
+        /// receiver names both the Orchard pool and the Ironwood pool (where payments to
+        /// Orchard receivers are accounted once Ironwood is active).
+        #[test]
+        fn unified_source_spends_only_its_receivers_pools(
+            seed in any::<[u8; 32]>(),
+            account in arb_account(),
+            include_transparent in any::<bool>(),
+        ) {
+            let Some(ua) = ua_from(&seed, account) else { return Ok(()) };
+            let orchard = ua.orchard().copied();
+            let sapling = ua.sapling().cloned();
+            // The transparent receiver's presence must make no difference to the
+            // permitted pools, so the property quantifies over it.
+            let transparent = include_transparent
+                .then(|| ua.transparent().copied())
+                .flatten();
+
+            let orchard_pools = BTreeSet::from([ShieldedPool::Orchard, ShieldedPool::Ironwood]);
+            let sapling_pools = BTreeSet::from([ShieldedPool::Sapling]);
+
+            // Each combo pairs a receiver subset with the exact pool set it must permit.
+            // Some seeds derive an address without every shielded receiver, so only the
+            // combos this seed can express are exercised.
+            let mut combos = Vec::new();
+            if orchard.is_some() {
+                combos.push((orchard, None, orchard_pools.clone()));
+            }
+            if sapling.is_some() {
+                combos.push((None, sapling, sapling_pools.clone()));
+            }
+            if orchard.is_some() && sapling.is_some() {
+                combos.push((
+                    orchard,
+                    sapling,
+                    orchard_pools.union(&sapling_pools).copied().collect(),
+                ));
+            }
+
+            for (orchard, sapling, expected) in combos {
+                let Some(ua) = UnifiedAddress::from_receivers(orchard, sapling, transparent)
+                else {
+                    continue;
+                };
+
+                let policy = spend_policy_for(&Address::Unified(ua));
+
+                prop_assert_eq!(
+                    policy.shielded(),
+                    &expected,
+                    "permitted pools must be exactly those named by the source's receivers",
+                );
+                prop_assert!(
+                    policy.transparent().is_none(),
+                    "a shielded source must not permit transparent spending",
+                );
+            }
         }
 
         /// Change may be returned to the transparent pool exactly when the source could spend

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -161,6 +161,15 @@ pub(super) fn confirmations_policy_for_minconf(
 /// account's other transparent receivers. Every other source stays shielded-only, so a
 /// shielded send can never silently reach into transparent funds.
 ///
+/// A shielded source selects inputs only from the value pools its receivers name, as the
+/// `z_sendmany` documentation promises: a bare Sapling address or a Sapling-only unified
+/// address does not reach into the account's Orchard notes, and an Orchard-only unified
+/// address does not reach into its Sapling notes. An Orchard receiver corresponds to both
+/// the Orchard pool and the Ironwood pool: once Ironwood is active, payments to Orchard
+/// receivers are accounted to the Ironwood bundle, so an Orchard-receiver source must be
+/// able to draw on both. A unified address's transparent receiver deliberately does *not*
+/// permit transparent spending (see above).
+///
 /// Coinbase UTXOs are excluded: `TransparentSpendPolicy` defaults to
 /// `CoinbasePolicy::NonCoinbase`, and consensus requires coinbase to be spent to a single
 /// shielded output, which is `z_shieldcoinbase`'s job.
@@ -169,10 +178,33 @@ pub(super) fn confirmations_policy_for_minconf(
 /// proposal, and [`enforce_privacy_policy`] rejects it afterwards if it leaks more than the
 /// caller permitted.
 pub(super) fn spend_policy_for(source: &Address) -> SpendPolicy {
+    /// The pools an Orchard receiver's funds can live in.
+    const ORCHARD_RECEIVER_POOLS: [ShieldedPool; 2] =
+        [ShieldedPool::Orchard, ShieldedPool::Ironwood];
+
     match source {
         Address::Transparent(taddr) => SpendPolicy::shielded_pools([])
             .with_transparent(TransparentSpendPolicy::from_one_address(*taddr)),
-        _ => SpendPolicy::default(),
+        Address::Sapling(_) => SpendPolicy::shielded_pools([ShieldedPool::Sapling]),
+        Address::Unified(ua) => SpendPolicy::shielded_pools(
+            ua.sapling()
+                .is_some()
+                .then_some(ShieldedPool::Sapling)
+                .into_iter()
+                .chain(
+                    ua.orchard()
+                        .is_some()
+                        .then_some(ORCHARD_RECEIVER_POOLS)
+                        .into_iter()
+                        .flatten(),
+                ),
+        ),
+        // A TEX address (ZIP 320) names transparent funds held by a counterparty and
+        // cannot correspond to a wallet account, so no spend policy applies; account
+        // resolution rejects it before this is consulted. Named explicitly (rather
+        // than `_`) so that a future `Address` variant is a compile error here
+        // instead of silently receiving an empty spend policy.
+        Address::Tex(_) => SpendPolicy::shielded_pools([]),
     }
 }
 


### PR DESCRIPTION
Closes #755.

> **Stacked PR** on #754 (`feature/cor-1670`) → #752 → #750 → #748; only the last commit is new here. Merge the stack bottom-up and retarget.

## Motivation

`z_sendmany` documents that a receiver-restricted unified address used as `fromaddress` selects inputs only from the value pools its receivers include, but `spend_policy_for` mapped every non-transparent source to `SpendPolicy::default()` (all shielded pools), so an Orchard-only address could spend the account's Sapling notes.

Fixes the finding tracked as:
- Least Authority ZCG Zallet Initial Audit Report (24 Jul 2026), Suggestion 1
- Linear: [COR-1663](https://linear.app/zodl/issue/COR-1663)

## Solution

Derive the `SpendPolicy` from the source address's receivers (the audit's first suggested option), for both `z_sendmany` and `pczt_create` which share `spend_policy_for`:

- Bare Sapling address / Sapling-only UA → Sapling pool only.
- Orchard receiver → Orchard **and Ironwood** pools: once Ironwood is active, payments to Orchard receivers are accounted to the Ironwood bundle, so an Orchard-receiver source must draw on both — restricting to Orchard alone would strand migrated funds.
- A UA's transparent receiver still permits no transparent spending (unchanged), and a bare transparent source is unchanged.
- A TEX source now permits nothing (it cannot correspond to a wallet account; account resolution rejects it first).

## Test evidence

- New proptests: a bare Sapling source permits exactly `{Sapling}`; receiver-restricted UAs (Orchard-only, Sapling-only, both — with and without a transparent receiver) permit exactly the pools their receivers name; existing properties (no transparent spending from shielded sources, transparent-source confinement, change policy) still pass.
- `cargo test -p zallet-core`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Integration tests

The stack-level cross-pool coverage lives in zcash/integration-tests#193, which has been merged; this PR's CI now exercises it from the integration-tests default branch.


