### PR TITLE
fix: resolve beta clippy 1.99.0 regressions

### DIFF
--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -1,3 +1,9 @@
+// The `#[rpc(server)]` proc macro from jsonrpsee emits `#[must_use]` on the
+// generated trait server methods, which already return `#[must_use]` types
+// (`RpcResult`). Clippy's `double_must_use` lint fires on this upstream macro
+// expansion; allow it module-wide until jsonrpsee ships a fix.
+#![allow(clippy::double_must_use)]
+
 use async_trait::async_trait;
 use jsonrpsee::{
     core::{JsonValue, RpcResult},

--- a/zallet-core/src/components/json_rpc/methods/z_send_many.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_send_many.rs
@@ -142,7 +142,7 @@ pub(crate) async fn call<C: Chain>(
             count = amounts.len(),
             limit = actions_limit,
             config = "-orchardactionlimit=N",
-            bound = format!("N >= %u"),
+            bound = "N >= %u".to_string(),
         )));
     }
 

--- a/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
+++ b/zallet-core/src/components/json_rpc/methods/z_shieldcoinbase.rs
@@ -253,7 +253,7 @@ pub(crate) async fn call<C: Chain>(
             kind = e.kind,
             limit = actions_limit,
             config = "-orchardactionlimit=N",
-            bound = format!("N >= %u"),
+            bound = "N >= %u".to_string(),
         ))
     })?;
 

--- a/zallet-core/src/components/json_rpc/payments.rs
+++ b/zallet-core/src/components/json_rpc/payments.rs
@@ -384,7 +384,7 @@ pub(super) fn propose_and_check(
             kind = e.kind,
             limit = actions_limit,
             config = "-orchardactionlimit=N",
-            bound = format!("N >= %u"),
+            bound = "N >= %u".to_string(),
         ))
     })?;
 

--- a/zallet-core/src/components/json_rpc/server/http_request_compatibility.rs
+++ b/zallet-core/src/components/json_rpc/server/http_request_compatibility.rs
@@ -112,9 +112,13 @@ impl<S> HttpRequestMiddleware<S> {
 
     /// Maps whatever JSON-RPC version the client is using to JSON-RPC 2.0.
     ///
-    /// Returns an error response to send back instead, if the request body could not
-    /// be buffered: `413 Payload Too Large` if it exceeds
+    /// Returns an error response to send back instead, if the request body could
+    /// not be buffered: `413 Payload Too Large` if it exceeds
     /// [`Self::MAX_REQUEST_BODY_SIZE`], or `400 Bad Request` if reading it failed.
+    // The `Err` variant is `jsonrpsee::server::HttpResponse` (an upstream type
+    // we cannot shrink); allow clippy's large-error lint rather than boxing it
+    // and paying a heap allocation on the error path.
+    #[allow(clippy::result_large_err)]
     async fn request_to_json_rpc_2(
         request: HttpRequest<HttpBody>,
     ) -> Result<(JsonRpcVersion, HttpRequest<HttpBody>), HttpResponse> {

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -938,7 +938,7 @@ async fn steady_state_iteration<C: Chain>(
             current_tip.hash()
         );
         lower_boundary
-            .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |current_boundary| {
+            .try_update(Ordering::SeqCst, Ordering::SeqCst, |current_boundary| {
                 Some(
                     update_boundary(
                         BlockHeight::from_u32(current_boundary),


### PR DESCRIPTION
Rust beta 1.99.0-beta.1 (2026-08-17) surfaced 47 preexisting clippy warnings in zallet-core. This PR clears all of them.

## Changes

- **clippy::useless_format** (3 sites): `format!("N >= %u")` → `"N >= %u".to_string()`. The `%u` is zcashd help syntax, not a Rust format specifier.
- **Atomic::fetch_update deprecation** (1 site, `sync.rs`): renamed to `try_update`. Signature unchanged.
- **clippy::double_must_use** (42 warnings): module-level `#![allow]` in `methods.rs`, scoped to the `#[rpc(server)]` jsonrpsee proc-macro expansion that emits redundant `#[must_use]` on already-`#[must_use]` `RpcResult` returns.
- **clippy::result_large_err** (1 site): targeted `#[allow]` on `request_to_json_rpc_2`, whose `Err` variant is the upstream `jsonrpsee::server::HttpResponse` type we cannot shrink without an error-path heap allocation.

No user-facing behaviour change; internal clippy hygiene only.

Co-Authored-By: Claude <noreply@anthropic.com>