### PR TITLE
rpc: Add z_listreceivedbyaddress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@ be considered breaking changes.
   to complete even when some accounts or transparent spending keys in the
   `zcashd` wallet could not be imported. The skipped items are reported as
   warnings; they remain accessible only via the original `wallet.dat` file.
+- `z_listreceivedbyaddress` JSON-RPC method, returning amounts received by an
+  address belonging to the wallet. For a shielded or unified address that
+  corresponds to a unified account, the account's received outputs are
+  returned irrespective of the provided address's diversifier, matching
+  `z_listunspent`'s account-level semantics; a transparent address returns
+  only that address's outputs. New `offset` and `limit` parameters (as for
+  `z_listtransactions`) allow paginating large results.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- `z_listreceivedbyaddress` JSON-RPC method, returning amounts received by an
+  address belonging to the wallet. For a shielded or unified address that
+  corresponds to a unified account, the account's received outputs are
+  returned irrespective of the provided address's diversifier, including the
+  change received on its internal addresses; a transparent address returns
+  only that address's outputs. New `offset` and `limit` parameters (as for
+  `z_listtransactions`) allow paginating large results.
+
 ## [0.1.0-beta.3] - 2026-08-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -248,7 +248,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1339,7 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1358,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2432,7 +2432,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2909,7 +2909,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3083,7 +3083,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3173,8 +3173,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.3"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3885,7 +3885,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4412,7 +4412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4547,7 +4547,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5406,7 +5406,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5858,7 +5858,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5910,8 +5910,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.22.0-rc.8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6004,7 +6004,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6049,8 +6049,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.1.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6101,7 +6101,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6131,7 +6131,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6166,7 +6166,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "corez",
  "document-features",
@@ -6229,7 +6229,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bip32",
  "bs58",
@@ -6408,7 +6408,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5870,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5923,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6052,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "corez",
  "document-features",
@@ -6142,7 +6142,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bip32",
  "bs58",
@@ -6321,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,24 +178,27 @@ tonic = "0.14"
 debug = "line-tables-only"
 
 [patch.crates-io]
-# TEMPORARY: pin the wallet-critical librustzcash crates to a `main` rev carrying
-# the fix for reading back a stored unmined transaction with a zero expiry height
+# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
+# `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972), which
+# `z_listreceivedbyaddress` uses to enumerate an account's received outputs,
+# spent and unspent. The branch is based on the `main` rev carrying the fix for
+# reading back a stored unmined transaction with a zero expiry height
 # (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
 # `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
 # imports from a zcashd wallet before any chain scan. The full in-repo dependency
 # closure of the two client crates is patched to the same rev so the whole cohort
-# resolves from a single source. Repoint at crates.io once the fix lands in a
+# resolves from a single source. Repoint at crates.io once the changes land in a
 # release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ shardtree = "0.7"
 time = "0.3"
 uuid = "1"
 zcash_client_backend = "=0.24.0-rc.7"
-zcash_client_sqlite = "=0.22.0-rc.7"
+zcash_client_sqlite = "=0.22.0-rc.8"
 zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
@@ -178,21 +178,24 @@ debug = "line-tables-only"
 
 [patch.crates-io]
 # TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
-# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
-# which `zallet import-address` uses to track watch-only transparent addresses
-# imported without key material. The full in-repo dependency closure of the two
-# client crates is patched to the same rev so the whole cohort resolves from a
-# single source. Repoint at crates.io once the change lands in a release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+# `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972), which
+# `z_listreceivedbyaddress` uses to enumerate an account's received outputs
+# (spent and unspent). The branch is based on librustzcash main, so it also
+# carries `WalletWrite::import_standalone_transparent_address`
+# (zcash/librustzcash#2941), which `zallet import-address` uses. The full
+# in-repo dependency closure of the two client crates is patched to the same
+# rev so the whole cohort resolves from a single source. Repoint at crates.io
+# once the changes land in a release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1377,7 +1377,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1542,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2714,7 +2714,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2971,7 +2971,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3349,7 +3349,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3686,8 +3686,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.3"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4001,7 +4001,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -4022,7 +4022,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -4678,7 +4678,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4737,7 +4737,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5452,7 +5452,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6476,7 +6476,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7022,7 +7022,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7087,8 +7087,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.22.0-rc.8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7192,7 +7192,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7237,8 +7237,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.1.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -7289,7 +7289,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7319,7 +7319,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7354,7 +7354,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "corez",
  "document-features",
@@ -7417,7 +7417,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bip32",
  "bs58",
@@ -7871,7 +7871,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7037,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7090,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7260,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7282,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "corez",
  "document-features",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bip32",
  "bs58",
@@ -7774,7 +7774,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -76,27 +76,30 @@ tempfile = "3"
 # after rocksdb 0.24.0 and can return to crates.io with the next release.
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 
-# TEMPORARY: pin the wallet-critical librustzcash crates to a `main` rev carrying
-# the fix for reading back a stored unmined transaction with a zero expiry height
+# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
+# `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972), which
+# `z_listreceivedbyaddress` uses to enumerate an account's received outputs,
+# spent and unspent. The branch is based on the `main` rev carrying the fix for
+# reading back a stored unmined transaction with a zero expiry height
 # (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
 # `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
 # imports from a zcashd wallet before any chain scan. The full in-repo dependency
 # closure of the two client crates is patched to the same rev so the whole cohort
-# resolves from a single source. Repoint at crates.io once the fix lands in a
+# resolves from a single source. Repoint at crates.io once the changes land in a
 # release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
 
 # TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
 # `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -77,24 +77,27 @@ tempfile = "3"
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 
 # TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
-# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
-# which `zallet import-address` uses to track watch-only transparent addresses
-# imported without key material. The full in-repo dependency closure of the two
-# client crates is patched to the same rev so the whole cohort resolves from a
-# single source. Repoint at crates.io once the change lands in a release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+# `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972), which
+# `z_listreceivedbyaddress` uses to enumerate an account's received outputs
+# (spent and unspent). The branch is based on librustzcash main, so it also
+# carries `WalletWrite::import_standalone_transparent_address`
+# (zcash/librustzcash#2941), which `zallet import-address` uses. The full
+# in-repo dependency closure of the two client crates is patched to the same
+# rev so the whole cohort resolves from a single source. Repoint at crates.io
+# once the changes land in a release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
 
 # TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
 # `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6649,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6894,7 +6894,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "corez",
  "document-features",
@@ -6932,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "bip32",
  "bs58",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf#8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -243,7 +243,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1284,7 +1284,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1449,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2619,7 +2619,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2832,7 +2832,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3194,7 +3194,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3399,7 +3399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3517,8 +3517,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.3"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3832,7 +3832,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
  "heck",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph 0.8.3",
@@ -3853,7 +3853,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -4456,7 +4456,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5026,7 +5026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5176,7 +5176,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6165,7 +6165,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6624,7 +6624,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6637,7 +6637,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6689,8 +6689,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.22.0-rc.8"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6794,7 +6794,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6839,8 +6839,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.1.0-rc.7"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6891,7 +6891,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6921,7 +6921,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6956,7 +6956,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "corez",
  "document-features",
@@ -7019,7 +7019,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "bip32",
  "bs58",
@@ -7473,7 +7473,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=ac28b9150b8efa002b9e541bace60462fed611d4#ac28b9150b8efa002b9e541bace60462fed611d4"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -79,27 +79,30 @@ tokio-console = ["zallet-core/tokio-console"]
 # after rocksdb 0.24.0 and can return to crates.io with the next release.
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 
-# TEMPORARY: pin the wallet-critical librustzcash crates to a `main` rev carrying
-# the fix for reading back a stored unmined transaction with a zero expiry height
+# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
+# `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972), which
+# `z_listreceivedbyaddress` uses to enumerate an account's received outputs,
+# spent and unspent. The branch is based on the `main` rev carrying the fix for
+# reading back a stored unmined transaction with a zero expiry height
 # (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
 # `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
 # imports from a zcashd wallet before any chain scan. The full in-repo dependency
 # closure of the two client crates is patched to the same rev so the whole cohort
-# resolves from a single source. Repoint at crates.io once the fix lands in a
+# resolves from a single source. Repoint at crates.io once the changes land in a
 # release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -80,24 +80,27 @@ tokio-console = ["zallet-core/tokio-console"]
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 
 # TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
-# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
-# which `zallet import-address` uses to track watch-only transparent addresses
-# imported without key material. The full in-repo dependency closure of the two
-# client crates is patched to the same rev so the whole cohort resolves from a
-# single source. Repoint at crates.io once the change lands in a release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+# `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972), which
+# `z_listreceivedbyaddress` uses to enumerate an account's received outputs
+# (spent and unspent). The branch is based on librustzcash main, so it also
+# carries `WalletWrite::import_standalone_transparent_address`
+# (zcash/librustzcash#2941), which `zallet import-address` uses. The full
+# in-repo dependency closure of the two client crates is patched to the same
+# rev so the whole cohort resolves from a single source. Repoint at crates.io
+# once the changes land in a release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "ac28b9150b8efa002b9e541bace60462fed611d4" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -544,6 +544,38 @@ Returns the list of operation ids currently known to the wallet.
 #### Arguments
 - `status` (string, optional) Filter result by the operation's state e.g. "success".
 
+## `z_listreceivedbyaddress`
+
+*Only available in wallet builds of Zallet.*
+
+Returns a list of amounts received by an address belonging to the wallet, including
+both spent and unspent outputs.
+
+For a shielded or unified address that corresponds to a unified account, the
+received outputs of that account are returned irrespective of whether the provided
+address's diversifier corresponds to the diversifier of the address that received
+the funds; this includes change outputs received on wallet-internal addresses. A
+transparent address returns only the outputs received by that specific address.
+
+Results are ordered by mined height ascending (unmined outputs last); `offset` and
+`limit` page over that ordering.
+
+#### Arguments
+- `address`: The address that received the outputs to list.
+- `minconf`: Only include outputs of transactions confirmed at least this many
+  times (default = 1). Must be at least 1 when `as_of_height` is provided; a value
+  of 0 includes outputs of unmined transactions.
+- `as_of_height`: Execute the query as if it were run when the blockchain was at
+  the height specified by this argument. The default is to use the entire
+  blockchain that the node is aware of. -1 can be used as in other RPC calls to
+  indicate the current height (including the mempool), but this does not support
+  negative values in general. A “future” height will fall back to the current
+  height.
+- `offset`: An optional number of outputs to skip over before a page of results is
+  returned. Defaults to zero.
+- `limit`: An optional upper bound on the number of results that should be
+  returned in a page.
+
 ## `z_listtransactions`
 
 Returns a list of the wallet's transactions, optionally filtered by account and block

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -531,6 +531,38 @@ Returns the list of operation ids currently known to the wallet.
 #### Arguments
 - `status` (string, optional) Filter result by the operation's state e.g. "success".
 
+## `z_listreceivedbyaddress`
+
+*Only available in wallet builds of Zallet.*
+
+Returns a list of amounts received by an address belonging to the wallet, including
+both spent and unspent outputs.
+
+For a shielded or unified address that corresponds to a unified account, the
+received outputs of that account are returned irrespective of whether the provided
+address's diversifier corresponds to the diversifier of the address that received
+the funds; this includes change outputs received on wallet-internal addresses. A
+transparent address returns only the outputs received by that specific address.
+
+Results are ordered by mined height ascending (unmined outputs last); `offset` and
+`limit` page over that ordering.
+
+#### Arguments
+- `address`: The address that received the outputs to list.
+- `minconf`: Only include outputs of transactions confirmed at least this many
+  times (default = 1). Must be at least 1 when `as_of_height` is provided; a value
+  of 0 includes outputs of unmined transactions.
+- `as_of_height`: Execute the query as if it were run when the blockchain was at
+  the height specified by this argument. The default is to use the entire
+  blockchain that the node is aware of. -1 can be used as in other RPC calls to
+  indicate the current height (including the mempool), but this does not support
+  negative values in general. A “future” height will fall back to the current
+  height.
+- `offset`: An optional number of outputs to skip over before a page of results is
+  returned. Defaults to zero.
+- `limit`: An optional upper bound on the number of results that should be
+  returned in a page.
+
 ## `z_listtransactions`
 
 Returns a list of the wallet's transactions, optionally filtered by account and block

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -121,6 +121,43 @@ Changes to response:
   - `memoStr` field on outputs is no longer only omitted if `memo` does not
     contain valid UTF-8.
 
+### `z_listreceivedbyaddress`
+
+Changes to parameters:
+- New `offset` and `limit` optional parameters (as for `z_listtransactions`),
+  allowing large result sets to be paginated.
+
+Changes to response:
+- For a shielded or unified address that corresponds to a unified account, the
+  received outputs of that account are returned irrespective of whether the
+  provided address's diversifier corresponds to the diversifier of the address
+  that received the funds; this includes change outputs received on
+  wallet-internal addresses, which are reported with `change: true`. A
+  transparent address returns only the outputs received by that specific
+  address.
+- An address that is a bare receiver of a larger Unified Address in the wallet
+  is rejected, as in `zcashd`. However, an address whose receivers exactly
+  match the receivers of a wallet address (for example, the Sapling address of
+  an account created by `z_importkey`) is accepted.
+- Locked notes are now included. `zcashd` silently excluded notes locked via
+  `lockunspent`; whether a note is locked is a concern for input selection,
+  not for reporting what the wallet has received.
+- The `memo` and `memoStr` fields are omitted for shielded outputs whose memo
+  has not yet been downloaded from the chain. This could not occur in
+  `zcashd`, which always had the full transaction available.
+- Sprout is unsupported; the `pool` field can additionally be `"ironwood"`.
+  The `jsindex` and `jsoutindex` fields do not exist; `outindex` is used for
+  all pools, as `zcashd`'s transparent entries already did.
+- `zcashd`'s quirk of skipping coinbase transactions that have no Sapling
+  outputs is not replicated.
+- TEX addresses are rejected.
+- Results are now returned in a deterministic order (mined height ascending,
+  with unmined outputs last); `zcashd`'s ordering was unspecified.
+- Legacy Sapling addresses migrated from a `zcashd` `wallet.dat` are not
+  tracked by the wallet (their notes are not scanned), so querying them
+  returns the "does not belong to this node" error; see the
+  [`zcashd` wallet migration](../cli/migrate-zcashd-wallet.md) documentation.
+
 ### `z_listunspent`
 
 Changes to response:

--- a/book/src/zcashd/json_rpc.md
+++ b/book/src/zcashd/json_rpc.md
@@ -149,6 +149,43 @@ Changes to response:
   - `memoStr` field on outputs is no longer only omitted if `memo` does not
     contain valid UTF-8.
 
+### `z_listreceivedbyaddress`
+
+Changes to parameters:
+- New `offset` and `limit` optional parameters (as for `z_listtransactions`),
+  allowing large result sets to be paginated.
+
+Changes to response:
+- For a shielded or unified address that corresponds to a unified account, the
+  received outputs of that account are returned irrespective of whether the
+  provided address's diversifier corresponds to the diversifier of the address
+  that received the funds; this includes change outputs received on
+  wallet-internal addresses, which are reported with `change: true`. A
+  transparent address returns only the outputs received by that specific
+  address.
+- An address that is a bare receiver of a larger Unified Address in the wallet
+  is rejected, as in `zcashd`. However, an address whose receivers exactly
+  match the receivers of a wallet address (for example, the Sapling address of
+  an account created by `z_importkey`) is accepted.
+- Locked notes are now included. `zcashd` silently excluded notes locked via
+  `lockunspent`; whether a note is locked is a concern for input selection,
+  not for reporting what the wallet has received.
+- The `memo` and `memoStr` fields are omitted for shielded outputs whose memo
+  has not yet been downloaded from the chain. This could not occur in
+  `zcashd`, which always had the full transaction available.
+- Sprout is unsupported; the `pool` field can additionally be `"ironwood"`.
+  The `jsindex` and `jsoutindex` fields do not exist; `outindex` is used for
+  all pools, as `zcashd`'s transparent entries already did.
+- `zcashd`'s quirk of skipping coinbase transactions that have no Sapling
+  outputs is not replicated.
+- TEX addresses are rejected.
+- Results are now returned in a deterministic order (mined height ascending,
+  with unmined outputs last); `zcashd`'s ordering was unspecified.
+- Legacy Sapling addresses migrated from a `zcashd` `wallet.dat` are not
+  tracked by the wallet (their notes are not scanned), so querying them
+  returns the "does not belong to this node" error; see the
+  [`zcashd` wallet migration](../cli/migrate-zcashd-wallet.md) documentation.
+
 ### `z_listunspent`
 
 Changes to response:

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -71,7 +71,7 @@ Statuses:
 | `z_listaccounts` | Implemented (altered) | [Changes](json_rpc.md#z_listaccounts) |
 | `z_listaddresses` | Omitted | Use `listaddresses` |
 | `z_listoperationids` | Implemented | |
-| `z_listreceivedbyaddress` | Not yet implemented | [#84](https://github.com/zcash/zallet/issues/84) |
+| `z_listreceivedbyaddress` | Implemented (altered) | [Changes](json_rpc.md#z_listreceivedbyaddress) |
 | `z_listunifiedreceivers` | Implemented | |
 | `z_listunspent` | Implemented (altered) | [Changes](json_rpc.md#z_listunspent) |
 | `z_mergetoaddress` | Not yet implemented | [#87](https://github.com/zcash/zallet/issues/87) |

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -125,11 +125,13 @@ zcash_client_backend = { workspace = true, features = [
     "pczt",
     "sync-decryptor",
     "transparent-inputs",
+    "zcashd-compat",
 ] }
 zcash_client_sqlite = { workspace = true, features = [
     "orchard",
     "serde",
     "transparent-inputs",
+    "zcashd-compat",
 ] }
 zcash_note_encryption.workspace = true
 zip32.workspace = true

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -448,6 +448,14 @@ impl WalletRead for DbConnection {
         self.with(|db_data| db_data.get_received_outputs(txid, target_height, confirmations_policy))
     }
 
+    fn get_account_received_outputs(
+        &self,
+        account: Self::AccountId,
+        query: &zcash_client_backend::data_api::ReceivedOutputsQuery,
+    ) -> Result<Vec<zcash_client_backend::data_api::AccountReceivedOutput>, Self::Error> {
+        self.with(|db_data| db_data.get_account_received_outputs(account, query))
+    }
+
     fn find_account_for_address<P: zcash_protocol::consensus::Parameters>(
         &self,
         params: &P,

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -86,6 +86,8 @@ mod z_get_total_balance;
 #[cfg(zallet_build = "wallet")]
 pub(crate) mod z_import_address;
 #[cfg(zallet_build = "wallet")]
+mod z_list_received_by_address;
+#[cfg(zallet_build = "wallet")]
 mod z_send_from_account;
 #[cfg(zallet_build = "wallet")]
 mod z_send_many;
@@ -596,6 +598,43 @@ pub(crate) trait WalletRpc {
         addresses: Option<Vec<String>>,
         as_of_height: Option<i64>,
     ) -> list_unspent::Response;
+
+    /// Returns a list of amounts received by an address belonging to the wallet, including
+    /// both spent and unspent outputs.
+    ///
+    /// For a shielded or unified address that corresponds to a unified account, the
+    /// received outputs of that account are returned irrespective of whether the provided
+    /// address's diversifier corresponds to the diversifier of the address that received
+    /// the funds; this includes change outputs received on wallet-internal addresses. A
+    /// transparent address returns only the outputs received by that specific address.
+    ///
+    /// Results are ordered by mined height ascending (unmined outputs last); `offset` and
+    /// `limit` page over that ordering.
+    ///
+    /// # Arguments
+    /// - `address`: The address that received the outputs to list.
+    /// - `minconf`: Only include outputs of transactions confirmed at least this many
+    ///   times (default = 1). Must be at least 1 when `as_of_height` is provided; a value
+    ///   of 0 includes outputs of unmined transactions.
+    /// - `as_of_height`: Execute the query as if it were run when the blockchain was at
+    ///   the height specified by this argument. The default is to use the entire
+    ///   blockchain that the node is aware of. -1 can be used as in other RPC calls to
+    ///   indicate the current height (including the mempool), but this does not support
+    ///   negative values in general. A “future” height will fall back to the current
+    ///   height.
+    /// - `offset`: An optional number of outputs to skip over before a page of results is
+    ///   returned. Defaults to zero.
+    /// - `limit`: An optional upper bound on the number of results that should be
+    ///   returned in a page.
+    #[method(name = "z_listreceivedbyaddress")]
+    async fn z_list_received_by_address(
+        &self,
+        address: &str,
+        minconf: Option<u32>,
+        as_of_height: Option<i64>,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> z_list_received_by_address::Response;
 
     /// Returns the number of notes available in the wallet for each shielded value pool.
     ///
@@ -1329,6 +1368,25 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             include_watchonly,
             addresses,
             as_of_height,
+        )
+    }
+
+    async fn z_list_received_by_address(
+        &self,
+        address: &str,
+        minconf: Option<u32>,
+        as_of_height: Option<i64>,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> z_list_received_by_address::Response {
+        self.general.ensure_synced()?;
+        z_list_received_by_address::call(
+            self.wallet().await?.as_ref(),
+            address,
+            minconf,
+            as_of_height,
+            offset,
+            limit,
         )
     }
 

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -105,6 +105,8 @@ mod z_get_total_balance;
 #[cfg(zallet_build = "wallet")]
 pub(crate) mod z_import_address;
 #[cfg(zallet_build = "wallet")]
+mod z_list_received_by_address;
+#[cfg(zallet_build = "wallet")]
 mod z_send_from_account;
 #[cfg(zallet_build = "wallet")]
 mod z_send_many;
@@ -618,6 +620,43 @@ pub(crate) trait WalletRpc {
         addresses: Option<Vec<String>>,
         as_of_height: Option<i64>,
     ) -> list_unspent::Response;
+
+    /// Returns a list of amounts received by an address belonging to the wallet, including
+    /// both spent and unspent outputs.
+    ///
+    /// For a shielded or unified address that corresponds to a unified account, the
+    /// received outputs of that account are returned irrespective of whether the provided
+    /// address's diversifier corresponds to the diversifier of the address that received
+    /// the funds; this includes change outputs received on wallet-internal addresses. A
+    /// transparent address returns only the outputs received by that specific address.
+    ///
+    /// Results are ordered by mined height ascending (unmined outputs last); `offset` and
+    /// `limit` page over that ordering.
+    ///
+    /// # Arguments
+    /// - `address`: The address that received the outputs to list.
+    /// - `minconf`: Only include outputs of transactions confirmed at least this many
+    ///   times (default = 1). Must be at least 1 when `as_of_height` is provided; a value
+    ///   of 0 includes outputs of unmined transactions.
+    /// - `as_of_height`: Execute the query as if it were run when the blockchain was at
+    ///   the height specified by this argument. The default is to use the entire
+    ///   blockchain that the node is aware of. -1 can be used as in other RPC calls to
+    ///   indicate the current height (including the mempool), but this does not support
+    ///   negative values in general. A “future” height will fall back to the current
+    ///   height.
+    /// - `offset`: An optional number of outputs to skip over before a page of results is
+    ///   returned. Defaults to zero.
+    /// - `limit`: An optional upper bound on the number of results that should be
+    ///   returned in a page.
+    #[method(name = "z_listreceivedbyaddress")]
+    async fn z_list_received_by_address(
+        &self,
+        address: &str,
+        minconf: Option<u32>,
+        as_of_height: Option<i64>,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> z_list_received_by_address::Response;
 
     /// Returns the number of notes available in the wallet for each shielded value pool.
     ///
@@ -1359,6 +1398,25 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
             include_watchonly,
             addresses,
             as_of_height,
+        )
+    }
+
+    async fn z_list_received_by_address(
+        &self,
+        address: &str,
+        minconf: Option<u32>,
+        as_of_height: Option<i64>,
+        offset: Option<u32>,
+        limit: Option<u32>,
+    ) -> z_list_received_by_address::Response {
+        self.general.ensure_synced()?;
+        z_list_received_by_address::call(
+            self.wallet().await?.as_ref(),
+            address,
+            minconf,
+            as_of_height,
+            offset,
+            limit,
         )
     }
 

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -20,14 +20,16 @@ use zcash_client_backend::{
     wallet::NoteId,
 };
 use zcash_keys::address::Address;
-use zcash_protocol::{ShieldedPool, consensus::BlockHeight, value::Zatoshis};
+use zcash_protocol::{ShieldedPool, value::Zatoshis};
 use zip32::Scope;
 
 use crate::components::{
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
-        utils::{JsonZec, parse_as_of_height, parse_minconf, value_from_zatoshis},
+        utils::{
+            JsonZec, confirmation_count, parse_as_of_height, parse_minconf, value_from_zatoshis,
+        },
     },
 };
 
@@ -111,20 +113,6 @@ pub(super) const PARAM_INCLUDE_WATCHONLY_DESC: &str =
 pub(super) const PARAM_ADDRESSES_DESC: &str =
     "If non-empty, only outputs received by the provided addresses will be returned.";
 pub(super) const PARAM_AS_OF_HEIGHT_DESC: &str = "Execute the query as if it were run when the blockchain was at the height specified by this argument.";
-
-/// The number of confirmations that an output of a transaction mined at `mined_height` has as
-/// of `target_height`.
-///
-/// An output of a transaction that is not mined in the main chain has zero confirmations. Such
-/// an output can be reported by this RPC when its transaction is in the mempool, or when a
-/// transaction that had been mined has been un-mined by a reorg and its containing block has
-/// not yet been re-scanned.
-fn confirmation_count(target_height: TargetHeight, mined_height: Option<BlockHeight>) -> u32 {
-    // Subtraction of block heights saturates at zero, which correctly reports a transaction
-    // mined at or above the target height (possible when `asOfHeight` places the target below
-    // the chain tip) as having no confirmations as of that height.
-    mined_height.map_or(0, |h| target_height - h)
-}
 
 /// Whether an output with the given number of confirmations is within the range of
 /// confirmations requested for this query.

--- a/zallet-core/src/components/json_rpc/methods/list_unspent.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_unspent.rs
@@ -20,18 +20,16 @@ use zcash_client_backend::{
     wallet::NoteId,
 };
 use zcash_keys::address::Address;
-use zcash_protocol::{
-    ShieldedPool,
-    consensus::{BlockHeight, COINBASE_MATURITY_BLOCKS},
-    value::Zatoshis,
-};
+use zcash_protocol::{ShieldedPool, consensus::COINBASE_MATURITY_BLOCKS, value::Zatoshis};
 use zip32::Scope;
 
 use crate::components::{
     database::DbConnection,
     json_rpc::{
         server::LegacyCode,
-        utils::{JsonZec, parse_as_of_height, parse_minconf, value_from_zatoshis},
+        utils::{
+            JsonZec, confirmation_count, parse_as_of_height, parse_minconf, value_from_zatoshis,
+        },
     },
 };
 
@@ -123,20 +121,6 @@ pub(super) const PARAM_INCLUDE_WATCHONLY_DESC: &str =
 pub(super) const PARAM_ADDRESSES_DESC: &str =
     "If non-empty, only outputs received by the provided addresses will be returned.";
 pub(super) const PARAM_AS_OF_HEIGHT_DESC: &str = "Execute the query as if it were run when the blockchain was at the height specified by this argument.";
-
-/// The number of confirmations that an output of a transaction mined at `mined_height` has as
-/// of `target_height`.
-///
-/// An output of a transaction that is not mined in the main chain has zero confirmations. Such
-/// an output can be reported by this RPC when its transaction is in the mempool, or when a
-/// transaction that had been mined has been un-mined by a reorg and its containing block has
-/// not yet been re-scanned.
-fn confirmation_count(target_height: TargetHeight, mined_height: Option<BlockHeight>) -> u32 {
-    // Subtraction of block heights saturates at zero, which correctly reports a transaction
-    // mined at or above the target height (possible when `asOfHeight` places the target below
-    // the chain tip) as having no confirmations as of that height.
-    mined_height.map_or(0, |h| target_height - h)
-}
 
 /// Whether an output with the given number of confirmations is within the range of
 /// confirmations requested for this query.

--- a/zallet-core/src/components/json_rpc/methods/z_list_received_by_address.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_list_received_by_address.rs
@@ -1,0 +1,489 @@
+use std::num::NonZeroU32;
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_client_backend::data_api::{
+    Account, AccountPurpose, AccountReceivedOutput, MinedStateFilter, ReceivedOutputsQuery,
+    WalletRead, wallet::TargetHeight,
+};
+use zcash_keys::address::Address;
+use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, memo::Memo};
+
+use crate::components::{
+    database::DbConnection,
+    json_rpc::{
+        payments,
+        server::LegacyCode,
+        utils::{
+            JsonZec, confirmation_count, parse_as_of_height, parse_minconf, value_from_zatoshis,
+        },
+    },
+};
+
+/// Response to a `z_listreceivedbyaddress` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// A list of outputs received by an address.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+#[serde(transparent)]
+pub(crate) struct ResultType(Vec<ReceivedOutput>);
+
+/// An output received by the wallet, whether or not it has been spent.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub(crate) struct ReceivedOutput {
+    /// The value pool in which the output was received.
+    ///
+    /// One of `["transparent", "sapling", "orchard", "ironwood"]`.
+    pool: String,
+
+    /// The ID of the transaction that created this output.
+    txid: String,
+
+    /// The value of the output in ZEC.
+    amount: JsonZec,
+
+    /// The value of the output in zatoshis.
+    #[serde(rename = "amountZat")]
+    amount_zat: u64,
+
+    /// The hexadecimal string representation of the memo field.
+    ///
+    /// Absent for transparent outputs, and for shielded outputs whose memo has not yet
+    /// been downloaded from the chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memo: Option<String>,
+
+    /// UTF-8 string representation of the memo field, if it represents a valid UTF-8
+    /// string.
+    #[serde(rename = "memoStr")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memo_str: Option<String>,
+
+    /// The transparent output index, Sapling output index, or Orchard or Ironwood action
+    /// index of the output within its transaction.
+    outindex: u32,
+
+    /// The number of confirmations.
+    confirmations: u32,
+
+    /// The height of the block containing the transaction, or `0` if the transaction is
+    /// unmined.
+    blockheight: u32,
+
+    /// The index of the transaction within the block containing it, or `-1` if the
+    /// transaction is unmined.
+    blockindex: i64,
+
+    /// The time of the block containing the transaction, in seconds since the POSIX
+    /// epoch, or `0` if the transaction is unmined.
+    blocktime: i64,
+
+    /// `true` if the output was received as change.
+    ///
+    /// Omitted for outputs received by accounts for which the wallet does not have
+    /// spending authority.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    change: Option<bool>,
+}
+
+pub(super) const PARAM_ADDRESS_DESC: &str = "The address that received the outputs to list.";
+pub(super) const PARAM_MINCONF_DESC: &str =
+    "Only include outputs of transactions confirmed at least this many times.";
+pub(super) const PARAM_AS_OF_HEIGHT_DESC: &str = "Execute the query as if it were run when the blockchain was at the height specified by this argument.";
+pub(super) const PARAM_OFFSET_DESC: &str =
+    "An optional number of outputs to skip over before a page of results is returned.";
+pub(super) const PARAM_LIMIT_DESC: &str =
+    "An optional upper bound on the number of results that should be returned in a page.";
+
+/// The mined-height bound and unmined-inclusion filter equivalent to requiring at least
+/// `minconf` confirmations as of `query_height` (the chain tip, or the `asOfHeight`
+/// parameter when given).
+///
+/// An output mined at height `h` has `query_height + 1 - h` confirmations, so requiring
+/// at least `minconf` of them is the bound `h <= query_height + 1 - minconf`. Unmined
+/// outputs have zero confirmations, and so are included exactly when `minconf` is zero
+/// (which `parse_minconf` permits only when `asOfHeight` is absent).
+fn mined_bounds(
+    minconf: u32,
+    query_height: BlockHeight,
+) -> (Option<BlockHeight>, MinedStateFilter) {
+    if minconf == 0 {
+        (Some(query_height + 1), MinedStateFilter::All)
+    } else {
+        // Subtraction of block heights saturates at zero; a `minconf` larger than the
+        // chain height yields a bound that no mined output satisfies.
+        (
+            Some(query_height + 1 - minconf),
+            MinedStateFilter::MinedOnly,
+        )
+    }
+}
+
+/// The JSON name of the value pool in which an output was received.
+fn pool_name(pool_type: PoolType) -> &'static str {
+    match pool_type {
+        PoolType::Transparent => "transparent",
+        PoolType::Shielded(ShieldedPool::Sapling) => "sapling",
+        PoolType::Shielded(ShieldedPool::Orchard) => "orchard",
+        PoolType::Shielded(ShieldedPool::Ironwood) => "ironwood",
+    }
+}
+
+/// Renders a received output as a `z_listreceivedbyaddress` result entry.
+///
+/// The `change` field is rendered only when `include_change` is set; the wallet omits it
+/// for accounts without spending authority, for which change detection is unreliable.
+fn received_output(
+    output: &AccountReceivedOutput,
+    target_height: TargetHeight,
+    include_change: bool,
+) -> RpcResult<ReceivedOutput> {
+    let (memo, memo_str) = match output.memo() {
+        Some(memo_bytes) => (
+            Some(hex::encode(memo_bytes.as_array())),
+            match Memo::try_from(memo_bytes.clone()) {
+                Ok(Memo::Text(text)) => Some(text.to_string()),
+                _ => None,
+            },
+        ),
+        None => (None, None),
+    };
+
+    let mined = output.mined_position();
+
+    Ok(ReceivedOutput {
+        pool: pool_name(output.pool_type()).into(),
+        txid: output.txid().to_string(),
+        amount: value_from_zatoshis(output.value()),
+        amount_zat: output.value().into(),
+        memo,
+        memo_str,
+        outindex: u32::try_from(output.output_index())
+            .map_err(|_| LegacyCode::Database.with_static("output index out of range"))?,
+        confirmations: confirmation_count(target_height, mined.map(|p| p.height())),
+        blockheight: mined.map_or(0, |p| p.height().into()),
+        blockindex: mined
+            .and_then(|p| p.tx_index())
+            .map_or(-1, |i| i64::from(u32::from(i))),
+        blocktime: mined.and_then(|p| p.block_time()).map_or(0, i64::from),
+        change: include_change.then_some(output.is_change()),
+    })
+}
+
+pub(crate) fn call(
+    wallet: &DbConnection,
+    address: &str,
+    minconf: Option<u32>,
+    as_of_height: Option<i64>,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Response {
+    let as_of_height = parse_as_of_height(as_of_height)?;
+    let minconf = parse_minconf(minconf, 1, as_of_height)?;
+    let limit = limit
+        .map(|l| {
+            NonZeroU32::new(l)
+                .ok_or_else(|| LegacyCode::InvalidParameter.with_static("limit must be positive"))
+        })
+        .transpose()?;
+
+    let addr = Address::decode(wallet.params(), address)
+        .ok_or_else(|| LegacyCode::InvalidAddressOrKey.with_static("Invalid zaddr."))?;
+
+    // ZIP 320 (TEX) addresses direct the *sender* to use transparent funds; they are not
+    // addresses that a wallet receives on, and zcashd predates them.
+    if matches!(addr, Address::Tex(_)) {
+        return Err(LegacyCode::InvalidParameter.with_static(
+            "TEX addresses cannot receive outputs; provide the transparent address instead.",
+        ));
+    }
+
+    let account = payments::get_account_for_address(wallet, &addr).map_err(|e| {
+        let db_code: i32 = LegacyCode::Database.into();
+        if e.code() == db_code {
+            e
+        } else {
+            LegacyCode::InvalidAddressOrKey.with_static(
+                "From address does not belong to this node, zaddr spending key or viewing key not found.",
+            )
+        }
+    })?;
+
+    // Reject an address that is a bare receiver of a "larger" unified address of the
+    // account, mirroring zcashd. An address whose receivers are exactly the receivers of
+    // a wallet address is that address in another encoding (for example, the Sapling
+    // address of an account created by importing a Sapling key, whose wallet address is
+    // the sapling-only unified re-encoding of it), and is accepted.
+    if !matches!(addr, Address::Unified(_)) {
+        let receivers = addr.as_understood_unified_receivers();
+        let addresses = wallet
+            .list_addresses(account.id())
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+        let exact = addresses.iter().any(|info| info.address() == &addr);
+        if !exact
+            && addresses.iter().any(|info| {
+                let stored = info.address();
+                matches!(stored, Address::Unified(_))
+                    && stored.as_understood_unified_receivers().len() > receivers.len()
+                    && {
+                        let stored_addr = stored.to_zcash_address(wallet.params());
+                        receivers.iter().all(|r| r.corresponds(&stored_addr))
+                    }
+            })
+        {
+            return Err(LegacyCode::InvalidParameter.with_static(
+                "The provided address is a bare receiver from a Unified Address in this wallet. Provide the full UA instead.",
+            ));
+        }
+    }
+
+    let query_height = match as_of_height {
+        Some(h) => h,
+        None => match wallet
+            .chain_height()
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        {
+            Some(h) => h,
+            None => return Ok(ResultType(vec![])),
+        },
+    };
+    let target_height = TargetHeight::from(query_height + 1);
+    let (max_mined_height, mined_state_filter) = mined_bounds(minconf, query_height);
+
+    // A transparent address selects only its own outputs: the account synthesized by
+    // zcashd wallet.dat migration aggregates many otherwise-unrelated imported
+    // transparent addresses, which zcashd would never list together. A shielded or
+    // unified address selects all of the account's outputs, so that this listing of
+    // what the account has received covers notes received at its other diversifiers
+    // along with the change notes received on its internal addresses: an address
+    // filter resolves to an `addresses` row, and internal shielded receivers are
+    // never stored as addresses, so a per-address filter could not report change.
+    // This is deliberately broader than `z_listunspent`, which matches shielded
+    // notes against the exact address it is given.
+    let address_filter = matches!(addr, Address::Transparent(_)).then(|| addr.clone());
+
+    let query = ReceivedOutputsQuery::from_parts(
+        address_filter,
+        max_mined_height,
+        mined_state_filter,
+        offset.unwrap_or(0),
+        limit,
+    );
+
+    let include_change = matches!(account.purpose(), AccountPurpose::Spending { .. });
+
+    let outputs = wallet
+        .get_account_received_outputs(account.id(), &query)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    Ok(ResultType(
+        outputs
+            .iter()
+            .map(|output| received_output(output, target_height, include_change))
+            .collect::<Result<Vec<_>, _>>()?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_client_backend::data_api::{
+        AccountReceivedOutput, MinedPosition, MinedStateFilter, wallet::TargetHeight,
+    };
+    use zcash_protocol::{
+        PoolType, ShieldedPool, TxId,
+        consensus::{BlockHeight, TxIndex},
+        memo::MemoBytes,
+        value::Zatoshis,
+    };
+
+    use super::{mined_bounds, received_output};
+
+    /// The height of the next block to be mined, as used by the RPC. An output mined in
+    /// block 99 therefore has one confirmation, and one mined in block 90 has ten.
+    const TARGET: u32 = 100;
+
+    fn target() -> TargetHeight {
+        TargetHeight::from(BlockHeight::from(TARGET))
+    }
+
+    /// The chain height corresponding to [`target`], as passed to [`mined_bounds`].
+    fn query_height() -> BlockHeight {
+        BlockHeight::from(TARGET - 1)
+    }
+
+    #[test]
+    fn minconf_zero_includes_unmined_outputs_and_bounds_nothing() {
+        let (bound, filter) = mined_bounds(0, query_height());
+        assert_eq!(bound, Some(BlockHeight::from(TARGET)));
+        assert_eq!(filter, MinedStateFilter::All);
+    }
+
+    #[test]
+    fn positive_minconf_bounds_mined_height_and_excludes_unmined_outputs() {
+        // An output mined in the top block has exactly one confirmation, so it is the
+        // highest block that `minconf = 1` admits.
+        assert_eq!(
+            mined_bounds(1, query_height()),
+            (Some(query_height()), MinedStateFilter::MinedOnly),
+        );
+        assert_eq!(
+            mined_bounds(10, query_height()),
+            (
+                Some(BlockHeight::from(TARGET - 10)),
+                MinedStateFilter::MinedOnly
+            ),
+        );
+    }
+
+    #[test]
+    fn excessive_minconf_bound_saturates_at_the_genesis_height() {
+        let (bound, _) = mined_bounds(TARGET + 50, query_height());
+        assert_eq!(bound, Some(BlockHeight::from(0)));
+    }
+
+    fn entry(
+        pool_type: PoolType,
+        memo: Option<MemoBytes>,
+        mined: Option<MinedPosition>,
+        include_change: bool,
+    ) -> serde_json::Value {
+        serde_json::to_value(
+            received_output(
+                &AccountReceivedOutput::from_parts(
+                    pool_type,
+                    TxId::from_bytes([1u8; 32]),
+                    3,
+                    Zatoshis::const_from_u64(625_000_000),
+                    false,
+                    None,
+                    memo,
+                    mined,
+                ),
+                target(),
+                include_change,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn mined_at_90() -> Option<MinedPosition> {
+        Some(MinedPosition::from_parts(
+            BlockHeight::from(90),
+            Some(TxIndex::from(2u16)),
+            Some(1_700_000_000),
+        ))
+    }
+
+    #[test]
+    fn shielded_text_memo_entry_renders_all_fields() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Sapling),
+            Some(MemoBytes::from_bytes(b"Hello memo").unwrap()),
+            mined_at_90(),
+            true,
+        );
+
+        assert_eq!(rendered["pool"], serde_json::json!("sapling"));
+        assert_eq!(
+            rendered["txid"],
+            serde_json::json!(TxId::from_bytes([1u8; 32]).to_string()),
+        );
+        assert_eq!(rendered["amountZat"], serde_json::json!(625_000_000u64));
+        // `JsonZec` renders ZEC values with eight decimal places, as zcashd does.
+        assert_eq!(
+            rendered["amount"],
+            serde_json::to_value(crate::components::json_rpc::utils::value_from_zatoshis(
+                Zatoshis::const_from_u64(625_000_000)
+            ))
+            .unwrap(),
+        );
+        assert_eq!(rendered["amount"].to_string(), "6.25000000");
+        assert_eq!(rendered["outindex"], serde_json::json!(3));
+        assert_eq!(rendered["confirmations"], serde_json::json!(10));
+        assert_eq!(rendered["blockheight"], serde_json::json!(90));
+        assert_eq!(rendered["blockindex"], serde_json::json!(2));
+        assert_eq!(rendered["blocktime"], serde_json::json!(1_700_000_000i64));
+        assert_eq!(rendered["change"], serde_json::json!(false));
+        assert_eq!(rendered["memoStr"], serde_json::json!("Hello memo"));
+
+        // The memo is the full 512-byte memo field, hex-encoded.
+        let memo_hex = rendered["memo"].as_str().unwrap();
+        assert_eq!(memo_hex.len(), 512 * 2);
+        assert!(memo_hex.starts_with(&hex::encode(b"Hello memo")));
+        assert!(memo_hex.ends_with("00"));
+    }
+
+    #[test]
+    fn empty_memo_renders_hex_but_no_memo_str() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Orchard),
+            Some(MemoBytes::empty()),
+            mined_at_90(),
+            true,
+        );
+
+        assert_eq!(rendered["pool"], serde_json::json!("orchard"));
+        assert!(rendered["memo"].as_str().unwrap().starts_with("f6"));
+        assert!(rendered.get("memoStr").is_none());
+    }
+
+    #[test]
+    fn arbitrary_memo_renders_hex_but_no_memo_str() {
+        let mut memo_bytes = [0u8; 512];
+        memo_bytes[0] = 0xff;
+        memo_bytes[1] = 0x42;
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Ironwood),
+            Some(MemoBytes::from_bytes(&memo_bytes).unwrap()),
+            mined_at_90(),
+            true,
+        );
+
+        assert_eq!(rendered["pool"], serde_json::json!("ironwood"));
+        assert!(rendered["memo"].as_str().unwrap().starts_with("ff42"));
+        assert!(rendered.get("memoStr").is_none());
+    }
+
+    #[test]
+    fn absent_memo_omits_both_memo_fields() {
+        // Transparent outputs have no memo, and a shielded output whose memo has not yet
+        // been downloaded renders the same way; the keys must be omitted entirely rather
+        // than rendered as `null`.
+        let rendered = entry(PoolType::Transparent, None, mined_at_90(), true);
+
+        assert_eq!(rendered["pool"], serde_json::json!("transparent"));
+        assert!(rendered.get("memo").is_none());
+        assert!(rendered.get("memoStr").is_none());
+    }
+
+    #[test]
+    fn unmined_entry_renders_zcashd_placeholder_block_fields() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Sapling),
+            Some(MemoBytes::empty()),
+            None,
+            true,
+        );
+
+        assert_eq!(rendered["confirmations"], serde_json::json!(0));
+        assert_eq!(rendered["blockheight"], serde_json::json!(0));
+        assert_eq!(rendered["blockindex"], serde_json::json!(-1));
+        assert_eq!(rendered["blocktime"], serde_json::json!(0));
+    }
+
+    #[test]
+    fn change_field_is_omitted_for_accounts_without_spending_authority() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Sapling),
+            Some(MemoBytes::empty()),
+            mined_at_90(),
+            false,
+        );
+
+        assert!(rendered.get("change").is_none());
+    }
+}

--- a/zallet-core/src/components/json_rpc/methods/z_list_received_by_address.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_list_received_by_address.rs
@@ -1,0 +1,484 @@
+use std::num::NonZeroU32;
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+use zcash_client_backend::data_api::{
+    Account, AccountPurpose, AccountReceivedOutput, MinedStateFilter, ReceivedOutputsQuery,
+    WalletRead, wallet::TargetHeight,
+};
+use zcash_keys::address::Address;
+use zcash_protocol::{PoolType, ShieldedPool, consensus::BlockHeight, memo::Memo};
+
+use crate::components::{
+    database::DbConnection,
+    json_rpc::{
+        payments,
+        server::LegacyCode,
+        utils::{
+            JsonZec, confirmation_count, parse_as_of_height, parse_minconf, value_from_zatoshis,
+        },
+    },
+};
+
+/// Response to a `z_listreceivedbyaddress` RPC request.
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// A list of outputs received by an address.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+#[serde(transparent)]
+pub(crate) struct ResultType(Vec<ReceivedOutput>);
+
+/// An output received by the wallet, whether or not it has been spent.
+#[derive(Clone, Debug, Serialize, JsonSchema)]
+pub(crate) struct ReceivedOutput {
+    /// The value pool in which the output was received.
+    ///
+    /// One of `["transparent", "sapling", "orchard", "ironwood"]`.
+    pool: String,
+
+    /// The ID of the transaction that created this output.
+    txid: String,
+
+    /// The value of the output in ZEC.
+    amount: JsonZec,
+
+    /// The value of the output in zatoshis.
+    #[serde(rename = "amountZat")]
+    amount_zat: u64,
+
+    /// The hexadecimal string representation of the memo field.
+    ///
+    /// Absent for transparent outputs, and for shielded outputs whose memo has not yet
+    /// been downloaded from the chain.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memo: Option<String>,
+
+    /// UTF-8 string representation of the memo field, if it represents a valid UTF-8
+    /// string.
+    #[serde(rename = "memoStr")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    memo_str: Option<String>,
+
+    /// The transparent output index, Sapling output index, or Orchard or Ironwood action
+    /// index of the output within its transaction.
+    outindex: u32,
+
+    /// The number of confirmations.
+    confirmations: u32,
+
+    /// The height of the block containing the transaction, or `0` if the transaction is
+    /// unmined.
+    blockheight: u32,
+
+    /// The index of the transaction within the block containing it, or `-1` if the
+    /// transaction is unmined.
+    blockindex: i64,
+
+    /// The time of the block containing the transaction, in seconds since the POSIX
+    /// epoch, or `0` if the transaction is unmined.
+    blocktime: i64,
+
+    /// `true` if the output was received as change.
+    ///
+    /// Omitted for outputs received by accounts for which the wallet does not have
+    /// spending authority.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    change: Option<bool>,
+}
+
+pub(super) const PARAM_ADDRESS_DESC: &str = "The address that received the outputs to list.";
+pub(super) const PARAM_MINCONF_DESC: &str =
+    "Only include outputs of transactions confirmed at least this many times.";
+pub(super) const PARAM_AS_OF_HEIGHT_DESC: &str = "Execute the query as if it were run when the blockchain was at the height specified by this argument.";
+pub(super) const PARAM_OFFSET_DESC: &str =
+    "An optional number of outputs to skip over before a page of results is returned.";
+pub(super) const PARAM_LIMIT_DESC: &str =
+    "An optional upper bound on the number of results that should be returned in a page.";
+
+/// The mined-height bound and unmined-inclusion filter equivalent to requiring at least
+/// `minconf` confirmations as of `query_height` (the chain tip, or the `asOfHeight`
+/// parameter when given).
+///
+/// An output mined at height `h` has `query_height + 1 - h` confirmations, so requiring
+/// at least `minconf` of them is the bound `h <= query_height + 1 - minconf`. Unmined
+/// outputs have zero confirmations, and so are included exactly when `minconf` is zero
+/// (which `parse_minconf` permits only when `asOfHeight` is absent).
+fn mined_bounds(
+    minconf: u32,
+    query_height: BlockHeight,
+) -> (Option<BlockHeight>, MinedStateFilter) {
+    if minconf == 0 {
+        (Some(query_height + 1), MinedStateFilter::All)
+    } else {
+        // Subtraction of block heights saturates at zero; a `minconf` larger than the
+        // chain height yields a bound that no mined output satisfies.
+        (
+            Some(query_height + 1 - minconf),
+            MinedStateFilter::MinedOnly,
+        )
+    }
+}
+
+/// The JSON name of the value pool in which an output was received.
+fn pool_name(pool_type: PoolType) -> &'static str {
+    match pool_type {
+        PoolType::Transparent => "transparent",
+        PoolType::Shielded(ShieldedPool::Sapling) => "sapling",
+        PoolType::Shielded(ShieldedPool::Orchard) => "orchard",
+        PoolType::Shielded(ShieldedPool::Ironwood) => "ironwood",
+    }
+}
+
+/// Renders a received output as a `z_listreceivedbyaddress` result entry.
+///
+/// The `change` field is rendered only when `include_change` is set; the wallet omits it
+/// for accounts without spending authority, for which change detection is unreliable.
+fn received_output(
+    output: &AccountReceivedOutput,
+    target_height: TargetHeight,
+    include_change: bool,
+) -> RpcResult<ReceivedOutput> {
+    let (memo, memo_str) = match output.memo() {
+        Some(memo_bytes) => (
+            Some(hex::encode(memo_bytes.as_array())),
+            match Memo::try_from(memo_bytes.clone()) {
+                Ok(Memo::Text(text)) => Some(text.to_string()),
+                _ => None,
+            },
+        ),
+        None => (None, None),
+    };
+
+    let mined = output.mined_position();
+
+    Ok(ReceivedOutput {
+        pool: pool_name(output.pool_type()).into(),
+        txid: output.txid().to_string(),
+        amount: value_from_zatoshis(output.value()),
+        amount_zat: output.value().into(),
+        memo,
+        memo_str,
+        outindex: u32::try_from(output.output_index())
+            .map_err(|_| LegacyCode::Database.with_static("output index out of range"))?,
+        confirmations: confirmation_count(target_height, mined.map(|p| p.height())),
+        blockheight: mined.map_or(0, |p| p.height().into()),
+        blockindex: mined
+            .and_then(|p| p.tx_index())
+            .map_or(-1, |i| i64::from(u32::from(i))),
+        blocktime: mined.and_then(|p| p.block_time()).map_or(0, i64::from),
+        change: include_change.then_some(output.is_change()),
+    })
+}
+
+pub(crate) fn call(
+    wallet: &DbConnection,
+    address: &str,
+    minconf: Option<u32>,
+    as_of_height: Option<i64>,
+    offset: Option<u32>,
+    limit: Option<u32>,
+) -> Response {
+    let as_of_height = parse_as_of_height(as_of_height)?;
+    let minconf = parse_minconf(minconf, 1, as_of_height)?;
+    let limit = limit
+        .map(|l| {
+            NonZeroU32::new(l)
+                .ok_or_else(|| LegacyCode::InvalidParameter.with_static("limit must be positive"))
+        })
+        .transpose()?;
+
+    let addr = Address::decode(wallet.params(), address)
+        .ok_or_else(|| LegacyCode::InvalidAddressOrKey.with_static("Invalid zaddr."))?;
+
+    // ZIP 320 (TEX) addresses direct the *sender* to use transparent funds; they are not
+    // addresses that a wallet receives on, and zcashd predates them.
+    if matches!(addr, Address::Tex(_)) {
+        return Err(LegacyCode::InvalidParameter.with_static(
+            "TEX addresses cannot receive outputs; provide the transparent address instead.",
+        ));
+    }
+
+    let account = payments::get_account_for_address(wallet, &addr).map_err(|e| {
+        let db_code: i32 = LegacyCode::Database.into();
+        if e.code() == db_code {
+            e
+        } else {
+            LegacyCode::InvalidAddressOrKey.with_static(
+                "From address does not belong to this node, zaddr spending key or viewing key not found.",
+            )
+        }
+    })?;
+
+    // Reject an address that is a bare receiver of a "larger" unified address of the
+    // account, mirroring zcashd. An address whose receivers are exactly the receivers of
+    // a wallet address is that address in another encoding (for example, the Sapling
+    // address of an account created by importing a Sapling key, whose wallet address is
+    // the sapling-only unified re-encoding of it), and is accepted.
+    if !matches!(addr, Address::Unified(_)) {
+        let receivers = addr.as_understood_unified_receivers();
+        let addresses = wallet
+            .list_addresses(account.id())
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+        let exact = addresses.iter().any(|info| info.address() == &addr);
+        if !exact
+            && addresses.iter().any(|info| {
+                let stored = info.address();
+                matches!(stored, Address::Unified(_))
+                    && stored.as_understood_unified_receivers().len() > receivers.len()
+                    && {
+                        let stored_addr = stored.to_zcash_address(wallet.params());
+                        receivers.iter().all(|r| r.corresponds(&stored_addr))
+                    }
+            })
+        {
+            return Err(LegacyCode::InvalidParameter.with_static(
+                "The provided address is a bare receiver from a Unified Address in this wallet. Provide the full UA instead.",
+            ));
+        }
+    }
+
+    let query_height = match as_of_height {
+        Some(h) => h,
+        None => match wallet
+            .chain_height()
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        {
+            Some(h) => h,
+            None => return Ok(ResultType(vec![])),
+        },
+    };
+    let target_height = TargetHeight::from(query_height + 1);
+    let (max_mined_height, mined_state_filter) = mined_bounds(minconf, query_height);
+
+    // A transparent address selects only its own outputs: the account synthesized by
+    // zcashd wallet.dat migration aggregates many otherwise-unrelated imported
+    // transparent addresses, which zcashd would never list together. A shielded or
+    // unified address selects all of the account's outputs, matching the account-level
+    // semantics of `z_listunspent`.
+    let address_filter = matches!(addr, Address::Transparent(_)).then(|| addr.clone());
+
+    let query = ReceivedOutputsQuery::from_parts(
+        address_filter,
+        max_mined_height,
+        mined_state_filter,
+        offset.unwrap_or(0),
+        limit,
+    );
+
+    let include_change = matches!(account.purpose(), AccountPurpose::Spending { .. });
+
+    let outputs = wallet
+        .get_account_received_outputs(account.id(), &query)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    Ok(ResultType(
+        outputs
+            .iter()
+            .map(|output| received_output(output, target_height, include_change))
+            .collect::<Result<Vec<_>, _>>()?,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use zcash_client_backend::data_api::{
+        AccountReceivedOutput, MinedPosition, MinedStateFilter, wallet::TargetHeight,
+    };
+    use zcash_protocol::{
+        PoolType, ShieldedPool, TxId,
+        consensus::{BlockHeight, TxIndex},
+        memo::MemoBytes,
+        value::Zatoshis,
+    };
+
+    use super::{mined_bounds, received_output};
+
+    /// The height of the next block to be mined, as used by the RPC. An output mined in
+    /// block 99 therefore has one confirmation, and one mined in block 90 has ten.
+    const TARGET: u32 = 100;
+
+    fn target() -> TargetHeight {
+        TargetHeight::from(BlockHeight::from(TARGET))
+    }
+
+    /// The chain height corresponding to [`target`], as passed to [`mined_bounds`].
+    fn query_height() -> BlockHeight {
+        BlockHeight::from(TARGET - 1)
+    }
+
+    #[test]
+    fn minconf_zero_includes_unmined_outputs_and_bounds_nothing() {
+        let (bound, filter) = mined_bounds(0, query_height());
+        assert_eq!(bound, Some(BlockHeight::from(TARGET)));
+        assert_eq!(filter, MinedStateFilter::All);
+    }
+
+    #[test]
+    fn positive_minconf_bounds_mined_height_and_excludes_unmined_outputs() {
+        // An output mined in the top block has exactly one confirmation, so it is the
+        // highest block that `minconf = 1` admits.
+        assert_eq!(
+            mined_bounds(1, query_height()),
+            (Some(query_height()), MinedStateFilter::MinedOnly),
+        );
+        assert_eq!(
+            mined_bounds(10, query_height()),
+            (
+                Some(BlockHeight::from(TARGET - 10)),
+                MinedStateFilter::MinedOnly
+            ),
+        );
+    }
+
+    #[test]
+    fn excessive_minconf_bound_saturates_at_the_genesis_height() {
+        let (bound, _) = mined_bounds(TARGET + 50, query_height());
+        assert_eq!(bound, Some(BlockHeight::from(0)));
+    }
+
+    fn entry(
+        pool_type: PoolType,
+        memo: Option<MemoBytes>,
+        mined: Option<MinedPosition>,
+        include_change: bool,
+    ) -> serde_json::Value {
+        serde_json::to_value(
+            received_output(
+                &AccountReceivedOutput::from_parts(
+                    pool_type,
+                    TxId::from_bytes([1u8; 32]),
+                    3,
+                    Zatoshis::const_from_u64(625_000_000),
+                    false,
+                    None,
+                    memo,
+                    mined,
+                ),
+                target(),
+                include_change,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    fn mined_at_90() -> Option<MinedPosition> {
+        Some(MinedPosition::from_parts(
+            BlockHeight::from(90),
+            Some(TxIndex::from(2u16)),
+            Some(1_700_000_000),
+        ))
+    }
+
+    #[test]
+    fn shielded_text_memo_entry_renders_all_fields() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Sapling),
+            Some(MemoBytes::from_bytes(b"Hello memo").unwrap()),
+            mined_at_90(),
+            true,
+        );
+
+        assert_eq!(rendered["pool"], serde_json::json!("sapling"));
+        assert_eq!(
+            rendered["txid"],
+            serde_json::json!(TxId::from_bytes([1u8; 32]).to_string()),
+        );
+        assert_eq!(rendered["amountZat"], serde_json::json!(625_000_000u64));
+        // `JsonZec` renders ZEC values with eight decimal places, as zcashd does.
+        assert_eq!(
+            rendered["amount"],
+            serde_json::to_value(crate::components::json_rpc::utils::value_from_zatoshis(
+                Zatoshis::const_from_u64(625_000_000)
+            ))
+            .unwrap(),
+        );
+        assert_eq!(rendered["amount"].to_string(), "6.25000000");
+        assert_eq!(rendered["outindex"], serde_json::json!(3));
+        assert_eq!(rendered["confirmations"], serde_json::json!(10));
+        assert_eq!(rendered["blockheight"], serde_json::json!(90));
+        assert_eq!(rendered["blockindex"], serde_json::json!(2));
+        assert_eq!(rendered["blocktime"], serde_json::json!(1_700_000_000i64));
+        assert_eq!(rendered["change"], serde_json::json!(false));
+        assert_eq!(rendered["memoStr"], serde_json::json!("Hello memo"));
+
+        // The memo is the full 512-byte memo field, hex-encoded.
+        let memo_hex = rendered["memo"].as_str().unwrap();
+        assert_eq!(memo_hex.len(), 512 * 2);
+        assert!(memo_hex.starts_with(&hex::encode(b"Hello memo")));
+        assert!(memo_hex.ends_with("00"));
+    }
+
+    #[test]
+    fn empty_memo_renders_hex_but_no_memo_str() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Orchard),
+            Some(MemoBytes::empty()),
+            mined_at_90(),
+            true,
+        );
+
+        assert_eq!(rendered["pool"], serde_json::json!("orchard"));
+        assert!(rendered["memo"].as_str().unwrap().starts_with("f6"));
+        assert!(rendered.get("memoStr").is_none());
+    }
+
+    #[test]
+    fn arbitrary_memo_renders_hex_but_no_memo_str() {
+        let mut memo_bytes = [0u8; 512];
+        memo_bytes[0] = 0xff;
+        memo_bytes[1] = 0x42;
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Ironwood),
+            Some(MemoBytes::from_bytes(&memo_bytes).unwrap()),
+            mined_at_90(),
+            true,
+        );
+
+        assert_eq!(rendered["pool"], serde_json::json!("ironwood"));
+        assert!(rendered["memo"].as_str().unwrap().starts_with("ff42"));
+        assert!(rendered.get("memoStr").is_none());
+    }
+
+    #[test]
+    fn absent_memo_omits_both_memo_fields() {
+        // Transparent outputs have no memo, and a shielded output whose memo has not yet
+        // been downloaded renders the same way; the keys must be omitted entirely rather
+        // than rendered as `null`.
+        let rendered = entry(PoolType::Transparent, None, mined_at_90(), true);
+
+        assert_eq!(rendered["pool"], serde_json::json!("transparent"));
+        assert!(rendered.get("memo").is_none());
+        assert!(rendered.get("memoStr").is_none());
+    }
+
+    #[test]
+    fn unmined_entry_renders_zcashd_placeholder_block_fields() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Sapling),
+            Some(MemoBytes::empty()),
+            None,
+            true,
+        );
+
+        assert_eq!(rendered["confirmations"], serde_json::json!(0));
+        assert_eq!(rendered["blockheight"], serde_json::json!(0));
+        assert_eq!(rendered["blockindex"], serde_json::json!(-1));
+        assert_eq!(rendered["blocktime"], serde_json::json!(0));
+    }
+
+    #[test]
+    fn change_field_is_omitted_for_accounts_without_spending_authority() {
+        let rendered = entry(
+            PoolType::Shielded(ShieldedPool::Sapling),
+            Some(MemoBytes::empty()),
+            mined_at_90(),
+            false,
+        );
+
+        assert!(rendered.get("change").is_none());
+    }
+}

--- a/zallet-core/src/components/json_rpc/utils.rs
+++ b/zallet-core/src/components/json_rpc/utils.rs
@@ -322,6 +322,24 @@ pub(super) fn parse_minconf(
     }
 }
 
+/// The number of confirmations that an output of a transaction mined at `mined_height` has as
+/// of `target_height`.
+///
+/// An output of a transaction that is not mined in the main chain has zero confirmations. Such
+/// an output can be reported by an RPC when its transaction is in the mempool, or when a
+/// transaction that had been mined has been un-mined by a reorg and its containing block has
+/// not yet been re-scanned.
+#[cfg(zallet_build = "wallet")]
+pub(super) fn confirmation_count(
+    target_height: zcash_client_backend::data_api::wallet::TargetHeight,
+    mined_height: Option<BlockHeight>,
+) -> u32 {
+    // Subtraction of block heights saturates at zero, which correctly reports a transaction
+    // mined at or above the target height (possible when `asOfHeight` places the target below
+    // the chain tip) as having no confirmations as of that height.
+    mined_height.map_or(0, |h| target_height - h)
+}
+
 /// Equivalent of `AmountFromValue` in `zcashd`, permitting the same input formats.
 #[cfg(zallet_build = "wallet")]
 pub(super) fn zatoshis_from_value(value: &JsonValue) -> RpcResult<Zatoshis> {

--- a/zallet-core/src/components/json_rpc/utils.rs
+++ b/zallet-core/src/components/json_rpc/utils.rs
@@ -340,6 +340,24 @@ pub(super) fn parse_minconf(
     }
 }
 
+/// The number of confirmations that an output of a transaction mined at `mined_height` has as
+/// of `target_height`.
+///
+/// An output of a transaction that is not mined in the main chain has zero confirmations. Such
+/// an output can be reported by an RPC when its transaction is in the mempool, or when a
+/// transaction that had been mined has been un-mined by a reorg and its containing block has
+/// not yet been re-scanned.
+#[cfg(zallet_build = "wallet")]
+pub(super) fn confirmation_count(
+    target_height: zcash_client_backend::data_api::wallet::TargetHeight,
+    mined_height: Option<BlockHeight>,
+) -> u32 {
+    // Subtraction of block heights saturates at zero, which correctly reports a transaction
+    // mined at or above the target height (possible when `asOfHeight` places the target below
+    // the chain tip) as having no confirmations as of that height.
+    mined_height.map_or(0, |h| target_height - h)
+}
+
 /// Equivalent of `AmountFromValue` in `zcashd`, permitting the same input formats.
 #[cfg(zallet_build = "wallet")]
 pub(super) fn zatoshis_from_value(value: &JsonValue) -> RpcResult<Zatoshis> {


### PR DESCRIPTION
Implements the `z_listreceivedbyaddress` JSON-RPC method. Closes #84.

Data access goes exclusively through a new typed librustzcash API, `WalletRead::get_account_received_outputs` (zcash/librustzcash#2972, implemented on branch `pacu/account-received-outputs`, which this PR pins via `[patch.crates-io]`); no raw SQL was added to Zallet. The filters and pagination are pushed down into a single indexed wallet-DB query, so large wallets only pay for the page they request.

Semantics (documented in `book/src/zcashd/json_rpc.md`):
- **Shielded/unified addresses match at the account level**: any address of a unified account returns the account's received outputs irrespective of diversifier, including internal change notes (reported with `change: true`). This is deliberately broader than `zcashd`, which reported only what the given address received. The reason it is broader: an address filter resolves to an `addresses` row, and internal shielded receivers are never stored as addresses, so a per-address filter could not report change at all. Note this is *not* the behaviour of `z_listunspent`, which matches shielded notes against the exact address it is given — reviewers should weigh whether the broader listing is the semantics we want here.
- **Transparent addresses match per-address**, because the account synthesized by `zcashd` `wallet.dat` migration aggregates many otherwise-unrelated imported taddrs.
- Bare receivers of a larger UA in the wallet are rejected as in `zcashd`; an address whose receivers exactly equal a wallet address's receivers (e.g. the Sapling address of a `z_importkey` account) is accepted.
- Spent outputs are listed (this is a received-history listing, not a UTXO listing); locked notes are included, consistent with `z_listunspent`.
- New optional `offset`/`limit` parameters, following `z_listtransactions`, page over a deterministic height-ascending ordering.

## Dependency pin

`[patch.crates-io]` points at `pacu/account-received-outputs` @ `8759c9e40f7333f89b184aa8f0563e8ce7f8c2bf`. That branch is based on `1f6bb2072e` — the librustzcash `main` rev this repository already pinned — so it retains the zero-expiry unmined-transaction fix (zcash/librustzcash#2983) that `migrate-zcashd-wallet` needs, and the crate versions are unchanged from `main` (`zcash_client_backend =0.24.0`, `zcash_client_sqlite =0.22.0`).

**This PR cannot merge until the librustzcash change lands in a release.** zcash/librustzcash#2972 is still an open issue; the API exists only on that branch. Review of the Zallet side can proceed independently.

## Testing

- Unit tests for the response rendering (memo/memoStr, unmined placeholder fields, watch-only `change` omission) and the minconf→height-bound push-down mapping.
- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` and `cargo test` across all three workspaces; `utils/check-lockstep.sh` passes.
- Previously verified end-to-end by the paired integration test in zcash/integration-tests against a locally built zebrad+zainod+zallet stack (all 13 sub-cases passing, including minconf/asOfHeight semantics, bare-receiver errors, and pagination). **That run predates this rebase onto `main` and onto the newer librustzcash base, so it should be re-run before merge.**

## Known issue, out of scope

A transaction whose only relevance to the wallet is a transparent output (detected from the mempool) does not get its mined height stamped by the block scan — nothing in the block trial-decrypts — and the asynchronous status-polling path did not converge within the test's timeout, so such receipts stay at 0 confirmations in wallet views for an extended period. This affects `z_listunspent` equally and is noted in the integration test with a `minconf=0` workaround. Tracked in #778, with root-cause analysis and fix options.

ZIT-Revision: wallet-z-listreceivedbyaddress

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
