### PR TITLE
Release zallet version 0.1.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+## [0.1.0-beta.3] - 2026-08-24
+
 ### Added
 
 - `zallet import-address` CLI command for importing a transparent address as

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5752,7 +5752,7 @@ dependencies = [
 
 [[package]]
 name = "zallet"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "home",
  "toml 0.8.23",
@@ -5760,7 +5760,7 @@ dependencies = [
 
 [[package]]
 name = "zallet-core"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",

--- a/backends/zaino/CHANGELOG.md
+++ b/backends/zaino/CHANGELOG.md
@@ -20,6 +20,8 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+## [0.1.0-beta.3] - 2026-08-24
+
 ### Fixed
 
 - The chain view no longer substitutes an empty note commitment tree when the

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -6902,7 +6902,7 @@ dependencies = [
 
 [[package]]
 name = "zallet-core"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -6994,7 +6994,7 @@ dependencies = [
 
 [[package]]
 name = "zallet-zaino"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "abscissa_core",
  "futures",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zallet-zaino"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",

--- a/backends/zebra/CHANGELOG.md
+++ b/backends/zebra/CHANGELOG.md
@@ -20,6 +20,8 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+## [0.1.0-beta.3] - 2026-08-24
+
 ### Fixed
 
 - The chain view no longer substitutes an empty note commitment tree when

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -6511,7 +6511,7 @@ dependencies = [
 
 [[package]]
 name = "zallet-core"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "abscissa_core",
  "abscissa_tokio",
@@ -6603,7 +6603,7 @@ dependencies = [
 
 [[package]]
 name = "zallet-zebra"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 dependencies = [
  "abscissa_core",
  "age",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zallet-zebra"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 authors = [
     "Jack Grigg <jack@electriccoin.co>",
     "Kris Nuttycombe <kris@electriccoin.co>",

--- a/backends/zebra/tests/cmd/example_config.out/zallet.toml
+++ b/backends/zebra/tests/cmd/example_config.out/zallet.toml
@@ -174,7 +174,7 @@ network = "main"
 # features. If this version is not compatible with `zallet --version`, most Zallet
 # commands will error and print out information about how to upgrade your wallet,
 # along with any changes you need to make to your usage of Zallet.
-as_of_version = "0.1.0-beta.2"
+as_of_version = "0.1.0-beta.3"
 
 # Enable "legacy `zcashd` pool of funds" semantics for the given seed.
 #

--- a/backends/zebra/tests/cmd/migrate_zcash_conf_mainnet.toml
+++ b/backends/zebra/tests/cmd/migrate_zcash_conf_mainnet.toml
@@ -15,7 +15,7 @@ network = "main"
 [external]
 
 [features]
-as_of_version = "0.1.0-beta.2"
+as_of_version = "0.1.0-beta.3"
 
 [features.deprecated]
 

--- a/backends/zebra/tests/cmd/migrate_zcash_conf_regtest.toml
+++ b/backends/zebra/tests/cmd/migrate_zcash_conf_regtest.toml
@@ -23,7 +23,7 @@ regtest_nuparams = [
 [external]
 
 [features]
-as_of_version = "0.1.0-beta.2"
+as_of_version = "0.1.0-beta.3"
 
 [features.deprecated]
 

--- a/backends/zebra/tests/cmd/migrate_zcash_conf_testnet.toml
+++ b/backends/zebra/tests/cmd/migrate_zcash_conf_testnet.toml
@@ -15,7 +15,7 @@ network = "test"
 [external]
 
 [features]
-as_of_version = "0.1.0-beta.2"
+as_of_version = "0.1.0-beta.3"
 
 [features.deprecated]
 

--- a/book/src/cli/init-wallet-encryption.md
+++ b/book/src/cli/init-wallet-encryption.md
@@ -8,9 +8,9 @@ When run, Zallet will use the [age encryption] identity stored in a wallet's dat
 initialize the wallet's encryption keys. The encryption identity file name (or path) can
 be set with the `keystore.encryption_identity` [config option].
 
-> WARNING: As of the latest Zallet beta release (0.1.0-beta.3), `zallet` requires the
-> encryption identity file to already exist. You can generate a plain or
-> passphrase-encrypted identity with [`zallet generate-encryption-identity`].
+> WARNING: `zallet` requires the encryption identity file to already exist.
+> You can generate a plain or passphrase-encrypted identity with
+> [`zallet generate-encryption-identity`].
 
 ## Identity kinds
 

--- a/book/src/cli/init-wallet-encryption.md
+++ b/book/src/cli/init-wallet-encryption.md
@@ -8,7 +8,7 @@ When run, Zallet will use the [age encryption] identity stored in a wallet's dat
 initialize the wallet's encryption keys. The encryption identity file name (or path) can
 be set with the `keystore.encryption_identity` [config option].
 
-> WARNING: As of the latest Zallet beta release (0.1.0-beta.2), `zallet` requires the
+> WARNING: As of the latest Zallet beta release (0.1.0-beta.3), `zallet` requires the
 > encryption identity file to already exist. You can generate a plain or
 > passphrase-encrypted identity with [`zallet generate-encryption-identity`].
 

--- a/zallet-core/CHANGELOG.md
+++ b/zallet-core/CHANGELOG.md
@@ -21,6 +21,8 @@ should be considered breaking changes.
 
 ## [Unreleased]
 
+## [0.1.0-beta.3] - 2026-08-24
+
 ### Added
 
 - `ChainRuntime::run_import_address` (in wallet builds with the

--- a/zallet-core/Cargo.toml
+++ b/zallet-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zallet-core"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/zallet/Cargo.toml
+++ b/zallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zallet"
-version = "0.1.0-beta.2"
+version = "0.1.0-beta.3"
 authors.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Releases Zallet 0.1.0-beta.3. All 42 prerequisites tracked in dagny (zcash-ecosystem #270) are done with merged PRs. The release is unblocked and can be cut.

## What changed

See the four changelogs promoted under `## [0.1.0-beta.3] - 2026-08-24`:

- `CHANGELOG.md` — user-facing: `import-address` CLI, sync lock, `confirm-backup`, `repair check-witnesses`, `migrate-zcashd-wallet` improvements (regtest, partial import, pre-Sapling mnemonic), `keystore.require_backup`, `export-mnemonic --seedfp`, `getwalletstatus locked`, plus numerous bug fixes (note commitment tree corruption, deep reorg handling, bounded async operations, fallback network for regtest wallets, init-wallet-encryption canonicalization)
- `zallet-core/CHANGELOG.md` — Rust API: `ChainRuntime::run_import_address`, `TreePool`/`empty_tree_is_legitimate`, migrated to zcash_client_backend/sqlite 0.24.0-rc.7
- `backends/zebra/CHANGELOG.md` — treestate read failure handling
- `backends/zaino/CHANGELOG.md` — same treestate fix

## Version bump

Applied via `utils/bump-version.sh 0.1.0-beta.3 --date today`. No phase change (beta to beta). No new transitive dependencies (lockfile changes are version-only). `MIN_COMPATIBLE_ZALLET_VERSION` stays at `0.1.0-alpha.4` (no wallet DB format change; the new `mnemonic_backup_confirmation` migration is in the keystore, not the wallet DB).

## Process

Follows the procedure documented in #800 (RELEASE.md).

## Post-merge

Tag `v0.1.0-beta.3` at the release commit and push the tag to trigger `release.yml` (container build, binaries, debs, APT publish, GitHub Release).

Co-Authored-By: Claude <noreply@anthropic.com>