### PR TITLE
rpc: actually reserve the `__cookie__` JSON-RPC username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,19 @@ be considered breaking changes.
 
 ### Fixed
 
+- The `__cookie__` JSON-RPC username is now actually reserved. It is documented
+  as belonging to the cookie credential that Zallet generates at startup, but a
+  `[[rpc.auth]]` entry could claim it: Zallet warned, skipped cookie generation,
+  and served that name with the configured password, so a configured credential
+  gained access under the username clients treat as the short-lived,
+  filesystem-permission-protected cookie. Zallet now refuses to start if a
+  `[[rpc.auth]]` user is named `__cookie__`, and always generates its cookie.
+  `zallet add-rpc-user __cookie__` is rejected for the same reason, instead of
+  printing a config block that would not start.
+
+  Anyone who relied on configuring `__cookie__` as an ordinary RPC user must
+  rename that `[[rpc.auth]]` entry before upgrading, and update the clients
+  using it.
 - `migrate-zcashd-wallet` now passes a fallback network to the wallet parser
   for regtest wallets. A pre-Sapling wallet (zcashd < 5.0.0) has no
   `networkinfo` record; without a fallback, parsing failed with "wallet has no

--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -410,6 +410,10 @@ as_of_version = "0.1.0-beta.2"
 #
 # Each username must be unique. If duplicates are present, only one of the passwords
 # will work.
+#
+# The username `__cookie__` is reserved for the cookie credential that Zallet
+# generates at startup, and cannot be configured here; Zallet will refuse to start
+# if it is.
 #user = UNSET
 
 # The password for this user.

--- a/book/src/cli/rpc.md
+++ b/book/src/cli/rpc.md
@@ -45,6 +45,11 @@ access.
 If `[[rpc.auth]]` users are configured in `zallet.toml`, `zallet rpc` will prefer
 those credentials over the cookie file. Cookie-based auth and configured users coexist.
 
+The username `__cookie__` is reserved for the cookie credential, so it cannot be used
+for a `[[rpc.auth]]` user. Zallet refuses to start if a configured user claims it,
+rather than letting a configured password grant access under the name that clients
+treat as the cookie credential.
+
 ## Comparison to `zcash-cli`
 
 The `zcashd` full node came bundled with a `zcash-cli` binary, which served an equivalent

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -50,6 +50,7 @@ flags-header = Options
 cmd-add-rpc-user-prompt = Enter password:
 rpc-cli-param-prompt = Enter parameter value:
 cmd-add-rpc-user-password-empty = Password must not be empty.
+cmd-add-rpc-user-reserved = The username '{$user}' is reserved for the cookie credential that {-zallet} generates at startup; choose a different username.
 cmd-add-rpc-user-instructions = Add this to your {-zallet_toml} file:
 cmd-seed-fingerprint = Seed fingerprint: {$seedfp}
 cmd-import-mnemonic-prompt = Enter mnemonic:
@@ -105,7 +106,6 @@ rpc-pwhash-auth-info = Using '{-cfg-rpc-auth-pwhash}' authorization
 
 rpc-cookie-generated = Generated RPC authentication cookie {$path}
 rpc-cookie-read-failed = Failed to read cookie file: {$error}
-rpc-cookie-user-conflict = Configured user conflicts with cookie auth username, skipping cookie generation
 
 ## zallet.toml example messages
 
@@ -199,6 +199,10 @@ err-init-identity-not-passphrase-encrypted = {$path} is not encrypted with a pas
 err-init-path-not-utf8 = {$path} is not currently supported (not UTF-8)
 err-init-identity-not-usable = Identity file at {$path} is not usable: {$error}
 err-init-rpc-auth-invalid = Invalid '{-cfg-rpc-auth}' configuration
+err-init-rpc-auth-cookie-user-reserved =
+    The '{-cfg-rpc-auth}' username '{$user}' is reserved for the cookie credential that
+    {-zallet} generates at startup. Remove that '{-cfg-rpc-auth}' entry, or choose a
+    different username for it.
 err-init-rpc-bind-not-loopback =
     Refusing to open the JSON-RPC endpoint on non-loopback address {$addr}: the RPC
     interface is served over plaintext HTTP, so RPC credentials and wallet

--- a/zallet-core/src/commands/add_rpc_user.rs
+++ b/zallet-core/src/commands/add_rpc_user.rs
@@ -4,13 +4,20 @@ use secrecy::{ExposeSecret, SecretString};
 use crate::{
     cli::AddRpcUserCmd,
     commands::AsyncRunnable,
-    components::json_rpc::server::authorization::PasswordHash,
+    components::json_rpc::server::{authorization::PasswordHash, cookie},
     error::{Error, ErrorKind},
     fl,
 };
 
 impl AsyncRunnable for AddRpcUserCmd {
     async fn run(&self) -> Result<(), Error> {
+        // Refuse to emit a config block that Zallet would reject at startup.
+        if self.username == cookie::COOKIE_USER {
+            return Err(ErrorKind::Generic
+                .context(fl!("cmd-add-rpc-user-reserved", user = cookie::COOKIE_USER))
+                .into());
+        }
+
         let password = SecretString::new(
             rpassword::prompt_password(fl!("cmd-add-rpc-user-prompt"))
                 .map_err(|e| ErrorKind::Generic.context(e))?,

--- a/zallet-core/src/components/json_rpc/server.rs
+++ b/zallet-core/src/components/json_rpc/server.rs
@@ -2,7 +2,7 @@
 
 use jsonrpsee::{
     server::{RpcServiceBuilder, Server},
-    tracing::{info, warn},
+    tracing::info,
 };
 use std::path::PathBuf;
 use tokio::task::JoinHandle;
@@ -71,14 +71,19 @@ pub(crate) async fn spawn<C: Chain>(
 
     let timeout = config.timeout();
 
-    let has_cookie_user = config.auth.iter().any(|a| a.user == cookie::COOKIE_USER);
-    let (cookie, _cookie_guard) = if has_cookie_user {
-        warn!("{}", fl!("rpc-cookie-user-conflict"));
-        (None, None)
-    } else {
-        let (user, hash, guard) = cookie::generate_cookie(&datadir)?;
-        (Some((user, hash)), Some(guard))
-    };
+    // The cookie username is reserved. Reject the config before writing a cookie file we
+    // would only have to tear down again.
+    if config.auth.iter().any(|a| a.user == cookie::COOKIE_USER) {
+        return Err(ErrorKind::Init
+            .context(fl!(
+                "err-init-rpc-auth-cookie-user-reserved",
+                user = cookie::COOKIE_USER
+            ))
+            .into());
+    }
+
+    let (cookie_user, cookie_hash, _cookie_guard) = cookie::generate_cookie(&datadir)?;
+    let cookie = Some((cookie_user, cookie_hash));
 
     let http_middleware = tower::ServiceBuilder::new()
         .layer(

--- a/zallet-core/src/components/json_rpc/server/authorization.rs
+++ b/zallet-core/src/components/json_rpc/server/authorization.rs
@@ -250,8 +250,6 @@ mod tests {
 
     use hyper::header::HeaderValue;
 
-    use tower::Layer;
-
     use super::{Authorization, AuthorizationLayer, PasswordHash};
     use crate::components::json_rpc::server::cookie;
 
@@ -286,7 +284,7 @@ mod tests {
         use crate::config::RpcAuthSection;
 
         let auth = vec![RpcAuthSection {
-            user: "__cookie__".to_string(),
+            user: "user1".to_string(),
             password: None,
             pwhash: Some(PasswordHash::from_bare("").to_string()),
         }];
@@ -355,21 +353,50 @@ mod tests {
         assert!(!auth.is_authorized(&header));
     }
 
+    /// The cookie username is reserved for the credential Zallet generates at startup. A
+    /// config that claims it must be rejected, not silently honoured: otherwise a
+    /// configured password grants access under the name that clients trust to be the
+    /// short-lived, filesystem-permission-protected cookie.
     #[test]
-    fn configured_cookie_user_works_without_generated_cookie() {
+    fn configured_cookie_user_is_rejected() {
         use crate::config::RpcAuthSection;
         use secrecy::SecretString;
 
-        let password = "mypassword";
         let auth = vec![RpcAuthSection {
             user: cookie::COOKIE_USER.to_string(),
-            password: Some(SecretString::new(password.to_string())),
+            password: Some(SecretString::new("mypassword".to_string())),
             pwhash: None,
         }];
-        let layer = AuthorizationLayer::new(auth, None).unwrap();
-        let auth = layer.layer(());
-        let header = basic_auth_header(cookie::COOKIE_USER, password);
-        assert!(auth.is_authorized(&header));
+        assert!(AuthorizationLayer::new(auth, None).is_err());
+
+        let auth = vec![RpcAuthSection {
+            user: cookie::COOKIE_USER.to_string(),
+            password: None,
+            pwhash: Some(PasswordHash::from_bare("mypassword").to_string()),
+        }];
+        assert!(AuthorizationLayer::new(auth, None).is_err());
+    }
+
+    /// The reserved username is rejected even alongside valid entries, so a config cannot
+    /// smuggle it in behind an otherwise-fine user list.
+    #[test]
+    fn configured_cookie_user_is_rejected_alongside_valid_users() {
+        use crate::config::RpcAuthSection;
+        use secrecy::SecretString;
+
+        let auth = vec![
+            RpcAuthSection {
+                user: "user1".to_string(),
+                password: Some(SecretString::new("abadpassword".to_string())),
+                pwhash: None,
+            },
+            RpcAuthSection {
+                user: cookie::COOKIE_USER.to_string(),
+                password: Some(SecretString::new("mypassword".to_string())),
+                pwhash: None,
+            },
+        ];
+        assert!(AuthorizationLayer::new(auth, None).is_err());
     }
 
     #[cfg(feature = "rpc-cli")]

--- a/zallet-core/src/components/json_rpc/server/authorization.rs
+++ b/zallet-core/src/components/json_rpc/server/authorization.rs
@@ -24,6 +24,7 @@ use sha2::{
 use tower::Service;
 use tracing::{info, warn};
 
+use super::cookie;
 use crate::{config::RpcAuthSection, fl};
 
 type SaltedPasswordHash = CtOutput<Hmac<Sha256>>;
@@ -161,23 +162,33 @@ impl AuthorizationLayer {
 
         let mut users: HashMap<String, PasswordHash> = auth
             .into_iter()
-            .map(|a| match (a.password, a.pwhash) {
-                // An empty password provides no authentication; treat it as an
-                // invalid config rather than an open RPC interface.
-                (Some(password), None) if !password.expose_secret().is_empty() => {
-                    using_bare_password = true;
-                    Ok((a.user, PasswordHash::from_bare(password.expose_secret())))
+            .map(|a| {
+                // The cookie username is reserved for the credential that Zallet
+                // generates at startup. Honouring a configured entry under that name
+                // would grant long-lived access via the username that clients treat as
+                // the short-lived, filesystem-protected cookie credential.
+                if a.user == cookie::COOKIE_USER {
+                    return Err(());
                 }
-                (None, Some(pwhash)) => {
-                    using_pwhash = true;
-                    let hash: PasswordHash = pwhash.parse()?;
-                    // Reject empty passwords.
-                    if hash.check("") {
-                        return Err(());
+
+                match (a.password, a.pwhash) {
+                    // An empty password provides no authentication; treat it as an
+                    // invalid config rather than an open RPC interface.
+                    (Some(password), None) if !password.expose_secret().is_empty() => {
+                        using_bare_password = true;
+                        Ok((a.user, PasswordHash::from_bare(password.expose_secret())))
                     }
-                    Ok((a.user, hash))
+                    (None, Some(pwhash)) => {
+                        using_pwhash = true;
+                        let hash: PasswordHash = pwhash.parse()?;
+                        // Reject empty passwords.
+                        if hash.check("") {
+                            return Err(());
+                        }
+                        Ok((a.user, hash))
+                    }
+                    _ => Err(()),
                 }
-                _ => Err(()),
             })
             .collect::<Result<_, _>>()?;
 

--- a/zallet-core/src/config.rs
+++ b/zallet-core/src/config.rs
@@ -853,6 +853,10 @@ pub struct RpcAuthSection {
     ///
     /// Each username must be unique. If duplicates are present, only one of the passwords
     /// will work.
+    ///
+    /// The username `__cookie__` is reserved for the cookie credential that Zallet
+    /// generates at startup, and cannot be configured here; Zallet will refuse to start
+    /// if it is.
     pub user: String,
 
     /// The password for this user.


### PR DESCRIPTION
Closes #664.

## The bug

`__cookie__` is documented as the username belonging to the cookie credential Zallet
generates at startup, but nothing enforced it. A `[[rpc.auth]]` entry could claim the
name: Zallet logged a warning (`rpc-cookie-user-conflict`), **skipped cookie generation
entirely**, and then served `__cookie__` with the configured password.

Two consequences:

- A long-lived credential configured in plain text in `zallet.toml` presented itself
  under the username that clients treat as the short-lived cookie credential — the one
  that exists only in a `0600` file for the lifetime of the process and is removed on
  shutdown.
- With no cookie file written at all, `zallet rpc`'s default local authentication
  silently stopped working for anyone not using the configured credentials.

## The fix

Zallet now refuses to start if a `[[rpc.auth]]` user is named `__cookie__`, and always
generates its cookie. The check lives in two places:

- In `spawn()`, before the cookie file is written, so the operator gets a specific error
  naming the reserved username and what to do about it.
- In `AuthorizationLayer::new()`, so no construction path can produce a layer that
  serves the reserved name. This is where the unit tests bite.

`zallet add-rpc-user __cookie__` is rejected on the same grounds, rather than printing a
config block that Zallet would then refuse to start with.

## Commits

Per CONTRIBUTING, the bug is demonstrated by a failing unit test in a commit preceding
the fix:

1. `test:` — adds `configured_cookie_user_is_rejected` and
   `configured_cookie_user_is_rejected_alongside_valid_users`, which fail at that commit.
   Also retargets `pwhash_of_empty_password_is_rejected` at an ordinary username, so it
   keeps testing empty-password rejection rather than the new rule.
2. `rpc:` — the fix. The pre-existing test asserting the old behavior
   (`configured_cookie_user_works_without_generated_cookie`) is what commit 1 inverts.

## Compatibility

This is a breaking config change, and is called out as such in `CHANGELOG.md`: anyone
who configured `__cookie__` as an ordinary RPC user must rename that entry and update
the clients using it before upgrading. That seems right for an `I-SECURITY` issue — the
alternative is continuing to serve the reserved name — but say the word if you'd prefer
a deprecation cycle.

Note that `migrate-zcash-conf` can still translate an `rpcauth=__cookie__:...` line from
a `zcash.conf` into a config that Zallet refuses to start with. I left that alone: the
startup error names the offending entry and says what to change. Happy to add a
migration-time warning if you'd rather catch it there.

## Testing

- `cargo test -p zallet-core --lib` — 362 passed.
- `cargo test --manifest-path backends/zebra/Cargo.toml` — 9 passed, including the
  `example_config` golden (updated for the new `user` doc comment).
- `cargo clippy --all-targets -- -D warnings` and the same for `backends/zebra` — clean.
- `cargo fmt --all --check` — clean.

Docs updated: `book/src/cli/rpc.md`, the `RpcAuthSection::user` rustdoc, and the
generated example config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)