### PR TITLE
sync: deflake wallet_sync_error_shuts_down_the_spawned_batch_decryptor

### DIFF
--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -1705,17 +1705,29 @@ mod tests {
         .await;
 
         assert!(result.is_err(), "mock chain rejects wallet sync startup");
-        // `reload_keys` returns `None` only when the decryptor handle has no engine to
-        // reload, which itself indicates the engine was dropped during the failed
-        // startup. Either outcome proves the batch decryptor is not left running;
-        // assert the `Some` case explicitly, and accept `None` as equivalent shutdown.
-        if let Some(reload_finished) = decryptor_observer.reload_keys().await {
-            assert!(
-                reload_finished.await.is_err(),
-                "failed wallet sync startup must not leave its batch decryptor running",
-            );
-        }
-        // `None` means there is no engine to reload — the decryptor is already down.
+        // The failed startup aborts the batch decryptor task, but the abort only lands
+        // at the task's next yield point, so the engine may still answer requests that
+        // race ahead of it (zallet#766). Poll until shutdown is observed: `None` from
+        // `reload_keys` means the engine (the queue receiver) is gone, and an errored
+        // receiver means the engine dropped the request unserved. A served reload
+        // (`Ok`) only proves the abort has not landed yet, so retry. Bound the wait so
+        // a decryptor that really is left running fails the test here instead of
+        // hanging until the CI job timeout.
+        tokio::time::timeout(Duration::from_secs(30), async {
+            loop {
+                match decryptor_observer.reload_keys().await {
+                    None => break,
+                    Some(reload_finished) => {
+                        if reload_finished.await.is_err() {
+                            break;
+                        }
+                    }
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("failed wallet sync startup must not leave its batch decryptor running");
     }
 
     // Regression for zallet#136: when a sibling task fails and `steady_state` is


### PR DESCRIPTION
Fixes #766.

## Problem

The test aborts the batch decryptor task via `WalletSync::spawn`'s failed-startup path, then asserts on the outcome of a **single** `reload_keys` request. But the abort only lands at the engine task's next yield point, and the engine's request-processing loop can serve a request without yielding. Two flaky manifestations:

- **Assertion failure** (macOS CI, #766): the engine wins the race and serves the reload with `Ok(())` before the abort lands.
- **6-hour hang** (PR #767's `Test default on Linux` run): the request is accepted but the engine wedges inside a poll that never yields, so the oneshot receiver never resolves and nothing bounds the wait — the job runs until GitHub's 6-hour timeout cancels it.

## Fix

Poll `reload_keys()` until shutdown is actually observed:

- `None` — the engine (queue receiver) is gone; or
- the returned receiver errors — the engine dropped the request unserved.

A served reload (`Ok`) only proves the abort has not landed *yet*, so retry after a short sleep. The whole wait is bounded by a 30-second `tokio::time::timeout`, so a decryptor that genuinely is left running fails the test promptly with a clear message instead of hanging CI.

## Testing

- `cargo test -p zallet-core --lib components::sync` — 48 passed.
- Ran the fixed test 150 consecutive times — all passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)