### PR TITLE
book: document Zallet's threat model and recommend encrypting backups before upload COR-1648 COR-1649

### DIFF
--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -54,4 +54,5 @@
 
 # Security
 
+- [Threat model](security/threat-model.md)
 - [Supply Chain Security (SLSA)](slsa/slsa.md)

--- a/book/src/guide/backup.md
+++ b/book/src/guide/backup.md
@@ -46,6 +46,30 @@ passphrase-encrypted — the key material in every copy of `wallet.db` becomes
 permanently undecryptable. Store the identity file separately from `wallet.db`
 where practical, since together they grant full spending access.
 
+## Encrypting backups before upload
+
+`wallet.db` as a whole is not encrypted (see [Wallet encryption]). Transaction
+history and viewing keys are stored in the clear, so any copy of the file,
+even one held by a backup service you do not fully control, exposes your full
+transaction history. Encrypt the database before uploading it to any
+third-party storage:
+
+```bash
+age -r <recipient> wallet.db > wallet.db.age
+```
+
+[`rage`] works the same way (`rage -r <recipient> wallet.db > wallet.db.age`).
+The recipient is the age public key from your wallet's
+[encryption identity](../concepts/encryption.md), or any other age recipient
+you control.
+
+Do not bundle the identity file in the same encrypted archive as `wallet.db`.
+Together they grant full spending access; encrypting them together means
+whoever decrypts the archive can spend. Back them up to separate locations.
+
+[Wallet encryption]: ../concepts/encryption.md
+[`rage`]: https://github.com/str4d/rage
+
 ### Backing up a mnemonic
 
 A phrase that Zallet generated for you exists nowhere else until you write it

--- a/book/src/security/threat-model.md
+++ b/book/src/security/threat-model.md
@@ -1,0 +1,129 @@
+# Threat model
+
+Zallet is software that holds spending authority. The threats that matter are
+the ones that can redirect that authority, leak the secrets backing it, or
+coerce the wallet into accepting state the operator did not author. This page
+scopes what Zallet defends against, what it does not, and what it relies on the
+operator to do.
+
+## In scope
+
+### Secret key material confidentiality
+
+Spending keys, mnemonic phrases, and standalone Sapling and transparent keys
+are stored in `wallet.db` as [age] ciphertexts. Decrypting any of them
+requires the age identity file (and its passphrase, if set), which the
+operator stores separately from the database. See
+[Wallet encryption](../concepts/encryption.md).
+
+The identity file can itself be passphrase-encrypted. With a passphrase set,
+the keystore starts **locked**: operations that need spending keys fail with
+"Wallet is locked" until `walletpassphrase` supplies the passphrase, and
+`walletlock` re-locks it.
+
+### Per-read integrity of stored secrets
+
+When the wallet decrypts a stored secret, it recomputes the fingerprint or
+public key from the decrypted material and requires it to match the row key
+before using it. This catches ciphertext substitution and cached-change-address
+tampering of individual rows: an attacker who replaces a keystore ciphertext
+with an encryption of their own key material is detected at the point of use,
+because the recomputed fingerprint does not match the row that selected it.
+
+These per-read re-derive checks were landed in #643 and cover mnemonic seeds,
+standalone Sapling extended spending keys, standalone transparent secret keys,
+and seed-derived account UFVKs at spend time.
+
+### RPC channel hygiene
+
+The JSON-RPC interface is the primary control surface an attacker targets when
+the wallet is running. Zallet defends the channel itself:
+
+- **Method-name-only RPC logging.** The RPC middleware logs only the method
+  name and an `is_error` flag, never call parameters or response bodies, so
+  secrets passed to methods like `walletpassphrase` or `z_importkey` do not
+  appear in logs (#677).
+- **No secrets in argv or environment variables.** Sensitive parameters are
+  read from files or stdin via the `@PATH` convention (#722). The
+  `ZALLET_IDENTITY_PASSPHRASE` environment variable was removed because sibling
+  processes could read it (#677).
+- **Filesystem permissions.** The datadir is set to `0700` on lock, and
+  `wallet.db` is created with mode `0600` so journal, WAL, and sidecar files
+  inherit restrictive permissions (#677).
+- **Authentication required on every request.** A random cookie credential is
+  written to `{datadir}/.cookie` at startup, and password users can be
+  provisioned with `zallet add-rpc-user`. The cookie file grants full wallet
+  access and must be protected by datadir permissions. See
+  [Operating Zallet](../operations/README.md#securing-the-json-rpc-interface).
+- **Loopback binding by default.** The RPC server is disabled unless the config
+  sets `rpc.bind`. Non-loopback binding is discouraged; see the operations
+  guide for the secure remote-access pattern (SSH tunnel or VPN).
+
+### Supply chain integrity
+
+Every release artifact is produced on GitHub Actions with an auditable workflow
+identity, emits a [SLSA v1.0] Build L3 provenance statement, and is
+reproducible. See [Supply Chain Security (SLSA)](slsa.md).
+
+## Out of scope
+
+### Full filesystem compromise
+
+If an attacker can write arbitrary files in the datadir as the wallet user
+while Zallet is running, or between sessions, they can mutate `wallet.db`, the
+identity file, the config file, and any sidecar. Zallet cannot secure its own
+filesystem against its operator; that is the operating system's job. We assume
+the datadir lives on a host the operator controls, with filesystem permissions
+set as documented above.
+
+A sub-case worth naming: an attacker who obtains a copy of `wallet.db` (from a
+backup service, a DB dump, a misconfigured restore) and modifies it before it
+is restored. The per-read re-derive checks catch direct ciphertext-substitution
+attacks against individual secret rows, but an attacker who can rewrite the
+database has a wider surface than single-row swaps. The operator's defense is
+to treat any restored `wallet.db` as untrusted: verify its provenance, and rely
+on the identity file (which the attacker does not have) as the second factor
+that prevents spending.
+
+### Plaintext transaction history and viewing keys
+
+`wallet.db` as a whole is **not** encrypted. Spending key material inside it is
+encrypted to the age identity, but transaction history, addresses, and viewing
+keys are stored in the clear. Anyone who reads the file learns the wallet's
+full transaction history and viewing keys, though they cannot spend without the
+identity. This is a deliberate design choice documented in
+[Wallet encryption](../concepts/encryption.md): encrypting the whole database
+would conflict with the existing age-based scheme and would still leave the
+identity file as the single decryption secret. The operator's defense is
+filesystem permissions and encrypting backups before upload (see
+[Backup and restore](../guide/backup.md#encrypting-backups-before-upload)).
+
+### Backup confidentiality
+
+A `wallet.db` copy stored in a third-party backup service is outside Zallet's
+reach. The operator must encrypt it before upload. See
+[Encrypting backups before upload](../guide/backup.md#encrypting-backups-before-upload).
+
+### Side-channel and physical attacks
+
+Cold-boot attacks, DMA, a compromised hypervisor, and other physical or
+side-channel attacks against the host are out of scope. Any of these can
+recover keys from memory regardless of the wallet software in use.
+
+## What an attacker with a DB copy can and cannot do
+
+| Attacker capability | Requires identity file? | Caught by |
+|---|---|---|
+| Read transaction history and viewing keys | No | Nothing. This is the plaintext-DB trade-off. |
+| Attempt offline brute force of age ciphertexts | No (but needs the ciphertext) | Computationally infeasible if the identity passphrase is strong. |
+| Spend funds | **Yes** | The spending key is age-encrypted; the attacker cannot decrypt it without the identity file. |
+| Substitute a keystore ciphertext with their own key | No | Per-read re-derive check: the recomputed fingerprint does not match the row key. |
+| Substitute a cached transparent change address | No | Per-read re-derive check: change outputs are re-derived from the USK before broadcast. |
+| Forge a UFVK signature over a swapped UFVK | No | Computationally infeasible without the spending key (the signature is produced at import time by the USK). |
+| Append an age recipient to silently receive future ciphertexts | No | Not caught by per-read checks. The operator's defense is encrypting backups and verifying restored DB provenance. |
+
+[age]: https://age-encryption.org/
+[SLSA v1.0]: https://slsa.dev/spec/v1.0
+[#643]: https://github.com/zcash/zallet/pull/643
+[#677]: https://github.com/zcash/zallet/pull/677
+[#722]: https://github.com/zcash/zallet/pull/722


### PR DESCRIPTION
## Summary

Zallet's threat model was implicit, scattered across #642, #677, the encryption concept page, and the operations guide. This makes it explicit in one place and adds an explicit encrypt-before-upload recommendation to the backup guide.

## Changes

- **New page** `book/src/security/threat-model.md` — scopes what Zallet defends against and what it does not:
  - **In scope:** secret key material confidentiality (age encryption of the keystore), per-read integrity of stored secrets (re-derive checks from #643), RPC channel hygiene (#677 / #722), supply chain integrity (SLSA Build L3).
  - **Out of scope:** full filesystem compromise (can't secure the operator's own filesystem), plaintext transaction history and viewing keys in `wallet.db` (deliberate; operator defends with permissions and encrypted backups), backup confidentiality (operator's responsibility), side-channel and physical attacks.
  - A concrete table of what an attacker with a DB copy can and cannot do, including which defenses catch each attack.
- **Updated** `book/src/guide/backup.md` — new "Encrypting backups before upload" section with a concrete `age -r <recipient> wallet.db > wallet.db.age` one-liner and a note not to bundle the identity file in the same archive.
- **Updated** `book/src/SUMMARY.md` — threat model linked under `# Security`.

## Motivation

Two drivers:

1. The Least Authority audit (Linear COR-1648 / COR-1649) surfaced that the threat model was not written down. Pacu's 1.0.0 requirement includes a written threat model.
2. `wallet.db` as a whole is not encrypted. Transaction history and viewing keys are stored in the clear (documented in `concepts/encryption.md` but only implied in the backup guide). Operators using third-party backup services need an explicit instruction to encrypt before upload.

## No code changes

Documentation-only. No CHANGELOG entries per the AGENTS.md routing rules ("Documentation-only changes (book pages, rustdoc corrections) do not get entries").

`mdbook build` passes clean. The `mdbook test` failure in `slsa/slsa.md:412` is pre-existing (a non-Rust block marked as Rust) and unrelated to this PR.

## Related

- #642 — original security umbrella (items 1-3 in #643, item 4 deferred)
- #643 — per-read re-derive checks (referenced in the threat model)
- #677 — LA security hardening (referenced)
- #722 — Pacu follow-on to #677 (referenced)
- #732 / #733 — closed NOT_PLANNED; the signature direction from #733 is a prerequisite for future set-tampering detection work
- #195 — robust online backup (the encrypt-before-upload recommendation is complementary)