### PR TITLE
fix: pass fallback_network for pre-Sapling wallets and bump zewif-zcashd to rc.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,14 @@ be considered breaking changes.
 
 ### Fixed
 
+- `migrate-zcashd-wallet` now passes a fallback network to the wallet parser
+  for regtest wallets. A pre-Sapling wallet (zcashd < 5.0.0) has no
+  `networkinfo` record; without a fallback, parsing failed with "wallet has no
+  networkinfo record". The fallback is derived from the wallet database's
+  configured network type.
+- A regtest wallet's transactions mined under NU6.3 (Ironwood) no longer fail
+  to import with "Consensus branch ID not known". Bumped `zewif-zcashd` to
+  0.1.0-rc.5, which includes NU6.3 in the regtest activation schedule.
 - A note commitment tree conflict during sync no longer shuts the wallet down
   permanently. Zallet now rolls the wallet back to a progressively older point
   and rescans, up to a bounded number of attempts and never below the wallet's

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6209,9 +6209,9 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424c72d333c20864e9655b4a71767069fb9e5d9228cff647b3164396e779a3cd"
+checksum = "b67252cc55aad73afc6d608f29d14711d86e2b06bffcb76585aba31ee6310901"
 dependencies = [
  "aes",
  "bech32 0.12.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,7 +166,7 @@ bip32 = "0.2"
 
 # Zcashd wallet migration
 zewif = { version = "1.0.0-rc.3" }
-zewif-zcashd = { version = "0.1.0-rc.4" }
+zewif-zcashd = { version = "0.1.0-rc.5" }
 which = "8.0"
 anyhow = "1.0"
 

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -7672,9 +7672,9 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424c72d333c20864e9655b4a71767069fb9e5d9228cff647b3164396e779a3cd"
+checksum = "b67252cc55aad73afc6d608f29d14711d86e2b06bffcb76585aba31ee6310901"
 dependencies = [
  "aes",
  "bech32 0.12.0",

--- a/backends/zaino/supply-chain/config.toml
+++ b/backends/zaino/supply-chain/config.toml
@@ -2049,7 +2049,7 @@ version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.zewif-zcashd]]
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -7274,9 +7274,9 @@ dependencies = [
 
 [[package]]
 name = "zewif-zcashd"
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424c72d333c20864e9655b4a71767069fb9e5d9228cff647b3164396e779a3cd"
+checksum = "b67252cc55aad73afc6d608f29d14711d86e2b06bffcb76585aba31ee6310901"
 dependencies = [
  "aes",
  "bech32 0.12.0",

--- a/backends/zebra/supply-chain/config.toml
+++ b/backends/zebra/supply-chain/config.toml
@@ -1937,7 +1937,7 @@ version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.zewif-zcashd]]
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -1662,7 +1662,7 @@ version = "0.11.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.zewif-zcashd]]
-version = "0.1.0-rc.4"
+version = "0.1.0-rc.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.zmij]]

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -18,7 +18,9 @@ use zcash_client_sqlite::zewif::{
 };
 use zcash_primitives::block::BlockHash;
 use zcash_protocol::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
-use zewif_zcashd::{BDBDump, EncryptedKeyPolicy, ZcashdDump, ZcashdParser, ZcashdWallet};
+use zewif_zcashd::{
+    BDBDump, EncryptedKeyPolicy, ParseOptions, ZcashdDump, ZcashdParser, ZcashdWallet,
+};
 use zip32::fingerprint::SeedFingerprint;
 
 use crate::{
@@ -71,7 +73,7 @@ impl MigrateZcashdWalletCmd {
         let keystore = KeyStore::new(&config, db.clone())?;
 
         info!("Dumping zcashd wallet");
-        let wallet = self.dump_wallet()?;
+        let wallet = self.dump_wallet(config.consensus.network)?;
         info!("Wallet dumped");
 
         Self::migrate_zcashd_wallet(
@@ -97,7 +99,7 @@ impl AsyncRunnable for MigrateZcashdWalletCmd {
 }
 
 impl MigrateZcashdWalletCmd {
-    fn dump_wallet(&self) -> Result<ZcashdWallet, MigrateError> {
+    fn dump_wallet(&self, network_type: NetworkType) -> Result<ZcashdWallet, MigrateError> {
         let wallet_path = if self.path.is_relative() {
             if let Some(datadir) = self.zcashd_datadir.as_ref() {
                 datadir.join(&self.path)
@@ -154,7 +156,25 @@ impl MigrateZcashdWalletCmd {
                 }
             })?;
 
-        let parse_result = match ZcashdParser::parse_dump(&zcashd_dump, !self.allow_warnings) {
+        // A pre-Sapling wallet (zcashd < 5.0.0) has no `networkinfo` record;
+        // the parser requires a fallback network to identify its chain. For
+        // regtest, supply the wallet database's configured network. Mainnet
+        // and testnet wallets carry `networkinfo` from zcashd 2.0.0 onwards,
+        // so no fallback is needed for them, but supplying one is harmless
+        // (the wallet's own `networkinfo` record is authoritative when present).
+        let fallback_network = match network_type {
+            NetworkType::Regtest => Some(zewif::Network::Regtest(zewif::RegtestParams::default())),
+            NetworkType::Main | NetworkType::Test => None,
+        };
+
+        let base_options = ParseOptions::new().strict(!self.allow_warnings);
+        let base_options = if let Some(net) = fallback_network.clone() {
+            base_options.fallback_network(net)
+        } else {
+            base_options
+        };
+
+        let parse_result = match ZcashdParser::parse_dump_with_options(&zcashd_dump, base_options) {
             // The wallet's key material is encrypted; interactively request the wallet
             // passphrase and retry.
             Err(zewif_zcashd::Error::EncryptedWalletRequiresPassphrase) => {
@@ -164,11 +184,15 @@ impl MigrateZcashdWalletCmd {
                         rpassword::prompt_password(fl!("cmd-migrate-wallet-passphrase-prompt"))
                             .map_err(|e| ErrorKind::Generic.context(e))?;
                     attempts += 1;
-                    match ZcashdParser::parse_dump_with_policy(
-                        &zcashd_dump,
-                        !self.allow_warnings,
-                        EncryptedKeyPolicy::Decrypt(SecretVec::new(passphrase.into_bytes())),
-                    ) {
+                    let mut options = ParseOptions::new()
+                        .strict(!self.allow_warnings)
+                        .encrypted_key_policy(EncryptedKeyPolicy::Decrypt(SecretVec::new(
+                            passphrase.into_bytes(),
+                        )));
+                    if let Some(net) = fallback_network.clone() {
+                        options = options.fallback_network(net);
+                    }
+                    match ZcashdParser::parse_dump_with_options(&zcashd_dump, options) {
                         Err(zewif_zcashd::Error::WrongWalletPassphrase) if attempts < 3 => {
                             eprintln!("{}", fl!("cmd-migrate-wallet-passphrase-wrong"));
                         }


### PR DESCRIPTION
Two bugs surfaced when integration-tests#197 ran against zallet main (which includes #741):

**1. Pre-Sapling wallet parsing fails with MissingNetworkInfo**

```
Error: An error occurred in extracting wallet data from '...wallet.dat': 
'wallet has no networkinfo record; supply the wallet's network to parse this pre-5.0.0 wallet'
```

A pre-Sapling wallet (zcashd < 5.0.0) has no `networkinfo` record. The `zewif-zcashd` rc.4 parser (PR #23) correctly requires a fallback network instead of guessing, but zallet was calling `ZcashdParser::parse_dump` (the old API) which doesn't accept one. Fixed by switching to `parse_dump_with_options` with `ParseOptions::fallback_network(...)`, deriving the network from the wallet database's configured `NetworkType`.

**2. NU6.3 transactions fail to import with "Consensus branch ID not known"**

```
Error: An error occurred importing the ZeWIF document into the wallet database: 
'Wallet database error: Data DB is corrupted: Consensus branch ID not known, 
cannot parse this transaction until it is mined'
```

`zewif-zcashd` rc.4's `regtest_params_from_local` was missing NU6.3 (Ironwood) in the activation map. Fixed in `zewif-zcashd` 0.1.0-rc.5 (zcash/zewif-zcashd#25) and bumped here.

Co-Authored-By: Claude <noreply@anthropic.com>