### PR TITLE
rpc: Hide regtest-only RPC methods from `help` on non-regtest nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,10 @@ be considered breaking changes.
   wallet passphrases to the network path; remote access should instead go
   through an authenticated, encrypted tunnel such as SSH port forwarding or a
   VPN. Previously any bind address was accepted without a warning.
+- The `help` JSON-RPC method (and `zallet rpc help`) now omits regtest-only
+  methods (currently just `stop`) unless the node is running on the regtest
+  network, matching the "method not found" error those methods return on other
+  networks.
 
 ### Fixed
 

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -46,6 +46,9 @@ Returns wallet status information.
 
 List all commands, or get help for a specified command.
 
+Commands that are not available on the network this node is running on (such as
+regtest-only commands) are omitted.
+
 #### Arguments
 - `command` (string, optional) The command to get help on.
 

--- a/zallet-core/src/commands/rpc_cli.rs
+++ b/zallet-core/src/commands/rpc_cli.rs
@@ -42,6 +42,8 @@ macro_rules! wlnfl {
 
 impl AsyncRunnable for RpcCliCmd {
     async fn run(&self) -> Result<(), Error> {
+        let config = APP.config();
+
         // `help` is generated from static method metadata, so answer it locally
         // instead of requiring a wallet with a running JSON-RPC server.
         #[cfg(zallet_build = "wallet")]
@@ -57,12 +59,13 @@ impl AsyncRunnable for RpcCliCmd {
             };
             print!(
                 "{}",
-                crate::components::json_rpc::methods::help::text(command.as_deref())
+                crate::components::json_rpc::methods::help::text(
+                    config.consensus.network,
+                    command.as_deref(),
+                )
             );
             return Ok(());
         }
-
-        let config = APP.config();
 
         let timeout = Duration::from_secs(match self.timeout {
             Some(0) => u64::MAX,

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -3,6 +3,8 @@ use jsonrpsee::{
     core::{JsonValue, RpcResult},
     proc_macros::rpc,
 };
+#[cfg(zallet_build = "wallet")]
+use zcash_protocol::consensus::Parameters;
 
 use crate::components::{
     chain::Chain,
@@ -17,6 +19,15 @@ use {
         json_rpc::payments::AmountParameter, keystore::KeyStore, sync::WalletDecryptorHandle,
     },
 };
+
+/// The JSON-RPC methods that are only available when Zallet is running on the regtest
+/// network.
+///
+/// These methods return a "method not found" error on other networks, and `help` hides
+/// them there. Every method gated on `NetworkType::Regtest` in its `call` implementation
+/// must be listed here.
+#[cfg(zallet_build = "wallet")]
+const REGTEST_ONLY_METHODS: &[&str] = &["stop"];
 
 mod convert_tex;
 mod decode_raw_transaction;
@@ -349,11 +360,14 @@ pub(crate) trait Rpc {
 pub(crate) trait WalletRpc {
     /// List all commands, or get help for a specified command.
     ///
+    /// Commands that are not available on the network this node is running on (such as
+    /// regtest-only commands) are omitted.
+    ///
     /// # Arguments
     /// - `command` (string, optional) The command to get help on.
     // TODO: Improve the build script so this works with non-wallet Zallet builds.
     #[method(name = "help")]
-    fn help(&self, command: Option<&str>) -> help::Response;
+    async fn help(&self, command: Option<&str>) -> help::Response;
 
     /// Returns an OpenRPC schema as a description of this service.
     // TODO: Improve the build script so this works with non-wallet Zallet builds.
@@ -1186,8 +1200,8 @@ impl<C: Chain> RpcServer for RpcImpl<C> {
 #[cfg(zallet_build = "wallet")]
 #[async_trait]
 impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
-    fn help(&self, command: Option<&str>) -> help::Response {
-        help::call(command)
+    async fn help(&self, command: Option<&str>) -> help::Response {
+        help::call(self.wallet().await?.params().network_type(), command)
     }
 
     fn openrpc(&self) -> openrpc::Response {

--- a/zallet-core/src/components/json_rpc/methods/help.rs
+++ b/zallet-core/src/components/json_rpc/methods/help.rs
@@ -2,8 +2,9 @@ use documented::Documented;
 use jsonrpsee::core::RpcResult;
 use schemars::JsonSchema;
 use serde::Serialize;
+use zcash_protocol::consensus::NetworkType;
 
-use super::openrpc::METHODS;
+use super::{REGTEST_ONLY_METHODS, openrpc::METHODS};
 
 /// Response to a `help` RPC request.
 pub(crate) type Response = RpcResult<ResultType>;
@@ -15,18 +16,26 @@ pub(crate) struct ResultType(String);
 
 pub(super) const PARAM_COMMAND_DESC: &str = "The command to get help on.";
 
-pub(crate) fn call(command: Option<&str>) -> Response {
-    Ok(ResultType(text(command)))
+pub(crate) fn call(network: NetworkType, command: Option<&str>) -> Response {
+    Ok(ResultType(text(network, command)))
 }
 
-pub(crate) fn text(command: Option<&str>) -> String {
+pub(crate) fn text(network: NetworkType, command: Option<&str>) -> String {
+    // Regtest-only commands return a "method not found" error on other networks, so
+    // hide them from help there as well.
+    let available =
+        |command: &str| network == NetworkType::Regtest || !REGTEST_ONLY_METHODS.contains(&command);
+
     if let Some(command) = command {
-        match METHODS.get(command) {
+        match METHODS.get(command).filter(|_| available(command)) {
             None => format!("help: unknown command: {command}\n"),
             Some(method) => format!("{command}\n\n{}", method.description),
         }
     } else {
-        let mut commands = METHODS.entries().collect::<Vec<_>>();
+        let mut commands = METHODS
+            .entries()
+            .filter(|(command, _)| available(command))
+            .collect::<Vec<_>>();
         commands.sort_by_cached_key(|(command, _)| command.to_string());
 
         let mut ret = String::new();
@@ -35,5 +44,32 @@ pub(crate) fn text(command: Option<&str>) -> String {
             ret.push('\n');
         }
         ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_protocol::consensus::NetworkType;
+
+    use super::{REGTEST_ONLY_METHODS, text};
+
+    #[test]
+    fn regtest_only_methods_are_hidden_on_other_networks() {
+        for method in REGTEST_ONLY_METHODS {
+            for network in [NetworkType::Main, NetworkType::Test] {
+                assert!(!text(network, None).lines().any(|line| line == *method));
+                assert_eq!(
+                    text(network, Some(method)),
+                    format!("help: unknown command: {method}\n"),
+                );
+            }
+
+            assert!(
+                text(NetworkType::Regtest, None)
+                    .lines()
+                    .any(|line| line == *method)
+            );
+            assert!(!text(NetworkType::Regtest, Some(method)).starts_with("help:"));
+        }
     }
 }


### PR DESCRIPTION
Closes #242.

## Motivation

Regtest-only JSON-RPC methods (currently just `stop`, added in #153 for the RPC test framework) return a "method not found" error on mainnet and testnet, but were still listed by the `help` RPC method and by `zallet rpc help`.

## Solution

- A new `REGTEST_ONLY_METHODS` const next to the RPC traits records which methods are gated on `NetworkType::Regtest` (with a doc comment requiring new regtest-gated methods to be added to it).
- `help::text` now takes the node's `NetworkType` and omits regtest-only methods on other networks — both from the method listing and from `help <command>` lookups, which report "unknown command", matching the "method not found" error the method itself returns there.
- The server-side `help` method becomes `async` so it can read the network type from the wallet database handle, the same way `stop` itself does. The local `zallet rpc help` fast path uses the configured `consensus.network`.

Out of scope, noting for completeness: `rpc.discover` still describes all methods, and `stop` is also unavailable on Windows regardless of network (it remains listed there when on regtest).

## Test evidence

- New unit test `regtest_only_methods_are_hidden_on_other_networks` covering listing and per-command lookup on main/test/regtest.
- `cargo test -p zallet-core`: 343 passed + `book_rpc_reference` golden (regenerated for the updated `help` rustdoc).
- `cargo clippy -p zallet-core --all-targets` and `cargo fmt --check` clean; `cargo check` in `backends/zebra` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Claude Fable 5), reviewed by @pacu.