### PR TITLE
backend/zebra: guard against zebrad dropping the non_finalized_state_change stream (zebra#11265)

### DIFF
--- a/backends/zaino/CHANGELOG.md
+++ b/backends/zaino/CHANGELOG.md
@@ -22,6 +22,16 @@ should be considered breaking changes.
 
 ### Fixed
 
+- The optional `[indexer.read_state_service]` mode no longer livelocks when
+  `zebrad` (v6.2.1–v6.3.0) drops the `non_finalized_state_change` stream
+  during its initial send
+  ([ZcashFoundation/zebra#11265](https://github.com/ZcashFoundation/zebra/issues/11265)):
+  the zebra crates are temporarily consumed from a patched branch whose
+  read-state syncer catches up to the validator's tip over unary `get_block`
+  calls before subscribing, backs off between failed subscription attempts,
+  and keeps publishing the finalized tip until the first non-finalized block
+  commits. The default JSON-RPC mode is unaffected.
+
 - The chain view no longer substitutes an empty note commitment tree when the
   validator reports no treestate for a pool at or after that pool's activation
   height. Previously any such read — for Sapling, Orchard, or Ironwood — was

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -5869,8 +5869,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bb785abb0207bee98b1d7d874467bb1043d4e434f9a8c8a4714603563c762b"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "futures",
  "futures-core",
@@ -5886,8 +5885,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700b6ca0cca8b86ef35046dfc7bab9196b8271ab72e9d410f8f63d94857d14f"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -7441,8 +7439,7 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "11.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825050a409c120d9dd0cffb36d99638a5e716e9cb092662009d087b4c227cc14"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bech32 0.11.1",
  "bitflags 2.13.1",
@@ -7505,8 +7502,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "14.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a2f87471e58f9cedee3698ac4eeb6502ec60d059b054d67796eccfb896439"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7548,8 +7544,7 @@ dependencies = [
 [[package]]
 name = "zebra-network"
 version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4592281fa43e961048c4a2a4c153be1eacff481d64f0340bc70e1f9b84c53eca"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bitflags 2.13.1",
  "byteorder",
@@ -7586,8 +7581,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "9.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee11bf0e45b764d09722f1e8f4c5a8d86ef021d9698b576bdf81d325c75b9b8"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7602,8 +7596,7 @@ dependencies = [
 [[package]]
 name = "zebra-rpc"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761839b2ad7ff46c1836521f674d76458cd1c78f555e56d2259ead4cc9ddb170"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7663,8 +7656,7 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "10.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad711c56bfe377e184a9dfbec4d2c21633d0254bbea5338d20640fd62574bb88"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "libzcash_script",
  "rand 0.8.7",
@@ -7677,8 +7669,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01b530a3fdd28a9d2988895272e970bc0053acf6dbf467785f146cabf21ac3f"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bincode",
  "chrono",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -104,9 +104,25 @@ zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51ac
 # required for Ironwood notes to be spendable; an empty frontier conflicts with
 # the wallet's advancing tree and sync fails with `CheckpointConflict`. This is
 # zingolabs/zaino#1428; repoint at upstream zaino once it (and the NU6.3 work)
-# lands in a release. The zebra crates are consumed from crates.io at the
-# librustzcash 0.30/0.10 versions (chain 11.3 / state 12.0.1 / rpc 15.0), so no
-# zebra [patch] is needed.
+# lands in a release.
 zaino-common = { git = "https://github.com/zodl-inc/zaino.git", rev = "d2d06bdd" }
 zaino-fetch = { git = "https://github.com/zodl-inc/zaino.git", rev = "d2d06bdd" }
 zaino-state = { git = "https://github.com/zodl-inc/zaino.git", rev = "d2d06bdd" }
+
+# TEMPORARY: pin the zebra crates to a branch that hardens
+# `zebra_rpc::sync::TrustedChainSync` against zebrad dropping the
+# `non_finalized_state_change` stream during large initial sends
+# (ZcashFoundation/zebra#11265); see backends/zebra/Cargo.toml for the full
+# rationale. The branch is based on the commit the crates.io versions this
+# workspace already uses (chain 11.3 / state 12.0.1 / rpc 15.0) were published
+# from, so only zebra-rpc's code actually changes. This guards the optional
+# `[indexer.read_state_service]` mode; the whole cohort is patched so the graph
+# resolves from a single source. Drop this patch once the fix ships in a
+# zebra-rpc release.
+zebra-chain = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-consensus = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-network = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-node-services = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-rpc = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-script = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-state = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }

--- a/backends/zebra/CHANGELOG.md
+++ b/backends/zebra/CHANGELOG.md
@@ -20,7 +20,30 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- A watchdog now supervises the read-state syncer: if the wallet's chain tip
+  stops advancing while the validator's height keeps growing, it logs an
+  error identifying the stall (and the likely upstream cause) instead of the
+  wallet silently serving stale data, and chain "no tip yet" errors include
+  the diagnosis.
+
 ### Fixed
+
+- The backend no longer livelocks when `zebrad` (v6.2.1–v6.3.0) drops the
+  `non_finalized_state_change` stream during its initial send — the regression
+  reported as [ZcashFoundation/zebra#11265], which zebrad logs as
+  `slow consumer, dropping non_finalized_state_change stream after buffer filled`
+  and which left the wallet's chain tip frozen while both processes spun in a
+  full-speed resubscribe cycle. The read-state syncer (`zebra-rpc`, temporarily
+  consumed from a patched branch) now catches up to the validator's best tip
+  over unary `get_block` calls before every subscription, so the stream's
+  initial send stays far below the server-side buffer that triggers the drop;
+  it backs off between failed subscription attempts; and it keeps publishing
+  the finalized tip until the first non-finalized block actually commits, so a
+  failing stream can no longer freeze the reported tip.
+
+[ZcashFoundation/zebra#11265]: https://github.com/ZcashFoundation/zebra/issues/11265
 
 - The chain view no longer substitutes an empty note commitment tree when
   `zebrad` reports no treestate for a finalized block at or after the pool's

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -5606,8 +5606,7 @@ dependencies = [
 [[package]]
 name = "tower-batch-control"
 version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58bb785abb0207bee98b1d7d874467bb1043d4e434f9a8c8a4714603563c762b"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "futures",
  "futures-core",
@@ -5623,8 +5622,7 @@ dependencies = [
 [[package]]
 name = "tower-fallback"
 version = "0.2.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700b6ca0cca8b86ef35046dfc7bab9196b8271ab72e9d410f8f63d94857d14f"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "futures-core",
  "pin-project",
@@ -7043,8 +7041,7 @@ dependencies = [
 [[package]]
 name = "zebra-chain"
 version = "11.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825050a409c120d9dd0cffb36d99638a5e716e9cb092662009d087b4c227cc14"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bech32 0.11.1",
  "bitflags",
@@ -7107,8 +7104,7 @@ dependencies = [
 [[package]]
 name = "zebra-consensus"
 version = "14.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a2f87471e58f9cedee3698ac4eeb6502ec60d059b054d67796eccfb896439"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7150,8 +7146,7 @@ dependencies = [
 [[package]]
 name = "zebra-network"
 version = "11.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4592281fa43e961048c4a2a4c153be1eacff481d64f0340bc70e1f9b84c53eca"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -7188,8 +7183,7 @@ dependencies = [
 [[package]]
 name = "zebra-node-services"
 version = "9.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aee11bf0e45b764d09722f1e8f4c5a8d86ef021d9698b576bdf81d325c75b9b8"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "color-eyre",
  "jsonrpsee-types",
@@ -7204,8 +7198,7 @@ dependencies = [
 [[package]]
 name = "zebra-rpc"
 version = "15.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "761839b2ad7ff46c1836521f674d76458cd1c78f555e56d2259ead4cc9ddb170"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7265,8 +7258,7 @@ dependencies = [
 [[package]]
 name = "zebra-script"
 version = "10.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad711c56bfe377e184a9dfbec4d2c21633d0254bbea5338d20640fd62574bb88"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "libzcash_script",
  "rand 0.8.7",
@@ -7279,8 +7271,7 @@ dependencies = [
 [[package]]
 name = "zebra-state"
 version = "12.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01b530a3fdd28a9d2988895272e970bc0053acf6dbf467785f146cabf21ac3f"
+source = "git+https://github.com/pacu/zebra.git?rev=487e6f9312b60bcd3007a7c17c942b1d481a93e6#487e6f9312b60bcd3007a7c17c942b1d481a93e6"
 dependencies = [
  "bincode",
  "chrono",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -98,6 +98,26 @@ zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc
 zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
 zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
 zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+
+# TEMPORARY: pin the zebra crates to a branch that hardens
+# `zebra_rpc::sync::TrustedChainSync` against zebrad dropping the
+# `non_finalized_state_change` stream during large initial sends
+# (ZcashFoundation/zebra#11265): catch up over unary `get_block` calls before
+# every (re)subscription, back off between re-subscription attempts, and keep
+# the finalized-tip fallback alive until the first successful commit. The
+# branch is `zallet/zebra-rpc-15-sync-hardening`, based on the commit the
+# crates.io versions this workspace already uses were published from, so only
+# zebra-rpc's code actually changes; the whole cohort is patched so the graph
+# resolves from a single source (librocksdb-sys's `links = "rocksdb"` forbids
+# two zebra-state instances). Drop this patch once the fix ships in a
+# zebra-rpc release.
+zebra-chain = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-consensus = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-network = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-node-services = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-rpc = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-script = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
+zebra-state = { git = "https://github.com/pacu/zebra.git", rev = "487e6f9312b60bcd3007a7c17c942b1d481a93e6" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -318,9 +318,9 @@ impl Chain for ZebraChain {
             // Include the watchdog's diagnosis so "no tip" failures explain themselves when
             // the cause is a stalled read-state syncer rather than normal startup.
             match self.syncer_health.lock().unwrap().as_deref() {
-                Some(diagnosis) => ChainError::unavailable(format!(
-                    "the chain state has no tip yet ({diagnosis})"
-                )),
+                Some(diagnosis) => {
+                    ChainError::unavailable(format!("the chain state has no tip yet ({diagnosis})"))
+                }
                 None => ChainError::unavailable("the chain state has no tip yet"),
             }
         })?;

--- a/backends/zebra/src/chain.rs
+++ b/backends/zebra/src/chain.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 
 use futures::{StreamExt as _, stream::BoxStream};
 use incrementalmerkletree::frontier::CommitmentTree;
-use jsonrpsee::tracing::warn;
+use jsonrpsee::tracing::{self, warn};
 use zcash_client_backend::data_api::{
     TransactionStatus,
     chain::{ChainState, CommitmentTreeRoot},
@@ -54,12 +54,29 @@ use crate::read_state::{AbortOnDrop, init_read_state_service, network_to_zebra};
 /// this below the captured tip are treated as finalized and served by height.
 const MAX_REORG_DEPTH: u32 = 1000;
 
+/// How often the syncer watchdog compares the read-state tip against the validator's height.
+const WATCHDOG_INTERVAL: Duration = Duration::from_secs(60);
+
+/// How many blocks the read-state tip may lag the validator before a watchdog check counts as
+/// stalled. Small lags are normal while the syncer commits a burst of blocks.
+const WATCHDOG_LAG_THRESHOLD: u32 = 4;
+
+/// How many consecutive stalled checks before the watchdog reports the syncer as stalled.
+/// Together with [`WATCHDOG_INTERVAL`] this tolerates a few minutes of catch-up (e.g. right
+/// after startup) without a false alarm.
+const WATCHDOG_STALLED_CHECKS: u32 = 3;
+
+/// The syncer watchdog's latest diagnosis, shared with [`ZebraChain`] so chain errors can say
+/// *why* the state is unavailable. `None` means healthy (or not yet diagnosed).
+type SyncerHealth = Arc<Mutex<Option<String>>>;
+
 /// A handle to chain data read from a local zebrad's `zebra-state`.
 #[derive(Clone)]
 pub struct ZebraChain {
     read_state_service: ReadStateService,
     validator_rpc: ValidatorRpcClient,
     params: Network,
+    syncer_health: SyncerHealth,
     _syncer: Arc<AbortOnDrop>,
 }
 
@@ -112,23 +129,115 @@ impl ZebraChain {
             .map_err(|e| ErrorKind::Init.context(e))?
         };
 
+        let syncer_health: SyncerHealth = Arc::new(Mutex::new(None));
+
         let chain = Self {
             read_state_service,
             validator_rpc,
             params,
+            syncer_health: syncer_health.clone(),
             _syncer: Arc::new(AbortOnDrop::new(sync_task)),
         };
 
-        // Lifecycle task. The syncer is owned by `_syncer` (aborted when the last
-        // `ZebraChain` clone drops). This task exists to match the backend lifecycle
-        // shape; it runs until aborted on shutdown.
-        // TODO: signal syncer failure through this task once the syncer exposes it.
-        let task = zallet_core::spawn!("Zebra read-state syncer", async move {
-            std::future::pending::<()>().await;
-            Ok::<(), Error>(())
-        });
+        // Lifecycle task: a watchdog over the read-state syncer, which is owned by `_syncer`
+        // (aborted when the last `ZebraChain` clone drops). The syncer task itself never
+        // returns and swallows stream failures internally, so the watchdog infers its health
+        // from the outside: a read-state tip that stops following the validator's height means
+        // the non-finalized syncer has stalled (e.g. the zebrad-side stream drop in
+        // <https://github.com/ZcashFoundation/zebra/issues/11265>), and without this check the
+        // wallet would silently serve a frozen tip. The zaino backend's `State` mode uses the
+        // same syncer and has no watchdog yet; if this logic proves out, port it there.
+        let task = {
+            let reader = chain.reader();
+            let validator_rpc = chain.validator_rpc.clone();
+            zallet_core::spawn!("Zebra read-state syncer", async move {
+                syncer_watchdog(reader, validator_rpc, syncer_health).await;
+                Ok::<(), Error>(())
+            })
+        };
 
         Ok((chain, task))
+    }
+}
+
+/// Periodically compares the read-state tip against the validator's reported height and
+/// records a diagnosis in `health` (also logging on transitions) when the tip stops advancing
+/// while the validator's does. Never returns; it is aborted on shutdown.
+async fn syncer_watchdog(
+    reader: ReadStateChainReader,
+    validator_rpc: ValidatorRpcClient,
+    health: SyncerHealth,
+) {
+    let mut interval = tokio::time::interval(WATCHDOG_INTERVAL);
+    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    // The read-state tip height at the previous check, if it succeeded.
+    let mut prev_state_height: Option<u32> = None;
+    let mut stalled_checks: u32 = 0;
+    let mut reported = false;
+
+    loop {
+        interval.tick().await;
+
+        // If the validator is unreachable we can't judge the syncer, so skip this check
+        // without touching the counters; the validator's own outage surfaces elsewhere.
+        let validator_height = match validator_rpc.get_blockchain_info().await {
+            Ok(info) => info.blocks,
+            Err(error) => {
+                tracing::debug!(?error, "syncer watchdog could not query the validator");
+                continue;
+            }
+        };
+
+        let state_height = match reader.tip().await {
+            Ok(tip) => tip.map(|block| u32::from(block.height())),
+            Err(error) => {
+                tracing::debug!(?error, "syncer watchdog could not read the state tip");
+                continue;
+            }
+        };
+
+        let lagging =
+            validator_height.saturating_sub(state_height.unwrap_or(0)) > WATCHDOG_LAG_THRESHOLD;
+        let advanced = match (state_height, prev_state_height) {
+            (Some(now), Some(prev)) => now > prev,
+            // First successful check, or the tip just appeared: treat as progress.
+            (Some(_), None) => true,
+            (None, _) => false,
+        };
+        prev_state_height = state_height.or(prev_state_height);
+
+        if lagging && !advanced {
+            stalled_checks = stalled_checks.saturating_add(1);
+        } else {
+            stalled_checks = 0;
+            if reported {
+                reported = false;
+                *health.lock().unwrap() = None;
+                tracing::info!(
+                    ?state_height,
+                    validator_height,
+                    "the zebra read-state syncer has recovered and is following the chain tip again"
+                );
+            }
+        }
+
+        if stalled_checks >= WATCHDOG_STALLED_CHECKS && !reported {
+            reported = true;
+            let diagnosis = format!(
+                "the zebra read-state syncer appears stalled: the wallet's chain tip is at \
+                 {state_height:?} while the validator reports height {validator_height}, and the \
+                 tip has not advanced for at least {} checks {}s apart",
+                WATCHDOG_STALLED_CHECKS,
+                WATCHDOG_INTERVAL.as_secs(),
+            );
+            *health.lock().unwrap() = Some(diagnosis.clone());
+            tracing::error!(
+                "{diagnosis}; wallet data will lag the chain until it recovers. If zebrad logs \
+                 show repeated 'slow consumer, dropping non_finalized_state_change stream' \
+                 warnings, this is likely \
+                 https://github.com/ZcashFoundation/zebra/issues/11265"
+            );
+        }
     }
 }
 
@@ -205,10 +314,16 @@ impl Chain for ZebraChain {
 
     async fn snapshot(&self) -> Result<Self::View, ChainError> {
         let reader = self.reader();
-        let tip = reader
-            .tip()
-            .await?
-            .ok_or_else(|| ChainError::unavailable("the chain state has no tip yet"))?;
+        let tip = reader.tip().await?.ok_or_else(|| {
+            // Include the watchdog's diagnosis so "no tip" failures explain themselves when
+            // the cause is a stalled read-state syncer rather than normal startup.
+            match self.syncer_health.lock().unwrap().as_deref() {
+                Some(diagnosis) => ChainError::unavailable(format!(
+                    "the chain state has no tip yet ({diagnosis})"
+                )),
+                None => ChainError::unavailable("the chain state has no tip yet"),
+            }
+        })?;
         let finalized_floor =
             BlockHeight::from_u32(u32::from(tip.height()).saturating_sub(MAX_REORG_DEPTH));
         let mut cache = BTreeMap::new();

--- a/backends/zebra/src/chain/rpc.rs
+++ b/backends/zebra/src/chain/rpc.rs
@@ -20,6 +20,9 @@ use zallet_core::error::{Error, ErrorKind};
 #[derive(Deserialize)]
 pub(crate) struct BlockchainInfo {
     pub(crate) upgrades: HashMap<String, NetworkUpgradeInfo>,
+    /// The validator's best block height, used by the syncer watchdog to detect a
+    /// read-state tip that has stopped following the validator.
+    pub(crate) blocks: u32,
 }
 
 /// A single entry of the `getblockchaininfo` `upgrades` table.


### PR DESCRIPTION
Closes #769

zebrad v6.2.1–v6.3.0 drops the indexer `non_finalized_state_change` stream whenever the initial send to a fresh subscriber overflows a server-side buffer ([ZcashFoundation/zebra#11265](https://github.com/ZcashFoundation/zebra/issues/11265)), and `TrustedChainSync` turns that drop into a livelock: it resubscribes with no delay and no tips (forcing the same oversized send again), and its finalized-tip fallback is permanently dead by then, so the wallet's chain tip freezes while both processes spin. See #769 for the full analysis.

Two parts:

**1. Harden `TrustedChainSync`** — carried as a `[patch.crates-io]` on both backend workspaces pointing at [`pacu/zebra@zallet/zebra-rpc-15-sync-hardening`](https://github.com/pacu/zebra/tree/zallet/zebra-rpc-15-sync-hardening) (single commit on top of the exact commit `zebra-rpc 15.0.0` was published from, so only `zebra-rpc/src/sync.rs` changes; the whole zebra cohort is patched because `librocksdb-sys`'s `links` key forbids mixing git and crates.io copies of `zebra-state` in one graph):

- **Catch up before subscribing**: a new `catch_up_to_tip()` (generalizing the existing `fill_finalized_gap`) walks unary `get_block(height)` calls from the secondary's tip to the primary's best tip and commits them, before every (re)subscription. The subscription then carries real `chain_tip_hashes`, so the server's initial send shrinks from potentially thousands of blocks to just side-chain blocks — far below the buffer whose overflow triggers the drop.
- **Resubscribe backoff**: staged 1s→30s delays between failed subscription attempts, reset once a stream survives 60s. Longevity (not message delivery) is the reset signal, because the failing server delivers a partial burst before every drop.
- **Keep the finalized-tip fallback alive**: `started_sync` now flips on the first successful *commit* instead of the first parseable message, so a stream that dies before anything commits no longer permanently freezes the published tip below the finalized tip.

The patch is temporary: the hardening will be proposed upstream on zebra#11265, and the patch dropped once it ships in a zebra-rpc release.

**2. Syncer watchdog in the zebra backend** — replaces the `pending()` lifecycle stub with a supervisor that compares the read-state tip against the validator's `getblockchaininfo` height every 60s. If the tip stops advancing while the validator's grows (>4 blocks for 3 consecutive checks), it logs a transition-based `error!` naming the stall and the likely upstream cause, records the diagnosis in a shared handle so chain "no tip yet" errors explain themselves, and logs recovery. Detect + surface only — no auto-restart, no fallback data path (out of scope per #769).

## Testing

- `cargo test` in `backends/zebra`, `cargo check` in `backends/zaino`, `cargo clippy --all-targets` clean, `utils/check-lockstep.sh` passes; lockfiles regenerated with `utils/sync-lockfiles.sh`.
- `cargo check -p zebra-rpc` + clippy clean on the fork branch.
- End-to-end verification against a real zebrad (functional happy path, forced-drop reproduction, watchdog stall/recovery) is still pending — tracked in #769 before this merges; a test build should go to the affected operator once the happy path is confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LkTycSKRrFfe5rxjFncRj2