### PR TITLE
fix: record resolved mined heights on migrated transactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,6 +129,13 @@ be considered breaking changes.
 - A regtest wallet's transactions mined under NU6.3 (Ironwood) no longer fail
   to import with "Consensus branch ID not known". Bumped `zewif-zcashd` to
   0.1.0-rc.5, which includes NU6.3 in the regtest activation schedule.
+- `migrate-zcashd-wallet` now records each migrated transaction's main-chain
+  mined height (resolved from the block hash the zcashd wallet stored) instead
+  of importing every transaction as unmined. Previously, a mined transaction
+  whose sender had disabled expiry (`nExpiryHeight = 0`) could not be read back
+  during the import — there was no height from which to infer its consensus
+  branch ID — and the migration failed with "Consensus branch ID not known,
+  cannot parse this transaction until it is mined".
 - A note commitment tree conflict during sync no longer shuts the wallet down
   permanently. Zallet now rolls the wallet back to a progressively older point
   and rescans, up to a bounded number of attempts and never below the wallet's

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -403,8 +403,8 @@ impl MigrateZcashdWalletCmd {
         // constructs precise account birthdays with no further chain access. In
         // no-scan mode, estimate a conservative birthday from transaction expiry
         // heights; the importer will schedule a rescan from there.
+        let mut block_heights = HashMap::new();
         let (birthday_chain_state, recover_until) = if let Some(chain_view) = chain_view.as_ref() {
-            let mut block_heights = HashMap::new();
             for tx in document.transactions().values() {
                 if let Some(position) = tx.block_position() {
                     let block_hash = BlockHash(*position.block_hash().as_bytes());
@@ -470,6 +470,7 @@ impl MigrateZcashdWalletCmd {
             birthday_chain_state.as_ref(),
             recover_until,
             no_scan_birthday_estimate,
+            &block_heights,
         );
 
         // Persist all spending material in the keystore before any wallet-database
@@ -905,6 +906,7 @@ fn enriched_document(
     birthday_chain_state: Option<&zewif::ChainState>,
     recover_until: Option<BlockHeight>,
     no_scan_birthday_estimate: Option<BlockHeight>,
+    main_chain_block_heights: &HashMap<BlockHash, BlockHeight>,
 ) -> zewif::Zewif {
     let mut out = zewif::Zewif::new(
         document.export_height(),
@@ -970,10 +972,28 @@ fn enriched_document(
     // recorded only against a non-main-chain block (a conflicted or reorged
     // transaction). Importing them all here is what preserves that history.
     //
-    // The importer stores each transaction as unmined (it has no mined height to
-    // record); for one that was in fact mined, the scan later re-encounters it and
-    // fills in its true height and block.
-    out.set_transactions(document.transactions().clone());
+    // Record the main-chain mined height on each transaction whose block hash
+    // resolved to one. The importer stores a transaction without a mined height as
+    // unmined, and an unmined transaction can only be re-parsed later (to select
+    // its consensus branch ID) if it carries a non-zero expiry height; a mined
+    // transaction whose sender disabled expiry (`nExpiryHeight = 0`) would make
+    // the import fail. Transactions whose block hash did not resolve (never mined,
+    // or recorded against a non-main-chain block) are stored unmined; the scan
+    // fills in the height of any that later re-enter the main chain.
+    let mut transactions = document.transactions().clone();
+    for tx in transactions.values_mut() {
+        if tx.mined_height().is_some() {
+            continue;
+        }
+        let resolved_height = tx
+            .block_position()
+            .map(|position| BlockHash(*position.block_hash().as_bytes()))
+            .and_then(|hash| main_chain_block_heights.get(&hash));
+        if let Some(height) = resolved_height {
+            tx.set_mined_height(zewif::BlockHeight::from_u32(u32::from(*height)));
+        }
+    }
+    out.set_transactions(transactions);
 
     if let Some(store) = secret_store {
         out.set_secrets(zewif::Secrets::Plain(store));
@@ -1256,6 +1276,8 @@ impl From<ChainError> for MigrateError {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
+
     use incrementalmerkletree::{Position, frontier::Frontier};
     use orchard::tree::MerkleHashOrchard;
     use zcash_client_sqlite::{
@@ -1268,9 +1290,10 @@ mod tests {
     use zcash_protocol::consensus::{BlockHeight, NetworkType};
 
     use super::{
-        MigrateError, MigrateZcashdWalletCmd, ZCASHD_LEGACY_ACCOUNT_INDEX, ZCASHD_LEGACY_SOURCE,
-        check_import_report, derive_regtest_activations, describe_skipped_items, enriched_document,
-        has_seedless_legacy_account, mint_legacy_mnemonic, to_zewif_frontier,
+        BlockHash, MigrateError, MigrateZcashdWalletCmd, ZCASHD_LEGACY_ACCOUNT_INDEX,
+        ZCASHD_LEGACY_SOURCE, check_import_report, derive_regtest_activations,
+        describe_skipped_items, enriched_document, has_seedless_legacy_account,
+        mint_legacy_mnemonic, to_zewif_frontier,
     };
 
     fn node(byte: u8) -> MerkleHashOrchard {
@@ -1554,6 +1577,7 @@ mod tests {
             None,
             None,
             Some(BlockHeight::from_u32(1_900_000)),
+            &HashMap::new(),
         );
 
         let account = &enriched.wallets()[0].accounts()[0];
@@ -1588,6 +1612,7 @@ mod tests {
             Some(&chain_state),
             Some(BlockHeight::from_u32(2_000_000)),
             None,
+            &HashMap::new(),
         );
 
         let account = &enriched.wallets()[0].accounts()[0];
@@ -1609,6 +1634,50 @@ mod tests {
             Some(zewif::BlockHeight::from_u32(2_000_000))
         );
         assert_eq!(enriched.transactions().len(), 1);
+    }
+
+    #[test]
+    fn enrichment_records_resolved_mined_heights() {
+        let (mut document, _legacy_fp, mnemonic_fp) = test_document();
+
+        // A transaction recorded against a block that did not resolve to a
+        // main-chain height (conflicted or reorged).
+        let conflicted_txid = zewif::TxId::from_bytes([6u8; 32]);
+        let mut conflicted = zewif::Transaction::new(conflicted_txid);
+        conflicted.set_block_position(zewif::TxBlockPosition::new(
+            zewif::BlockHash::from_bytes([9u8; 32]),
+            0,
+        ));
+        document.add_transaction(conflicted_txid, conflicted);
+
+        // A never-mined transaction (no block position).
+        let unmined_txid = zewif::TxId::from_bytes([5u8; 32]);
+        document.add_transaction(unmined_txid, zewif::Transaction::new(unmined_txid));
+
+        // The mined transaction from `test_document` sits in block [7u8; 32].
+        let block_heights =
+            HashMap::from([(BlockHash([7u8; 32]), BlockHeight::from_u32(1_234_567))]);
+
+        let enriched = enriched_document(
+            &document,
+            None,
+            Some(&mnemonic_fp),
+            None,
+            None,
+            None,
+            &block_heights,
+        );
+
+        let mined_txid = zewif::TxId::from_bytes([4u8; 32]);
+        assert_eq!(
+            enriched.transactions()[&mined_txid].mined_height(),
+            Some(zewif::BlockHeight::from_u32(1_234_567))
+        );
+        assert_eq!(
+            enriched.transactions()[&conflicted_txid].mined_height(),
+            None
+        );
+        assert_eq!(enriched.transactions()[&unmined_txid].mined_height(), None);
     }
 
     /// A document as produced from a wallet with no HD seed material: the legacy
@@ -1699,8 +1768,15 @@ mod tests {
         let mut store = zewif::SecretStore::new();
         let minted_fp = mint_legacy_mnemonic(&mut store);
 
-        let enriched =
-            enriched_document(&document, Some(store), Some(&minted_fp), None, None, None);
+        let enriched = enriched_document(
+            &document,
+            Some(store),
+            Some(&minted_fp),
+            None,
+            None,
+            None,
+            &HashMap::new(),
+        );
 
         let accounts = enriched.wallets()[0].accounts();
         // The legacy account is anchored to the minted mnemonic.


### PR DESCRIPTION
Fixes #724 (COR-1744).

## The bug

`migrate-zcashd-wallet` on a mainnet wallet fails with:

```
Error: An error occurred importing the ZeWIF document into the wallet database:
'Wallet database error: Data DB is corrupted: Consensus branch ID not known,
cannot parse this transaction until it is mined'
```

This is distinct from the regtest failure fixed in #779, despite the identical error string.

The importer deliberately stores every migrated transaction as unmined, relying on the post-import scan to fill in heights. After storing each transaction, the import loop in `zcash_client_sqlite`'s zewif module reads it back via `get_transaction` to tally stored-vs-deferred. That read-back goes through `parse_tx`, which needs a height to select a consensus branch ID: mined height, else non-zero expiry height, else this error.

So any migrated wallet containing a transaction with `nExpiryHeight = 0` (senders may disable expiry — common for exchange withdrawals) deterministically aborts the migration. The failing transaction in #724 (`583ee401…2400`) is a mined mainnet v4 transaction with `expiryHeight = 0`.

## The fix

The migration already resolves each transaction's recorded block hash to a main-chain height in order to compute the wallet birthday. This PR stamps those resolved heights onto the enriched document's transactions, so mined transactions are stored mined (via `TransactionStatus::Mined`, the same path zewif-zcashd's Orchard-tree heights already exercise) and remain readable regardless of expiry height. Transactions whose block hash did not resolve — never mined, or recorded against a non-main-chain block — are still stored unmined, as before.

A genuinely-unmined transaction with `nExpiryHeight = 0` would still hit the same dead-end in `zcash_client_sqlite`; that residual case needs an upstream fix in the zewif import's read-back (issue to follow on zcash/librustzcash), but it is far rarer than the mined case that broke #724.

## Testing

- New unit test `enrichment_records_resolved_mined_heights` covering resolved, unresolved (conflicted), and never-mined transactions.
- All existing `migrate_zcashd_wallet` tests pass (`cargo test -p zallet-core --lib --features zcashd-import`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)