### PR TITLE
Add `createmultisig` and `addmultisigaddress`, and fix the `listaddresses` omission they depend on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,13 @@ be considered breaking changes.
   pre-Sapling wallet that has no HD seed. The minted seed never existed in
   zcashd, so backups of `wallet.dat` do not cover it; the migration prints a
   warning to that effect.
+- `createmultisig`, which builds an m-of-n multisignature redeem script and
+  reports its P2SH address. Each key may be given as a hex-encoded public key or
+  as a transparent address this wallet holds the public key for. A key given in
+  hex is placed in the script in the encoding it was given, so an address
+  created by `zcashd` from uncompressed keys can be reproduced exactly.
+  Note that Zallet cannot yet spend from a multisig address, as it has no way to
+  assemble a P2SH `scriptSig`; funds sent to one can be tracked but not moved.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,13 @@ be considered breaking changes.
   created by `zcashd` from uncompressed keys can be reproduced exactly.
   Note that Zallet cannot yet spend from a multisig address, as it has no way to
   assemble a P2SH `scriptSig`; funds sent to one can be tracked but not moved.
+- `addmultisigaddress`, which creates the same address and redeem script as
+  `createmultisig` and additionally records the script, so that the wallet
+  detects funds sent to the address. Its third argument is the UUID of the
+  account to track the address in, where `zcashd` took an account label; omitted,
+  it defaults to the legacy `zcashd` pool of funds, which requires
+  `features.legacy_pool_seed_fingerprint` to be set. Unlike `z_importaddress`
+  there is no `rescan` argument, as a newly created address has no history.
 
 ### Changed
 
@@ -304,12 +311,12 @@ be considered breaking changes.
   process’s, which cannot run concurrently with it in any case. The regtest
   account command is fixed the same way.
 - `listaddresses` now reports transparent addresses imported as a standalone
-  public key or redeem script, such as those imported by `z_importaddress`.
-  Previously such an address was not listed at all until funds arrived at it,
-  and was then listed among the account’s derived addresses. It is now reported
-  from the moment it is imported, in the `transparent` object rather than
-  `derived_transparent`, as it has no derivation information of its own even
-  when the account holding it does.
+  public key or redeem script, such as those created by `addmultisigaddress` or
+  imported by `z_importaddress`. Previously such an address was not listed at
+  all until funds arrived at it, and was then listed among the account’s derived
+  addresses. It is now reported from the moment it is imported, in the
+  `transparent` object rather than `derived_transparent`, as it has no
+  derivation information of its own even when the account holding it does.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,13 @@ be considered breaking changes.
   `walletpassphrase` unlocks a running server’s identities rather than this
   process’s, which cannot run concurrently with it in any case. The regtest
   account command is fixed the same way.
+- `listaddresses` now reports transparent addresses imported as a standalone
+  public key or redeem script, such as those imported by `z_importaddress`.
+  Previously such an address was not listed at all until funds arrived at it,
+  and was then listed among the account’s derived addresses. It is now reported
+  from the moment it is imported, in the `transparent` object rather than
+  `derived_transparent`, as it has no derivation information of its own even
+  when the account holding it does.
 
 ## [0.1.0-beta.2] - 2026-07-28
 

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -2,6 +2,31 @@
 edit. To regenerate after changing the rustdoc on the RPC traits, run:
 `ZALLET_BLESS=1 cargo test -p zallet-core --test book_rpc_reference` -->
 
+## `addmultisigaddress`
+
+*Only available in wallet builds of Zallet.*
+
+Creates a multisignature address and adds it to the wallet, so that funds sent
+to it are detected.
+
+The address and its redeem script are the same ones `createmultisig` reports for
+the same arguments; this additionally records the script. Retrieve the script
+with `createmultisig` if you did not keep it: it is required in order to spend,
+and cannot be recovered from the address.
+
+Note that Zallet cannot presently spend from a multisig address: it has no way
+to assemble a P2SH `scriptSig`. Funds sent to one are tracked but cannot be
+moved.
+
+#### Arguments
+- `nrequired` (numeric, required): The number of the supplied keys that must sign to spend.
+- `keys` (array, required): The keys the multisig address is composed of, each
+  either a hex-encoded public key or a transparent address this wallet holds the
+  public key for.
+- `account` (string, optional) The UUID of the account to track the address in.
+  Defaults to the legacy `zcashd` pool of funds, which requires
+  `features.legacy_pool_seed_fingerprint` to be set in the Zallet config file.
+
 ## `createmultisig`
 
 Creates a multisignature redeem script, and reports its P2SH address.

--- a/book/src/rpc/methods.md
+++ b/book/src/rpc/methods.md
@@ -2,6 +2,29 @@
 edit. To regenerate after changing the rustdoc on the RPC traits, run:
 `ZALLET_BLESS=1 cargo test -p zallet-core --test book_rpc_reference` -->
 
+## `createmultisig`
+
+Creates a multisignature redeem script, and reports its P2SH address.
+
+Nothing is recorded in the wallet; use `addmultisigaddress` to both create the
+script and have the wallet track its address.
+
+The returned `redeemScript` is required in order to spend funds sent to the
+address, and cannot be recovered from the address, which commits only to its
+hash. Record it.
+
+Note that Zallet cannot presently spend from a multisig address: it has no way
+to assemble a P2SH `scriptSig`. Funds sent to one can be tracked but not moved.
+
+Naming a key by transparent address requires the wallet that holds its public
+key, so a merchant-terminal build accepts hex-encoded public keys only.
+
+#### Arguments
+- `nrequired` (numeric, required): The number of the supplied keys that must sign to spend.
+- `keys` (array, required): The keys the multisig address is composed of, each
+  either a hex-encoded public key or a transparent address this wallet holds the
+  public key for.
+
 ## `decoderawtransaction`
 
 Return a JSON object representing the serialized, hex-encoded transaction.

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -20,7 +20,7 @@ Statuses:
 
 | `zcashd` method | Status | Notes |
 |---|---|---|
-| `addmultisigaddress` | Not yet implemented | Blocked on P2SH support in `zcash_client_sqlite` ([#48](https://github.com/zcash/zallet/issues/48), [librustzcash#1370](https://github.com/zcash/librustzcash/issues/1370)) |
+| `addmultisigaddress` | Implemented | Creates the address and tracks it, but Zallet cannot yet spend from a multisig address: it has no way to assemble a P2SH `scriptSig`. The `account` argument is a Zallet account UUID rather than a `zcashd` account label, and defaults to the legacy pool |
 | `backupwallet` | Not planned | Not planned as an RPC; may become a CLI command ([#49](https://github.com/zcash/zallet/issues/49)); robust backup is tracked in [#195](https://github.com/zcash/zallet/issues/195) |
 | `dumpprivkey` | Not planned | [#50](https://github.com/zcash/zallet/issues/50) |
 | `dumpwallet` | Not planned | Already removed from `zcashd` itself ([zcash#5513](https://github.com/zcash/zcash/issues/5513)); a [ZeWIF](https://github.com/zcash/zewif) export is planned instead ([#71](https://github.com/zcash/zallet/issues/71)) |

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -98,6 +98,7 @@ Zallet also provides methods that `zcashd`'s wallet did not have:
 
 Zallet additionally implements these methods that lived outside `zcashd`'s
 wallet category: `getrawtransaction` (with
-[altered semantics](json_rpc.md#getrawtransaction)), `decoderawtransaction`,
-`decodescript`, `validateaddress`, `verifymessage`, `help`, and `stop`, plus
-the wallet encryption methods `walletlock` and `walletpassphrase`.
+[altered semantics](json_rpc.md#getrawtransaction)), `createmultisig`,
+`decoderawtransaction`, `decodescript`, `validateaddress`, `verifymessage`,
+`help`, and `stop`, plus the wallet encryption methods `walletlock` and
+`walletpassphrase`.

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -36,6 +36,7 @@ use {
 const REGTEST_ONLY_METHODS: &[&str] = &["stop"];
 
 mod convert_tex;
+mod create_multisig;
 mod decode_raw_transaction;
 mod decode_script;
 #[cfg(zallet_build = "wallet")]
@@ -307,6 +308,29 @@ pub(crate) trait Rpc {
     /// - `transparent_address` (string, required): The transparent P2PKH address to convert.
     #[method(name = "z_converttex")]
     async fn convert_tex(&self, transparent_address: &str) -> convert_tex::Response;
+
+    /// Creates a multisignature redeem script, and reports its P2SH address.
+    ///
+    /// Nothing is recorded in the wallet; use `addmultisigaddress` to both create the
+    /// script and have the wallet track its address.
+    ///
+    /// The returned `redeemScript` is required in order to spend funds sent to the
+    /// address, and cannot be recovered from the address, which commits only to its
+    /// hash. Record it.
+    ///
+    /// Note that Zallet cannot presently spend from a multisig address: it has no way
+    /// to assemble a P2SH `scriptSig`. Funds sent to one can be tracked but not moved.
+    ///
+    /// Naming a key by transparent address requires the wallet that holds its public
+    /// key, so a merchant-terminal build accepts hex-encoded public keys only.
+    ///
+    /// # Arguments
+    /// - `nrequired` (numeric, required): The number of the supplied keys that must sign to spend.
+    /// - `keys` (array, required): The keys the multisig address is composed of, each
+    ///   either a hex-encoded public key or a transparent address this wallet holds the
+    ///   public key for.
+    #[method(name = "createmultisig")]
+    async fn create_multisig(&self, nrequired: u8, keys: Vec<String>) -> create_multisig::Response;
 
     /// Decodes a hex-encoded script.
     ///
@@ -1194,6 +1218,10 @@ impl<C: Chain> RpcServer for RpcImpl<C> {
 
     async fn convert_tex(&self, transparent_address: &str) -> convert_tex::Response {
         convert_tex::call(self.wallet().await?.params(), transparent_address)
+    }
+
+    async fn create_multisig(&self, nrequired: u8, keys: Vec<String>) -> create_multisig::Response {
+        create_multisig::call(self.wallet().await?.as_ref(), nrequired, &keys)
     }
 
     async fn decode_script(&self, hexstring: &str) -> decode_script::Response {

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -35,6 +35,8 @@ use {
 #[cfg(zallet_build = "wallet")]
 const REGTEST_ONLY_METHODS: &[&str] = &["stop"];
 
+#[cfg(zallet_build = "wallet")]
+mod add_multisig_address;
 mod convert_tex;
 mod create_multisig;
 mod decode_raw_transaction;
@@ -390,6 +392,34 @@ pub(crate) trait Rpc {
 #[cfg(zallet_build = "wallet")]
 #[rpc(server)]
 pub(crate) trait WalletRpc {
+    /// Creates a multisignature address and adds it to the wallet, so that funds sent
+    /// to it are detected.
+    ///
+    /// The address and its redeem script are the same ones `createmultisig` reports for
+    /// the same arguments; this additionally records the script. Retrieve the script
+    /// with `createmultisig` if you did not keep it: it is required in order to spend,
+    /// and cannot be recovered from the address.
+    ///
+    /// Note that Zallet cannot presently spend from a multisig address: it has no way
+    /// to assemble a P2SH `scriptSig`. Funds sent to one are tracked but cannot be
+    /// moved.
+    ///
+    /// # Arguments
+    /// - `nrequired` (numeric, required): The number of the supplied keys that must sign to spend.
+    /// - `keys` (array, required): The keys the multisig address is composed of, each
+    ///   either a hex-encoded public key or a transparent address this wallet holds the
+    ///   public key for.
+    /// - `account` (string, optional) The UUID of the account to track the address in.
+    ///   Defaults to the legacy `zcashd` pool of funds, which requires
+    ///   `features.legacy_pool_seed_fingerprint` to be set in the Zallet config file.
+    #[method(name = "addmultisigaddress")]
+    async fn add_multisig_address(
+        &self,
+        nrequired: u8,
+        keys: Vec<String>,
+        account: Option<&str>,
+    ) -> add_multisig_address::Response;
+
     /// List all commands, or get help for a specified command.
     ///
     /// Commands that are not available on the network this node is running on (such as
@@ -1250,6 +1280,15 @@ impl<C: Chain> WalletRpcServer for WalletRpcImpl<C> {
 
     fn openrpc(&self) -> openrpc::Response {
         openrpc::call()
+    }
+
+    async fn add_multisig_address(
+        &self,
+        nrequired: u8,
+        keys: Vec<String>,
+        account: Option<&str>,
+    ) -> add_multisig_address::Response {
+        add_multisig_address::call(self.wallet().await?.as_mut(), nrequired, &keys, account)
     }
 
     async fn list_operation_ids(&self, status: Option<&str>) -> list_operation_ids::Response {

--- a/zallet-core/src/components/json_rpc/methods/add_multisig_address.rs
+++ b/zallet-core/src/components/json_rpc/methods/add_multisig_address.rs
@@ -1,0 +1,79 @@
+//! `addmultisigaddress` — create an m-of-n multisig address and track it in the wallet.
+//!
+//! The script and address are exactly those `createmultisig` reports, because both
+//! come from the same [`build_multisig`]; the difference is that the redeem script is
+//! recorded against an account, so the wallet detects funds sent to the address.
+//!
+//! [`build_multisig`]: super::create_multisig::build_multisig
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use serde::Serialize;
+
+use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
+
+#[cfg(feature = "transparent-key-import")]
+use {
+    super::create_multisig::build_multisig,
+    crate::components::json_rpc::payments::get_legacy_pool_account,
+    zcash_client_backend::data_api::{Account as _, WalletWrite},
+    zcash_client_sqlite::AccountUuid,
+};
+
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// The P2SH address of the multisig redeem script, now tracked by the wallet.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+#[serde(transparent)]
+pub(crate) struct ResultType(String);
+
+pub(super) const PARAM_NREQUIRED_DESC: &str =
+    "The number of the supplied keys that must sign to spend.";
+pub(super) const PARAM_KEYS_DESC: &str = "The keys the multisig address is composed of, each either a hex-encoded public key \
+     or a transparent address this wallet holds the public key for.";
+pub(super) const PARAM_KEYS_REQUIRED: bool = true;
+pub(super) const PARAM_ACCOUNT_DESC: &str = "The UUID of the account to track the address in. Defaults to the legacy `zcashd` \
+     pool of funds, which requires `features.legacy_pool_seed_fingerprint` to be set in \
+     the Zallet config file.";
+
+/// Creates a multisig address and records its redeem script in the wallet.
+#[cfg(feature = "transparent-key-import")]
+pub(crate) fn call(
+    wallet: &mut DbConnection,
+    nrequired: u8,
+    keys: &[String],
+    account: Option<&str>,
+) -> Response {
+    // Everything that only reads the wallet happens before the write, so a bad
+    // argument is rejected without having recorded anything.
+    let multisig = build_multisig(wallet, nrequired, keys)?;
+
+    let account_id = match account {
+        Some(account) => account.parse().map(AccountUuid::from_uuid).map_err(|_| {
+            LegacyCode::InvalidParameter.with_message(format!("Invalid account UUID: {account}"))
+        })?,
+        // `zcashd` had one pool of transparent funds per wallet and put the address
+        // there. Zallet holds that pool in the legacy account, which the operator names
+        // via `features.legacy_pool_seed_fingerprint`; this reports an actionable error
+        // when they have not.
+        None => get_legacy_pool_account(wallet)?.id(),
+    };
+
+    wallet
+        .import_standalone_transparent_script(account_id, multisig.redeem)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
+
+    Ok(ResultType(multisig.address))
+}
+
+#[cfg(not(feature = "transparent-key-import"))]
+pub(crate) fn call(
+    _wallet: &mut DbConnection,
+    _nrequired: u8,
+    _keys: &[String],
+    _account: Option<&str>,
+) -> Response {
+    Err(LegacyCode::Misc
+        .with_static("addmultisigaddress requires the transparent-key-import feature"))
+}

--- a/zallet-core/src/components/json_rpc/methods/create_multisig.rs
+++ b/zallet-core/src/components/json_rpc/methods/create_multisig.rs
@@ -3,7 +3,7 @@
 //! This is the read-only half of the pair it forms with `addmultisigaddress`: it
 //! computes the script and address and returns them, without recording anything in
 //! the wallet. `zcashd` derived both from one helper, and so does Zallet — see
-//! [`build_multisig_redeem_script`], which `add_multisig_address` also uses.
+//! [`build_multisig`], which `add_multisig_address` also uses.
 
 use documented::Documented;
 use jsonrpsee::core::RpcResult;
@@ -73,9 +73,6 @@ const MAX_REDEEM_SCRIPT_SIZE: usize = 520;
 /// multisig, validating the arguments the way `zcashd` did, and returns it with its
 /// serialization.
 ///
-/// Shared with `addmultisigaddress`, which stores the result rather than only
-/// reporting it.
-///
 /// The serialization is returned rather than left to be derived again by each caller
 /// that needs it: the size limit, the address, and the hex `createmultisig` reports
 /// must all be the same bytes, and serializing afresh for each is another chance for
@@ -86,7 +83,7 @@ const MAX_REDEEM_SCRIPT_SIZE: usize = 520;
 /// naming an uncompressed key hashes to a different address than the same key
 /// compressed. Recreating a known multisig address requires reproducing that choice,
 /// so the caller's encoding is carried through rather than canonicalized here.
-pub(super) fn build_multisig_redeem_script(
+fn build_multisig_redeem_script(
     nrequired: u8,
     pubkeys: &[Vec<u8>],
 ) -> RpcResult<(Redeem, Vec<u8>)> {
@@ -159,7 +156,7 @@ fn check_reads_back_as_intended(
 }
 
 /// The P2SH address committing to a serialized redeem script.
-pub(super) fn p2sh_address(params: &Network, bytes: &[u8]) -> String {
+fn p2sh_address(params: &Network, bytes: &[u8]) -> String {
     TransparentAddress::ScriptHash(hash160::hash(bytes)).encode(params)
 }
 
@@ -276,17 +273,47 @@ fn resolve_address_pubkey(
     )))
 }
 
-/// Creates a multisig redeem script and reports its P2SH address.
-pub(crate) fn call(wallet: &DbConnection, nrequired: u8, keys: &[String]) -> Response {
+/// The multisig a `keys` argument describes.
+pub(super) struct Multisig {
+    /// The redeem script itself, to record in the wallet.
+    pub(super) redeem: Redeem,
+    /// Its serialization, to report in hex.
+    pub(super) bytes: Vec<u8>,
+    /// The P2SH address committing to it.
+    pub(super) address: String,
+}
+
+/// Resolves the `keys` argument and builds the multisig it describes.
+///
+/// This is the whole of `createmultisig`, and everything `addmultisigaddress` does
+/// before recording the script. Sharing it is what makes the two report the same
+/// address for the same arguments, rather than merely intend to.
+pub(super) fn build_multisig(
+    wallet: &DbConnection,
+    nrequired: u8,
+    keys: &[String],
+) -> RpcResult<Multisig> {
     let pubkeys = keys
         .iter()
         .map(|key| resolve_key(wallet, key))
         .collect::<RpcResult<Vec<_>>>()?;
-    let (_, bytes) = build_multisig_redeem_script(nrequired, &pubkeys)?;
+    let (redeem, bytes) = build_multisig_redeem_script(nrequired, &pubkeys)?;
+    let address = p2sh_address(wallet.params(), &bytes);
+
+    Ok(Multisig {
+        redeem,
+        bytes,
+        address,
+    })
+}
+
+/// Creates a multisig redeem script and reports its P2SH address.
+pub(crate) fn call(wallet: &DbConnection, nrequired: u8, keys: &[String]) -> Response {
+    let multisig = build_multisig(wallet, nrequired, keys)?;
 
     Ok(ResultType {
-        address: p2sh_address(wallet.params(), &bytes),
-        redeem_script: hex::encode(bytes),
+        address: multisig.address,
+        redeem_script: hex::encode(multisig.bytes),
     })
 }
 

--- a/zallet-core/src/components/json_rpc/methods/create_multisig.rs
+++ b/zallet-core/src/components/json_rpc/methods/create_multisig.rs
@@ -1,0 +1,448 @@
+//! `createmultisig` — build an m-of-n multisig redeem script and its P2SH address.
+//!
+//! This is the read-only half of the pair it forms with `addmultisigaddress`: it
+//! computes the script and address and returns them, without recording anything in
+//! the wallet. `zcashd` derived both from one helper, and so does Zallet — see
+//! [`build_multisig_redeem_script`], which `add_multisig_address` also uses.
+
+use documented::Documented;
+use jsonrpsee::core::RpcResult;
+use schemars::JsonSchema;
+use secp256k1::PublicKey;
+use serde::Serialize;
+use transparent::{address::TransparentAddress, util::hash160};
+use zcash_keys::encoding::AddressCodec;
+use zcash_script::{
+    pattern,
+    script::{Code, Component, Redeem},
+    solver::{self, ScriptKind},
+};
+
+use crate::{
+    components::{database::DbConnection, json_rpc::server::LegacyCode},
+    network::Network,
+};
+
+#[cfg(zallet_build = "wallet")]
+use {
+    crate::components::json_rpc::payments::get_account_for_address,
+    zcash_client_backend::{
+        data_api::{Account, WalletRead},
+        wallet::TransparentAddressSource,
+    },
+    zcash_keys::address::Address,
+};
+
+pub(crate) type Response = RpcResult<ResultType>;
+
+/// The multisig redeem script, and the P2SH address that commits to it.
+#[derive(Clone, Debug, Serialize, Documented, JsonSchema)]
+pub(crate) struct ResultType {
+    /// The P2SH address of the multisig redeem script.
+    address: String,
+
+    /// The hex-encoded multisig redeem script.
+    ///
+    /// This is required to spend any funds sent to `address`, and is not recoverable
+    /// from the address itself, which commits only to its hash. Record it.
+    #[serde(rename = "redeemScript")]
+    redeem_script: String,
+}
+
+pub(super) const PARAM_NREQUIRED_DESC: &str =
+    "The number of the supplied keys that must sign to spend.";
+pub(super) const PARAM_KEYS_DESC: &str = "The keys the multisig address is composed of, each either a hex-encoded public key \
+     or a transparent address this wallet holds the public key for.";
+pub(super) const PARAM_KEYS_REQUIRED: bool = true;
+
+/// The maximum number of keys a multisig script may name.
+///
+/// Both counts in the script are pushed as a single opcode in the `OP_1`..`OP_16`
+/// range, so 16 is the ceiling. `zcashd` enforced the same limit.
+const MAX_MULTISIG_KEYS: usize = 16;
+
+/// The maximum serialized size of a P2SH redeem script, in bytes.
+///
+/// A redeem script is supplied as a single stack element when the P2SH output is
+/// spent, so it is bounded by the interpreter's maximum push size. A script larger
+/// than this hashes to a perfectly good address that nothing can ever spend from,
+/// which is why the limit is checked here rather than left to the spender.
+const MAX_REDEEM_SCRIPT_SIZE: usize = 520;
+
+/// Builds the `OP_m <pubkey>… OP_n OP_CHECKMULTISIG` redeem script of an m-of-n
+/// multisig, validating the arguments the way `zcashd` did, and returns it with its
+/// serialization.
+///
+/// Shared with `addmultisigaddress`, which stores the result rather than only
+/// reporting it.
+///
+/// The serialization is returned rather than left to be derived again by each caller
+/// that needs it: the size limit, the address, and the hex `createmultisig` reports
+/// must all be the same bytes, and serializing afresh for each is another chance for
+/// them not to be.
+///
+/// `pubkeys` holds each key already serialized, because the encoding is part of what
+/// the address commits to: `zcashd` pushed a key exactly as it was given, so a script
+/// naming an uncompressed key hashes to a different address than the same key
+/// compressed. Recreating a known multisig address requires reproducing that choice,
+/// so the caller's encoding is carried through rather than canonicalized here.
+pub(super) fn build_multisig_redeem_script(
+    nrequired: u8,
+    pubkeys: &[Vec<u8>],
+) -> RpcResult<(Redeem, Vec<u8>)> {
+    if nrequired < 1 {
+        return Err(LegacyCode::InvalidParameter
+            .with_static("a multisignature address must require at least one key to redeem"));
+    }
+    if pubkeys.len() < usize::from(nrequired) {
+        return Err(LegacyCode::InvalidParameter.with_message(format!(
+            "not enough keys supplied (got {} keys, but need at least {nrequired} to redeem)",
+            pubkeys.len(),
+        )));
+    }
+    if pubkeys.len() > MAX_MULTISIG_KEYS {
+        return Err(LegacyCode::InvalidParameter.with_message(format!(
+            "number of keys involved in the multisignature address creation > {MAX_MULTISIG_KEYS}",
+        )));
+    }
+
+    // Both counts are in `1..=16` by the checks above, so `check_multisig` pushes each
+    // as a single `OP_1`..`OP_16`. It does not enforce either limit itself — its own
+    // errors cover only an unpushable key and a count too large for `i64` — so the
+    // checks above are what keep the result a standard multisig.
+    let keys: Vec<&[u8]> = pubkeys.iter().map(Vec::as_slice).collect();
+    let redeem: Redeem = Component(
+        pattern::check_multisig(nrequired, &keys, false)
+            .map_err(|e| LegacyCode::InvalidParameter.with_message(e.to_string()))?,
+    );
+
+    let bytes = Code::serialize(&redeem.0);
+    if bytes.len() > MAX_REDEEM_SCRIPT_SIZE {
+        return Err(LegacyCode::InvalidParameter.with_message(format!(
+            "redeemScript exceeds size limit: {} > {MAX_REDEEM_SCRIPT_SIZE}",
+            bytes.len(),
+        )));
+    }
+
+    check_reads_back_as_intended(&redeem, nrequired, pubkeys)?;
+
+    Ok((redeem, bytes))
+}
+
+/// Checks that `redeem` reads back as the multisig it was built to be: the same
+/// threshold, and the same keys in the same order, byte for byte.
+///
+/// This catches any drift between how we build a script and how the rest of the stack
+/// (`decodescript`, the solver, a spending wallet) interprets one. Comparing the keys
+/// and not merely counting them is what makes the check cover the encoding, which is
+/// the part of the script the address most easily disagrees about.
+fn check_reads_back_as_intended(
+    redeem: &Redeem,
+    nrequired: u8,
+    pubkeys: &[Vec<u8>],
+) -> RpcResult<()> {
+    match solver::standard(redeem) {
+        Some(ScriptKind::MultiSig {
+            required,
+            pubkeys: parsed,
+        }) if required == nrequired
+            && parsed.len() == pubkeys.len()
+            && parsed
+                .iter()
+                .zip(pubkeys)
+                .all(|(parsed, given)| parsed.as_slice() == given.as_slice()) =>
+        {
+            Ok(())
+        }
+        _ => Err(LegacyCode::Misc.with_static("constructed script is not a standard multisig")),
+    }
+}
+
+/// The P2SH address committing to a serialized redeem script.
+pub(super) fn p2sh_address(params: &Network, bytes: &[u8]) -> String {
+    TransparentAddress::ScriptHash(hash160::hash(bytes)).encode(params)
+}
+
+/// Resolves one entry of the `keys` argument to a public key.
+///
+/// An entry is either a hex-encoded public key, or a transparent address this wallet
+/// holds the public key for; `zcashd` accepted both.
+///
+/// The key is returned already serialized, in the encoding the script should name;
+/// see [`build_multisig_redeem_script`] for why that is preserved rather than
+/// normalized.
+fn resolve_key(wallet: &DbConnection, key: &str) -> RpcResult<Vec<u8>> {
+    // A hex-encoded public key needs no wallet at all. `from_slice` accepts both the
+    // compressed and uncompressed encodings, as `zcashd` did, and validates the point;
+    // the bytes are then used as given so the caller's encoding survives into the
+    // script.
+    if let Some(bytes) = hex::decode(key)
+        .ok()
+        .filter(|bytes| PublicKey::from_slice(bytes).is_ok())
+    {
+        return Ok(bytes);
+    }
+
+    let address = TransparentAddress::decode(wallet.params(), key).map_err(|_| {
+        LegacyCode::InvalidAddressOrKey
+            .with_message(format!("Invalid public key or transparent address: {key}"))
+    })?;
+
+    match address {
+        TransparentAddress::PublicKeyHash(_) => resolve_address_pubkey(wallet, &address),
+        // A P2SH address commits to a script, not to a key, so there is no public key
+        // to put in the multisig. (Nesting P2SH inside P2SH is not spendable anyway.)
+        TransparentAddress::ScriptHash(_) => Err(LegacyCode::InvalidAddressOrKey
+            .with_message(format!("{key} is a P2SH address, which has no public key"))),
+    }
+}
+
+/// The public key this wallet holds for a P2PKH address it knows.
+///
+/// Always the compressed encoding: a P2PKH address that Zallet derived or imported is
+/// the hash of the compressed key, and `secp256k1::PublicKey` does not retain the
+/// encoding it was parsed from. Name the key in hex to control that.
+#[cfg(zallet_build = "wallet")]
+fn resolve_address_pubkey(
+    wallet: &DbConnection,
+    address: &TransparentAddress,
+) -> RpcResult<Vec<u8>> {
+    let encoded = address.encode(wallet.params());
+
+    let account = get_account_for_address(wallet, &Address::Transparent(*address))?;
+    let metadata = wallet
+        .get_transparent_address_metadata(account.id(), address)
+        .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+        .ok_or_else(|| {
+            LegacyCode::InvalidAddressOrKey
+                .with_message(format!("No public key is known for address {encoded}"))
+        })?;
+
+    match metadata.source() {
+        // An imported key is stored as the public key itself. The standalone variants
+        // only exist under `transparent-key-import`; without it an address can only
+        // have been derived, and the match below is exhaustive without them.
+        #[cfg(feature = "transparent-key-import")]
+        TransparentAddressSource::StandalonePubkey(pubkey) => Ok(pubkey.serialize().to_vec()),
+
+        // An address imported on its own, with no key material behind it. The wallet
+        // watches it for incoming funds but holds nothing the address is the hash of,
+        // so there is no key to name in the script until that material is imported.
+        #[cfg(feature = "transparent-key-import")]
+        TransparentAddressSource::StandaloneAddress => Err(LegacyCode::InvalidAddressOrKey
+            .with_message(format!(
+                "{encoded} was imported as an address alone, so no public key is known for it"
+            ))),
+
+        // A derived receiver's public key is re-derived from the account's key rather
+        // than read from the address record, which is not integrity-protected.
+        TransparentAddressSource::Derived {
+            scope,
+            address_index,
+        } => account
+            .ufvk()
+            .and_then(|ufvk| ufvk.transparent())
+            .ok_or_else(|| {
+                LegacyCode::InvalidAddressOrKey.with_message(format!(
+                    "The account holding {encoded} has no transparent key",
+                ))
+            })?
+            .derive_address_pubkey(*scope, *address_index)
+            .map(|pubkey| pubkey.serialize().to_vec())
+            .map_err(|_| {
+                LegacyCode::InvalidAddressOrKey
+                    .with_message(format!("Could not derive the public key for {encoded}"))
+            }),
+
+        // Reached only for a P2SH address, which `resolve_key` rejects before here.
+        #[cfg(feature = "transparent-key-import")]
+        TransparentAddressSource::StandaloneScript(_) => Err(LegacyCode::InvalidAddressOrKey
+            .with_message(format!(
+                "{encoded} is a P2SH address, which has no public key"
+            ))),
+    }
+}
+
+/// Without a wallet there is nothing to resolve an address against, so this build
+/// accepts hex-encoded public keys only.
+#[cfg(not(zallet_build = "wallet"))]
+fn resolve_address_pubkey(
+    wallet: &DbConnection,
+    address: &TransparentAddress,
+) -> RpcResult<Vec<u8>> {
+    Err(LegacyCode::InvalidAddressOrKey.with_message(format!(
+        "{} cannot be resolved to a public key in this build; supply a hex-encoded public key",
+        address.encode(wallet.params()),
+    )))
+}
+
+/// Creates a multisig redeem script and reports its P2SH address.
+pub(crate) fn call(wallet: &DbConnection, nrequired: u8, keys: &[String]) -> Response {
+    let pubkeys = keys
+        .iter()
+        .map(|key| resolve_key(wallet, key))
+        .collect::<RpcResult<Vec<_>>>()?;
+    let (_, bytes) = build_multisig_redeem_script(nrequired, &pubkeys)?;
+
+    Ok(ResultType {
+        address: p2sh_address(wallet.params(), &bytes),
+        redeem_script: hex::encode(bytes),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use zcash_protocol::consensus;
+
+    fn mainnet() -> Network {
+        Network::Consensus(consensus::Network::MainNetwork)
+    }
+
+    // Compressed public key from zcashd qa/rpc-tests/decodescript.py:17
+    const COMPRESSED_PUBKEY: &str =
+        "03b0da749730dc9b4b1f4a14d6902877a92541f5368778853d9c4a0cb7802dcfb2";
+
+    fn pubkey() -> Vec<u8> {
+        hex::decode(COMPRESSED_PUBKEY).unwrap()
+    }
+
+    fn pubkeys(n: usize) -> Vec<Vec<u8>> {
+        vec![pubkey(); n]
+    }
+
+    /// `<len> <key>`: the direct push of a serialized public key, as a script names it.
+    ///
+    /// The length byte doubles as the opcode for any push of 1..=75 bytes, which covers
+    /// both key encodings, so it is taken from the key rather than written out.
+    fn push(key: &[u8]) -> String {
+        format!("{:02x}{}", key.len(), hex::encode(key))
+    }
+
+    /// The same key in its 65-byte uncompressed encoding.
+    fn uncompressed_pubkey() -> Vec<u8> {
+        PublicKey::from_slice(&pubkey())
+            .unwrap()
+            .serialize_uncompressed()
+            .to_vec()
+    }
+
+    /// The 2-of-3 script from zcashd qa/rpc-tests/decodescript.py:74-79:
+    /// `<m> <A pubkey> <B pubkey> <C pubkey> <n> OP_CHECKMULTISIG`.
+    #[test]
+    fn builds_the_zcashd_2_of_3_script() {
+        let (_, bytes) = build_multisig_redeem_script(2, &pubkeys(3)).unwrap();
+
+        let expected = format!("52{}53ae", push(&pubkey()).repeat(3));
+        assert_eq!(hex::encode(bytes), expected);
+    }
+
+    /// What we build must read back as what we meant, through the same solver
+    /// `decodescript` uses.
+    #[test]
+    fn round_trips_through_the_solver() {
+        let (_, bytes) = build_multisig_redeem_script(2, &pubkeys(3)).unwrap();
+
+        let parsed = Redeem::parse(&Code(bytes.clone())).unwrap();
+        match solver::standard(&parsed) {
+            Some(ScriptKind::MultiSig { required, pubkeys }) => {
+                assert_eq!(required, 2);
+                assert_eq!(pubkeys.len(), 3);
+                for parsed_pubkey in pubkeys {
+                    assert_eq!(parsed_pubkey.as_slice(), &pubkey()[..]);
+                }
+            }
+            // `ScriptKind` does not implement `Debug`, so report the script instead.
+            _ => panic!("expected a multisig script, got {}", hex::encode(&bytes)),
+        }
+    }
+
+    /// The address is the P2SH address of the script, which on mainnet is a `t3`.
+    #[test]
+    fn address_is_the_p2sh_of_the_script() {
+        let (_, bytes) = build_multisig_redeem_script(2, &pubkeys(3)).unwrap();
+
+        let expected = TransparentAddress::ScriptHash(hash160::hash(&bytes)).encode(&mainnet());
+        let address = p2sh_address(&mainnet(), &bytes);
+
+        assert_eq!(address, expected);
+        assert!(
+            address.starts_with("t3"),
+            "expected a mainnet P2SH address, got {address}"
+        );
+    }
+
+    /// The opcode range allows 16 keys, but the 520-byte redeem script limit binds
+    /// first: a compressed key costs 34 bytes to push, so 15 keys fit in 513 bytes and
+    /// 16 need 547. Fifteen is the real ceiling for a compressed-key multisig.
+    #[test]
+    fn fifteen_compressed_keys_fit_and_sixteen_do_not() {
+        assert!(build_multisig_redeem_script(15, &pubkeys(15)).is_ok());
+
+        let err = build_multisig_redeem_script(16, &pubkeys(16)).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+        assert!(
+            err.message().contains("exceeds size limit"),
+            "got: {}",
+            err.message(),
+        );
+    }
+
+    /// Past 16 the count is not pushable as a single opcode at all, which is a
+    /// different rejection from the size limit above.
+    #[test]
+    fn rejects_more_than_sixteen_keys() {
+        let err = build_multisig_redeem_script(1, &pubkeys(17)).unwrap_err();
+
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+        assert!(err.message().contains("> 16"), "got: {}", err.message());
+    }
+
+    /// A key is pushed in the encoding it was given, so an uncompressed one costs 66
+    /// bytes rather than 34 — which is what makes recreating a `zcashd` address that
+    /// names uncompressed keys possible, and what makes 8 of them too large.
+    #[test]
+    fn preserves_the_given_key_encoding() {
+        let (_, bytes) = build_multisig_redeem_script(1, &[uncompressed_pubkey()]).unwrap();
+
+        let expected = format!("51{}51ae", push(&uncompressed_pubkey()));
+        assert_eq!(hex::encode(bytes), expected);
+    }
+
+    #[test]
+    fn rejects_zero_required() {
+        let err = build_multisig_redeem_script(0, &pubkeys(3)).unwrap_err();
+
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+        assert_eq!(
+            err.message(),
+            "a multisignature address must require at least one key to redeem",
+        );
+    }
+
+    #[test]
+    fn rejects_more_required_than_supplied() {
+        let err = build_multisig_redeem_script(3, &pubkeys(2)).unwrap_err();
+
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+        assert_eq!(
+            err.message(),
+            "not enough keys supplied (got 2 keys, but need at least 3 to redeem)",
+        );
+    }
+
+    /// An uncompressed key costs 66 bytes to push, so 7 fit in 465 bytes and 8 need
+    /// 531 — over the limit, well below the 16-key ceiling.
+    #[test]
+    fn rejects_oversized_script() {
+        assert!(build_multisig_redeem_script(1, &vec![uncompressed_pubkey(); 7]).is_ok());
+
+        let err = build_multisig_redeem_script(1, &vec![uncompressed_pubkey(); 8]).unwrap_err();
+        assert_eq!(err.code(), LegacyCode::InvalidParameter as i32);
+        assert!(
+            err.message().contains("exceeds size limit"),
+            "got: {}",
+            err.message(),
+        );
+    }
+}

--- a/zallet-core/src/components/json_rpc/methods/list_addresses.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_addresses.rs
@@ -1,4 +1,7 @@
-use std::{collections::BTreeMap, mem};
+use std::{
+    collections::{BTreeMap, HashSet},
+    mem,
+};
 
 use documented::Documented;
 use jsonrpsee::{
@@ -161,32 +164,35 @@ struct TransparentBuckets {
 /// Splits an account's transparent addresses into the lists `listaddresses` reports.
 ///
 /// The wallet enumerates transparent addresses two ways and neither is complete on
-/// its own: `list_addresses` reports the account's derived and unified addresses but
-/// holds no record for a standalone imported redeem script, while
-/// `get_transparent_receivers` reports every receiver the account tracks, standalone
-/// imports included. Both are passed in, `listed` first so its ordering is preserved,
-/// and an address appearing in both is reported once.
+/// its own. `list_addresses` reports only addresses that have been exposed, and a
+/// standalone import never is, so it is missing from `listed` entirely.
+/// `get_transparent_receivers` applies no such filter and reports every receiver the
+/// account tracks, imports included.
 ///
-/// An unrecognized scope is a wallet-internal inconsistency rather than a caller
-/// error, so it is reported as such rather than silently dropped. Every address
-/// carrying one is reported, not merely the first: they are the evidence for
-/// whatever produced them, and which of them comes first says nothing about the
-/// inconsistency, only about the order the two enumerations happened to be read
-/// in. Phrasing them for a human is the caller's job, not this function's.
+/// `tracked` is therefore consulted only for what it alone can supply: an address with
+/// no derivation of its own. `listed` is taken first, and an address in both is
+/// reported once.
+///
+/// Every unrecognized scope is returned, and only from `listed`. Ordering the buckets
+/// and phrasing the error are the caller's job; the tests below carry the reasoning
+/// behind each of these choices.
 fn bucket_transparent(
     listed: Vec<TransparentReceiver>,
     tracked: Vec<TransparentReceiver>,
 ) -> Result<TransparentBuckets, NonEmpty<(String, TransparentKeyScope)>> {
-    // TODO: `tracked` is not consulted yet, which is why a standalone imported
-    // address is missing from the output. See the failing tests below.
-    let _ = tracked;
-
+    let mut seen = HashSet::new();
     let mut buckets = TransparentBuckets::default();
     let mut unrecognized = vec![];
-    for receiver in listed {
+    let tracked = tracked
+        .into_iter()
+        .filter(|receiver| receiver.scope.is_none());
+    for receiver in listed.into_iter().chain(tracked) {
+        if !seen.insert(receiver.address.clone()) {
+            continue;
+        }
         match receiver.scope {
-            // 'None' scope keys are imported, which must be treated as external
-            Some(TransparentKeyScope::EXTERNAL) | None => buckets.external.push(receiver.address),
+            Some(TransparentKeyScope::EXTERNAL) => buckets.external.push(receiver.address),
+            None => buckets.imported.push(receiver.address),
             Some(TransparentKeyScope::INTERNAL) => buckets.change.push(receiver.address),
             Some(TransparentKeyScope::EPHEMERAL) => buckets.ephemeral.push(receiver.address),
             Some(other) => unrecognized.push((receiver.address, other)),
@@ -493,25 +499,53 @@ mod tests {
         );
     }
 
-    /// The two enumerations overlap almost entirely, so an address in both must not
-    /// be reported twice.
+    /// The enumerations overlap once an import has been exposed — receiving funds is
+    /// enough — after which it is in both, and must not be reported twice.
     #[test]
     fn reports_an_address_in_both_enumerations_once() {
-        let buckets = bucket_transparent(
-            vec![derived("shared", TransparentKeyScope::EXTERNAL)],
-            vec![derived("shared", TransparentKeyScope::EXTERNAL)],
-        )
-        .unwrap();
+        let buckets =
+            bucket_transparent(vec![imported("shared")], vec![imported("shared")]).unwrap();
 
         assert_eq!(
             buckets,
             TransparentBuckets {
-                external: vec!["shared".into()],
+                external: vec![],
                 change: vec![],
                 ephemeral: vec![],
-                imported: vec![],
+                imported: vec!["shared".into()],
             },
         );
+    }
+
+    /// `tracked` holds derived receivers that `listed` does not: the transparent
+    /// receiver cached on each Unified Address, and the addresses generated ahead of
+    /// use to fill the gap limit, which are reported only once exposed. Neither is
+    /// what consulting `tracked` is for, and reporting them would put addresses the
+    /// wallet has never handed out into `derived_transparent`.
+    #[test]
+    fn ignores_a_derived_address_known_only_as_a_tracked_receiver() {
+        let buckets = bucket_transparent(
+            vec![],
+            vec![
+                derived("external", TransparentKeyScope::EXTERNAL),
+                derived("change", TransparentKeyScope::INTERNAL),
+            ],
+        )
+        .unwrap();
+
+        assert_eq!(buckets, TransparentBuckets::default());
+    }
+
+    /// An unrecognized scope fails the whole call, so which addresses are examined for
+    /// one decides which wallets `listaddresses` will refuse to answer for. Consulting
+    /// `tracked` must not widen that: an address dropped for having a derivation is
+    /// dropped before its scope is anyone's business.
+    #[test]
+    fn ignores_an_unrecognized_scope_from_the_tracked_receivers() {
+        let buckets =
+            bucket_transparent(vec![], vec![custom("custom", FIRST_CUSTOM_SCOPE)]).unwrap();
+
+        assert_eq!(buckets, TransparentBuckets::default());
     }
 
     /// A scope with no bucket is a wallet-internal inconsistency, and every address

--- a/zallet-core/src/components/json_rpc/methods/list_addresses.rs
+++ b/zallet-core/src/components/json_rpc/methods/list_addresses.rs
@@ -1,9 +1,12 @@
+use std::{collections::BTreeMap, mem};
+
 use documented::Documented;
 use jsonrpsee::{
     core::RpcResult,
     tracing::{error, warn},
-    types::ErrorCode as RpcErrorCode,
+    types::{ErrorCode as RpcErrorCode, ErrorObjectOwned},
 };
+use nonempty::NonEmpty;
 use schemars::JsonSchema;
 use serde::Serialize;
 use transparent::keys::TransparentKeyScope;
@@ -12,6 +15,7 @@ use zcash_client_backend::data_api::{
     Account as _, AccountPurpose, AccountSource, WalletRead, Zip32Derivation,
 };
 use zcash_keys::address::Address;
+use zcash_keys::encoding::AddressCodec;
 use zcash_protocol::consensus::NetworkConstants;
 
 use crate::components::{database::DbConnection, json_rpc::server::LegacyCode};
@@ -130,6 +134,70 @@ pub(crate) struct UnifiedAddress {
     address: String,
 }
 
+/// A transparent address of one account, with the key scope deciding which list it
+/// belongs in.
+///
+/// A `None` scope means the address was imported rather than derived — a standalone
+/// public key or redeem script — and so has no derivation information of its own.
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct TransparentReceiver {
+    address: String,
+    scope: Option<TransparentKeyScope>,
+}
+
+/// The lists `listaddresses` splits an account's transparent addresses into.
+///
+/// The first three are derived, and are reported together with the ZIP 32 derivation
+/// of the account they belong to. `imported` addresses have no derivation of their
+/// own and are reported apart from it.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TransparentBuckets {
+    external: Vec<String>,
+    change: Vec<String>,
+    ephemeral: Vec<String>,
+    imported: Vec<String>,
+}
+
+/// Splits an account's transparent addresses into the lists `listaddresses` reports.
+///
+/// The wallet enumerates transparent addresses two ways and neither is complete on
+/// its own: `list_addresses` reports the account's derived and unified addresses but
+/// holds no record for a standalone imported redeem script, while
+/// `get_transparent_receivers` reports every receiver the account tracks, standalone
+/// imports included. Both are passed in, `listed` first so its ordering is preserved,
+/// and an address appearing in both is reported once.
+///
+/// An unrecognized scope is a wallet-internal inconsistency rather than a caller
+/// error, so it is reported as such rather than silently dropped. Every address
+/// carrying one is reported, not merely the first: they are the evidence for
+/// whatever produced them, and which of them comes first says nothing about the
+/// inconsistency, only about the order the two enumerations happened to be read
+/// in. Phrasing them for a human is the caller's job, not this function's.
+fn bucket_transparent(
+    listed: Vec<TransparentReceiver>,
+    tracked: Vec<TransparentReceiver>,
+) -> Result<TransparentBuckets, NonEmpty<(String, TransparentKeyScope)>> {
+    // TODO: `tracked` is not consulted yet, which is why a standalone imported
+    // address is missing from the output. See the failing tests below.
+    let _ = tracked;
+
+    let mut buckets = TransparentBuckets::default();
+    let mut unrecognized = vec![];
+    for receiver in listed {
+        match receiver.scope {
+            // 'None' scope keys are imported, which must be treated as external
+            Some(TransparentKeyScope::EXTERNAL) | None => buckets.external.push(receiver.address),
+            Some(TransparentKeyScope::INTERNAL) => buckets.change.push(receiver.address),
+            Some(TransparentKeyScope::EPHEMERAL) => buckets.ephemeral.push(receiver.address),
+            Some(other) => unrecognized.push((receiver.address, other)),
+        }
+    }
+    match NonEmpty::from_vec(unrecognized) {
+        Some(unrecognized) => Err(unrecognized),
+        None => Ok(buckets),
+    }
+}
+
 pub(crate) fn call(wallet: &DbConnection) -> Response {
     let mut imported_watchonly = AddressSource::empty("imported_watchonly");
     let mut mnemonic_seed = AddressSource::empty("mnemonic_seed");
@@ -148,9 +216,7 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
             .list_addresses(account.id())
             .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?;
 
-        let mut transparent_addresses = vec![];
-        let mut transparent_change_addresses = vec![];
-        let mut transparent_ephemeral_addresses = vec![];
+        let mut listed_transparent = vec![];
         let mut sapling_addresses = vec![];
         let mut unified_addresses = vec![];
 
@@ -158,26 +224,10 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
             let addr = address_info.address();
             match addr {
                 Address::Transparent(_) | Address::Tex(_) => {
-                    match address_info.source().transparent_key_scope() {
-                        Some(&TransparentKeyScope::EXTERNAL) | None => {
-                            // 'None' scope keys are imported, which must be treated as external
-                            transparent_addresses.push(addr.encode(wallet.params()));
-                        }
-                        Some(&TransparentKeyScope::INTERNAL) => {
-                            transparent_change_addresses.push(addr.encode(wallet.params()));
-                        }
-                        Some(&TransparentKeyScope::EPHEMERAL) => {
-                            transparent_ephemeral_addresses.push(addr.encode(wallet.params()));
-                        }
-                        _ => {
-                            error!(
-                                "Unexpected {:?} for address {}",
-                                address_info.source().transparent_key_scope(),
-                                addr.encode(wallet.params()),
-                            );
-                            return Err(RpcErrorCode::InternalError.into());
-                        }
-                    }
+                    listed_transparent.push(TransparentReceiver {
+                        address: addr.encode(wallet.params()),
+                        scope: address_info.source().transparent_key_scope().copied(),
+                    });
                 }
                 Address::Sapling(_) => sapling_addresses.push(addr.encode(wallet.params())),
                 Address::Unified(addr) => {
@@ -216,15 +266,43 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
             }
         }
 
+        // Every transparent receiver the account tracks, which unlike `list_addresses`
+        // includes standalone imported public keys and redeem scripts. The wallet
+        // returns them in a `HashMap`, whose iteration order would vary between calls
+        // for no reason a caller could see, so they are taken in address order.
+        let tracked_transparent = wallet
+            .get_transparent_receivers(account.id(), true, true)
+            .map_err(|e| LegacyCode::Database.with_message(e.to_string()))?
+            .into_iter()
+            .collect::<BTreeMap<_, _>>()
+            .into_iter()
+            .map(|(addr, metadata)| TransparentReceiver {
+                address: addr.encode(wallet.params()),
+                scope: metadata.scope(),
+            })
+            .collect();
+
+        let mut buckets =
+            bucket_transparent(listed_transparent, tracked_transparent).map_err(|e| {
+                for (address, scope) in e {
+                    error!("Unexpected {scope:?} for address {address}");
+                }
+                ErrorObjectOwned::from(RpcErrorCode::InternalError)
+            })?;
+
         let add_addrs = |source: &mut AddressSource, derivation: Option<&Zip32Derivation>| {
             let seedfp = derivation
                 .as_ref()
                 .map(|d| d.seed_fingerprint().to_string());
             let account = derivation.as_ref().map(|d| d.account_index().into());
 
-            if !(transparent_addresses.is_empty()
-                && transparent_change_addresses.is_empty()
-                && transparent_ephemeral_addresses.is_empty())
+            // Addresses to report without any derivation information beside them.
+            let mut underived_addresses = vec![];
+            let mut underived_change_addresses = vec![];
+
+            if !(buckets.external.is_empty()
+                && buckets.change.is_empty()
+                && buckets.ephemeral.is_empty())
             {
                 if let Some((seedfp, account)) = seedfp.clone().zip(account) {
                     source
@@ -232,27 +310,38 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
                         .push(DerivedTransparentAddresses {
                             seedfp,
                             account,
-                            addresses: transparent_addresses,
-                            change_addresses: transparent_change_addresses,
-                            ephemeral_addresses: transparent_ephemeral_addresses,
+                            addresses: mem::take(&mut buckets.external),
+                            change_addresses: mem::take(&mut buckets.change),
+                            ephemeral_addresses: mem::take(&mut buckets.ephemeral),
                         });
                 } else {
-                    if !transparent_ephemeral_addresses.is_empty() {
+                    if !buckets.ephemeral.is_empty() {
                         warn!(
                             "Account {} has used transparent ephemeral addresses, but no derivation information",
                             account_id.expose_uuid(),
                         );
                     }
 
-                    let transparent = source.transparent.get_or_insert(TransparentAddresses {
-                        addresses: vec![],
-                        change_addresses: vec![],
-                    });
-                    transparent.addresses.append(&mut transparent_addresses);
-                    transparent
-                        .change_addresses
-                        .append(&mut transparent_change_addresses);
+                    underived_addresses.append(&mut buckets.external);
+                    underived_change_addresses.append(&mut buckets.change);
                 }
+            }
+
+            // A standalone import is reported here even when its account is derived.
+            // It is not reachable from the account's seed and ZIP 32 index, so listing
+            // it beside the addresses that are would misdescribe what restoring from
+            // that mnemonic recovers.
+            underived_addresses.append(&mut buckets.imported);
+
+            if !(underived_addresses.is_empty() && underived_change_addresses.is_empty()) {
+                let transparent = source.transparent.get_or_insert(TransparentAddresses {
+                    addresses: vec![],
+                    change_addresses: vec![],
+                });
+                transparent.addresses.append(&mut underived_addresses);
+                transparent
+                    .change_addresses
+                    .append(&mut underived_change_addresses);
             }
 
             if !sapling_addresses.is_empty() {
@@ -300,4 +389,154 @@ pub(crate) fn call(wallet: &DbConnection) -> Response {
         .flatten()
         .collect(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn derived(address: &str, scope: TransparentKeyScope) -> TransparentReceiver {
+        TransparentReceiver {
+            address: address.into(),
+            scope: Some(scope),
+        }
+    }
+
+    /// An imported address has no derivation, and so no key scope.
+    fn imported(address: &str) -> TransparentReceiver {
+        TransparentReceiver {
+            address: address.into(),
+            scope: None,
+        }
+    }
+
+    /// The two lowest custom key scopes. A [`TransparentKeyScope`] is any index
+    /// below 2^31, of which only the three standardized ones mean anything to
+    /// `listaddresses`, so these stand in for whatever else the wallet might
+    /// hand it.
+    const FIRST_CUSTOM_SCOPE: u32 = 3;
+    const SECOND_CUSTOM_SCOPE: u32 = 4;
+
+    fn custom_scope(scope: u32) -> TransparentKeyScope {
+        TransparentKeyScope::custom(scope).expect("custom scopes are below 2^31")
+    }
+
+    /// An address derived under a scope this function has no bucket for.
+    fn custom(address: &str, scope: u32) -> TransparentReceiver {
+        derived(address, custom_scope(scope))
+    }
+
+    #[test]
+    fn splits_derived_addresses_by_scope() {
+        let buckets = bucket_transparent(
+            vec![
+                derived("external", TransparentKeyScope::EXTERNAL),
+                derived("change", TransparentKeyScope::INTERNAL),
+                derived("ephemeral", TransparentKeyScope::EPHEMERAL),
+            ],
+            vec![],
+        )
+        .unwrap();
+
+        assert_eq!(
+            buckets,
+            TransparentBuckets {
+                external: vec!["external".into()],
+                change: vec!["change".into()],
+                ephemeral: vec!["ephemeral".into()],
+                imported: vec![],
+            },
+        );
+    }
+
+    /// A standalone import — a public key or a redeem script — has no `AddressInfo`
+    /// record, so it reaches us only through the tracked receivers. Dropping it is
+    /// what makes a P2SH address created by `addmultisigaddress` (or imported by
+    /// `z_importaddress`) invisible in `listaddresses`.
+    ///
+    /// It must land in `imported` rather than `external`: the caller reports the
+    /// derived lists beneath the account's seed fingerprint and ZIP 32 index, and an
+    /// import cannot be recovered from either.
+    #[test]
+    fn reports_an_address_known_only_as_a_tracked_receiver() {
+        let buckets = bucket_transparent(vec![], vec![imported("imported")]).unwrap();
+
+        assert_eq!(
+            buckets,
+            TransparentBuckets {
+                external: vec![],
+                change: vec![],
+                ephemeral: vec![],
+                imported: vec!["imported".into()],
+            },
+        );
+    }
+
+    /// An account can hold both, and the two must not be conflated: only the derived
+    /// address is reachable from the account's seed.
+    #[test]
+    fn keeps_an_imported_address_apart_from_the_derived_ones() {
+        let buckets = bucket_transparent(
+            vec![derived("derived", TransparentKeyScope::EXTERNAL)],
+            vec![imported("imported")],
+        )
+        .unwrap();
+
+        assert_eq!(
+            buckets,
+            TransparentBuckets {
+                external: vec!["derived".into()],
+                change: vec![],
+                ephemeral: vec![],
+                imported: vec!["imported".into()],
+            },
+        );
+    }
+
+    /// The two enumerations overlap almost entirely, so an address in both must not
+    /// be reported twice.
+    #[test]
+    fn reports_an_address_in_both_enumerations_once() {
+        let buckets = bucket_transparent(
+            vec![derived("shared", TransparentKeyScope::EXTERNAL)],
+            vec![derived("shared", TransparentKeyScope::EXTERNAL)],
+        )
+        .unwrap();
+
+        assert_eq!(
+            buckets,
+            TransparentBuckets {
+                external: vec!["shared".into()],
+                change: vec![],
+                ephemeral: vec![],
+                imported: vec![],
+            },
+        );
+    }
+
+    /// A scope with no bucket is a wallet-internal inconsistency, and every address
+    /// carrying one is evidence of it. Stopping at the first would report whichever
+    /// address the enumeration happened to reach first and leave the rest of the
+    /// evidence undiscovered until the operator looked again — hence the recognized
+    /// address between the two offenders, which a short-circuit would never reach.
+    #[test]
+    fn reports_every_unrecognized_scope() {
+        let unrecognized = bucket_transparent(
+            vec![
+                custom("first", FIRST_CUSTOM_SCOPE),
+                derived("external", TransparentKeyScope::EXTERNAL),
+                custom("second", SECOND_CUSTOM_SCOPE),
+            ],
+            vec![],
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            unrecognized,
+            NonEmpty::from((
+                ("first".into(), custom_scope(FIRST_CUSTOM_SCOPE)),
+                vec![("second".into(), custom_scope(SECOND_CUSTOM_SCOPE))],
+            )),
+        );
+    }
 }


### PR DESCRIPTION
Closes #91. Closes #48.

Adds `createmultisig` and `addmultisigaddress`, and first fixes the
`listaddresses` defect that would otherwise make the second of them useless.

### `listaddresses` (first two commits)

`listaddresses` built its transparent lists from `list_addresses` alone, which
reports only addresses that have been exposed. The row recording a standalone
import — a public key or a redeem script — is written without an exposure
height, so such an address was not listed at all until funds arrived at it, and
was then listed among the account's derived addresses, which it is not one of.

The bucketing is extracted into a `bucket_transparent` predicate so the decision
is testable without standing up a chain, and then merged with
`get_transparent_receivers`, whose `include_standalone` flag exists for exactly
this. Only its underived entries are taken: it applies no exposure filter at
all, so it also holds every derived receiver `list_addresses` withholds — the
transparent receiver cached on each Unified Address, and the addresses generated
ahead of use to fill the gap limit — and reporting those would put addresses the
wallet has never handed out into `derived_transparent`.

An import is reported in the `transparent` object rather than
`derived_transparent`, even when the account holding it is derived. Reporting it
as derived would state that it can be re-derived from that mnemonic, when only a
full `wallet.db` backup restores imported material.

The first commit is deliberately red: two of its five tests fail, representing
the defect, and the second commit clears them.

### `createmultisig` and `addmultisigaddress`

Both build the same m-of-n redeem script through one helper, as `zcashd` did
from `_createmultisig_redeemScript`; `addmultisigaddress` is that plus recording
the script against an account. The script comes from `zcash_script`'s
`pattern::check_multisig` and is read back through the same `solver::standard`
that `decodescript` uses, so what Zallet builds and what the rest of the stack
reads cannot drift apart.

A key may be given as a hex-encoded public key or as a transparent address the
wallet holds the public key for. A hex key is placed in the script in the
encoding it was given, so an address `zcashd` created from uncompressed keys can
be reproduced exactly.

Two departures from `zcashd`'s `addmultisigaddress` signature, both forced by
Zallet's account model: the third argument is an account UUID where `zcashd`
took an account label (omitted, it falls back to the legacy `zcashd` pool, which
requires `features.legacy_pool_seed_fingerprint`), and there is no `rescan`
argument, as a newly created address has no history.

### Known limitation

Zallet cannot yet spend from a multisig address: it has no way to assemble a
P2SH `scriptSig`. Funds sent to one are tracked but cannot be moved. The book
and CHANGELOG say so rather than implying the funds are usable.

### Testing

`cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets -- -D
warnings` under both default and `zcashd-import,rpc-cli,tokio-console`, and the
full test suite for all three workspaces under the CI feature set, all clean.
Each commit passes clippy individually; the first is red only in the two tests
its message names.

There is a companion integration test — `qa/rpc-tests/wallet_multisig.py`,
covering both methods end to end against a regtest stack — which is not yet
pushed.