### PR TITLE
deps: bump librustzcash to main for the zero-expiry read-back fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,14 @@ be considered breaking changes.
 - A regtest wallet's transactions mined under NU6.3 (Ironwood) no longer fail
   to import with "Consensus branch ID not known". Bumped `zewif-zcashd` to
   0.1.0-rc.5, which includes NU6.3 in the regtest activation schedule.
+- `migrate-zcashd-wallet` no longer aborts with "Consensus branch ID not known"
+  when the `zcashd` wallet contains an unmined transaction with a zero expiry
+  height, such as an imported coinbase transaction. The importer stores such a
+  transaction with neither a mined height nor a usable expiry height, and the
+  read-back it performs to tally the import then had no epoch from which to
+  select a consensus branch ID. Fixed upstream by bumping the librustzcash
+  wallet crates, which now fall back to the wallet's view of the chain tip
+  (zcash/librustzcash#2975).
 - Updated transitive dependencies flagged by `cargo audit`: `crossbeam-epoch`
   0.9.18 → 0.9.20 (RUSTSEC-2026-0204, invalid pointer dereference in
   `fmt::Pointer`), the yanked `num-bigint` 0.4.7 and `spin` 0.9.8 to their

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -248,7 +248,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1339,7 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1358,7 +1358,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2432,7 +2432,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2909,7 +2909,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3047,7 +3047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3137,8 +3137,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.3"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -3849,7 +3849,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4376,7 +4376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4521,7 +4521,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5380,7 +5380,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5869,8 +5869,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.24.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5922,8 +5922,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.22.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6030,8 +6030,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6051,8 +6051,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.30.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6103,8 +6103,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.10.5"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "corez",
  "document-features",
@@ -6142,7 +6142,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bip32",
  "bs58",
@@ -6320,8 +6320,8 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,8 +159,8 @@ schemerz-rusqlite = "0.370.0"
 shardtree = "0.7"
 time = "0.3"
 uuid = "1"
-zcash_client_backend = "=0.24.0-rc.7"
-zcash_client_sqlite = "=0.22.0-rc.7"
+zcash_client_backend = "=0.24.0"
+zcash_client_sqlite = "=0.22.0"
 zcash_note_encryption = "0.4"
 zip32 = "0.2"
 bip32 = "0.2"
@@ -178,22 +178,24 @@ tonic = "0.14"
 debug = "line-tables-only"
 
 [patch.crates-io]
-# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
-# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
-# which `zallet import-address` uses to track watch-only transparent addresses
-# imported without key material. The full in-repo dependency closure of the two
-# client crates is patched to the same rev so the whole cohort resolves from a
-# single source. Repoint at crates.io once the change lands in a release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+# TEMPORARY: pin the wallet-critical librustzcash crates to a `main` rev carrying
+# the fix for reading back a stored unmined transaction with a zero expiry height
+# (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
+# `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
+# imports from a zcashd wallet before any chain scan. The full in-repo dependency
+# closure of the two client crates is patched to the same rev so the whole cohort
+# resolves from a single source. Repoint at crates.io once the fix lands in a
+# release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1377,7 +1377,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1542,7 +1542,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2714,7 +2714,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2971,7 +2971,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3349,7 +3349,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3650,8 +3650,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.3"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4642,7 +4642,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4701,7 +4701,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5416,7 +5416,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6440,7 +6440,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7036,8 +7036,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.24.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7089,8 +7089,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.22.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7208,8 +7208,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -7229,8 +7229,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.30.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7260,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7281,8 +7281,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.10.5"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "corez",
  "document-features",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bip32",
  "bs58",
@@ -7773,8 +7773,8 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -34,7 +34,7 @@ transparent = { package = "zcash_transparent", version = "0.10.0" }
 zaino-common = "0.4"
 zaino-fetch = "0.4"
 zaino-state = "0.5"
-zcash_client_backend = "=0.24.0-rc.7"
+zcash_client_backend = "=0.24.0"
 zcash_keys = { version = "0.16.0", features = ["unstable"] }
 zcash_primitives = "0.30.0"
 zcash_protocol = "0.10.0"
@@ -76,25 +76,27 @@ tempfile = "3"
 # after rocksdb 0.24.0 and can return to crates.io with the next release.
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 
-# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
-# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
-# which `zallet import-address` uses to track watch-only transparent addresses
-# imported without key material. The full in-repo dependency closure of the two
-# client crates is patched to the same rev so the whole cohort resolves from a
-# single source. Repoint at crates.io once the change lands in a release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+# TEMPORARY: pin the wallet-critical librustzcash crates to a `main` rev carrying
+# the fix for reading back a stored unmined transaction with a zero expiry height
+# (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
+# `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
+# imports from a zcashd wallet before any chain scan. The full in-repo dependency
+# closure of the two client crates is patched to the same rev so the whole cohort
+# resolves from a single source. Repoint at crates.io once the fix lands in a
+# release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
 
 # TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
 # `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -243,7 +243,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -254,7 +254,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1284,7 +1284,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1449,7 +1449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
 ]
@@ -2619,7 +2619,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2832,7 +2832,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a1886916523694cd6ea3d175f03a1e5010699a2a4cc13696d83d7bea1d80638"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3194,7 +3194,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3363,7 +3363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3481,8 +3481,8 @@ dependencies = [
 
 [[package]]
 name = "pczt"
-version = "0.9.2"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.3"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -4420,7 +4420,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4990,7 +4990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5150,7 +5150,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6139,7 +6139,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6648,8 +6648,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_backend"
-version = "0.24.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.24.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6701,8 +6701,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_client_sqlite"
-version = "0.22.0-rc.7"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.22.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6820,8 +6820,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_pool_migration"
-version = "0.1.0-rc.6"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.1.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6841,8 +6841,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_primitives"
-version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.30.1"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6893,8 +6893,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_protocol"
-version = "0.10.4"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.10.5"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "corez",
  "document-features",
@@ -6932,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "bip32",
  "bs58",
@@ -7385,8 +7385,8 @@ dependencies = [
 
 [[package]]
 name = "zip321"
-version = "0.9.0-rc.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=375fc8e51acb2903777f3512bf92b28dc0ac42ef#375fc8e51acb2903777f3512bf92b28dc0ac42ef"
+version = "0.9.0"
+source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -43,7 +43,7 @@ jsonrpsee-http-client = { version = "0.24", default-features = false }
 tokio = { version = "1", features = ["net", "rt-multi-thread"] }
 tower = { version = "0.4", features = ["timeout"] }
 transparent = { package = "zcash_transparent", version = "0.10.0" }
-zcash_client_backend = "=0.24.0-rc.7"
+zcash_client_backend = "=0.24.0"
 zcash_primitives = "0.30.0"
 zcash_protocol = "0.10.0"
 zebra-chain = "11"
@@ -79,25 +79,27 @@ tokio-console = ["zallet-core/tokio-console"]
 # after rocksdb 0.24.0 and can return to crates.io with the next release.
 librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev = "0442de85de82234643b5ba0a8f66a13ecf31b17d" }
 
-# TEMPORARY: pin the wallet-critical librustzcash crates to the branch adding
-# `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941),
-# which `zallet import-address` uses to track watch-only transparent addresses
-# imported without key material. The full in-repo dependency closure of the two
-# client crates is patched to the same rev so the whole cohort resolves from a
-# single source. Repoint at crates.io once the change lands in a release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "375fc8e51acb2903777f3512bf92b28dc0ac42ef" }
+# TEMPORARY: pin the wallet-critical librustzcash crates to a `main` rev carrying
+# the fix for reading back a stored unmined transaction with a zero expiry height
+# (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
+# `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
+# imports from a zcashd wallet before any chain scan. The full in-repo dependency
+# closure of the two client crates is patched to the same rev so the whole cohort
+# resolves from a single source. Repoint at crates.io once the fix lands in a
+# release.
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',


### PR DESCRIPTION
Closes #795

Bumps the wallet-critical librustzcash crates from `375fc8e5` to current `main` (`1f6bb2072e7fcb142b0d90ff7b267a8699a84818`), to pick up the fix for [zcash/librustzcash#2975](https://github.com/zcash/librustzcash/issues/2975).

## What this fixes

`migrate-zcashd-wallet` aborts with `Consensus branch ID not known` when the `zcashd` wallet holds an **unmined** transaction with `nExpiryHeight = 0`, such as an imported coinbase transaction. The importer stores such a transaction with neither a mined height nor a usable expiry height, and the read-back it performs to tally the import then has no epoch from which to select a consensus branch ID, so `parse_tx` fails and the migration aborts.

#727 fixed the common case at the source by backfilling resolved main-chain mined heights; a genuinely unmined zero-expiry transaction still reproduces it. [zcash/librustzcash#2983](https://github.com/zcash/librustzcash/pull/2983) fixes that residual case upstream:

- `parse_tx` gained a `fallback_height` parameter, supplied by `chain_tip_height(conn)` from `get_transaction` and `get_txs_spending_transparent_outputs_of`. The consensus branch ID does not affect parsing (absent from the pre-v5 serialized form; v5 onward commit to their own), so it is now selected from that height. The error survives only when the chain tip is also unknown.
- `zewif::import_wallet` now establishes the chain view from the document when account import does not, so a pre-Sapling-birthday `zcashd` wallet is not left tip-less — which would otherwise have defeated the fallback for exactly this migration path.

## Why the patch block stays

The fix postdates the `zcash_client_sqlite` 0.22.0 release (cut 2026-08-18, two days before the merge) and sits in the crate's `[Unreleased]` section, so it is reached by moving the `[patch.crates-io]` rev forward rather than by dropping the patch.

The block's `TEMPORARY` comment is rewritten, because its stated reason had expired: `WalletWrite::import_standalone_transparent_address` (zcash/librustzcash#2941) landed via zcash/librustzcash#2944 *before* the 0.22.0 release, so it is in the published crates and no longer justifies a git pin on its own. The comment now names the reason that does still apply, so the next reader knows what has to land before the pin can go. Dropping the patch entirely is noted as follow-up in #795.

## Also

Version requirements move off release candidates now that both crates are published: `zcash_client_backend` `=0.24.0-rc.7` → `=0.24.0`, `zcash_client_sqlite` `=0.22.0-rc.7` → `=0.22.0`.

## Testing

- `utils/check-lockstep.sh` passes — 22 crates + 4 package versions consistent across all three lockfiles.
- `cargo check --workspace --all-targets` is clean in all three workspaces (root, `backends/zebra`, `backends/zaino`); none of the 63 upstream commits in the range broke an API Zallet uses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HejoFsphMwaw8EdqVa6U8J
