### PR TITLE
cli: improve RPC parameter parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,10 @@ be considered breaking changes.
 
 ### Changed
 
+- `zallet rpc` now accepts bare values for known string parameters, preserves
+  JSON-quoted strings, and validates known methods' positional argument counts
+  locally. Methods unknown to this Zallet binary retain JSON-only parameter
+  parsing without a local count check.
 - `zallet start` now completes chain-backend construction and consensus checks
   before opening or migrating the wallet database. If startup exits or is
   cancelled, tasks started by the backend, RPC server, or wallet sync engine

--- a/book/src/cli/rpc.md
+++ b/book/src/cli/rpc.md
@@ -70,28 +70,30 @@ below:
 | Hostname, domain, or IP address   | Only IP address                    |
 | `zcash-cli <method> [<param> ..]` | `zallet rpc <method> [<param> ..]` |
 
-For parameter parsing, `zallet rpc` is (as of the beta releases) both more and less
-flexible than `zcash-cli`:
+## Parameter parsing
 
-- It is more flexible because `zcash-cli` implements type-checking on method parameters,
-  which means that it cannot be used with Zallet JSON-RPC methods where the parameters
-  have [changed](../zcashd/json_rpc.md). `zallet rpc` currently lacks this, which means
-  that:
-    - `zallet rpc` will work against both `zcashd` and `zallet` processes, which can be
-      useful during the migration phase.
-    - As the alpha and beta phases of Zallet progress, we can easily make changes to RPC
-      methods as necessary.
+`zallet rpc` uses parameter metadata generated from the RPC traits in the local Zallet
+binary. For a method in that table, it validates the positional argument count locally
+before reading any indirect parameters. Known string positions accept either a bare value
+such as `string` or the backwards-compatible JSON-quoted shell argument `'"string"'`.
+A nullable string treats bare `null` as JSON null and `'"null"'` as the string `null`.
 
-- It is less flexible because parameters need to be valid JSON:
-  - Strings need to be quoted in order to parse as JSON strings.
-  - Parameters that contain strings need to be externally quoted.
+Known non-string positions still require valid JSON. Arrays and objects therefore need
+shell protection so their JSON syntax reaches Zallet unchanged. An `@PATH` parameter is
+read only after count validation and always produces a JSON string, regardless of the
+position's normal conversion.
+
+Methods absent from the local generated table retain JSON-only parameter parsing and have
+no local argument-count limit. This allows calls to remote-only methods, but it is not full
+compatibility with a divergent `zcashd` server: a same-named method always follows the
+local Zallet binary's parameter table.
 
 | `zcash-cli` parameter | `zallet rpc` parameter |
 |-----------------------|------------------------|
 | `null`                | `null`                 |
 | `true`                | `true`                 |
 | `42`                  | `42`                   |
-| `string`              | `'"string"'`           |
+| `string`              | `string` or `'"string"'` |
 | `[42]`                | `[42]`                 |
 | `["string"]`          | `'["string"]'`         |
 | `{"key": <value>}`    | `'{"key": <value>}'`   |

--- a/zallet-core/build.rs
+++ b/zallet-core/build.rs
@@ -50,6 +50,9 @@ fn main() -> Result<(), Box<dyn Error>> {
         Some(out_dir) => PathBuf::from(out_dir),
     };
 
+    #[cfg(feature = "rpc-cli")]
+    generate_rpc_cli_params(&out_dir)?;
+
     // `OUT_DIR` is "intentionally opaque as it is only intended for `rustc` interaction"
     // (https://github.com/rust-lang/cargo/issues/9858). Peek into the black box and use
     // it to figure out where the target directory is.
@@ -279,187 +282,315 @@ fn generate_rpc_book_reference(out_dir: &Path) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[cfg(not(zallet_build = "merchant_terminal"))]
-fn generate_rpc_openrpc(out_dir: &Path) -> Result<(), Box<dyn Error>> {
+#[cfg(any(not(zallet_build = "merchant_terminal"), feature = "rpc-cli"))]
+struct ParsedRpcMethod<'a> {
+    command: String,
+    module: String,
+    #[cfg_attr(zallet_build = "merchant_terminal", allow(dead_code))]
+    source: &'a syn::TraitItemFn,
+    params: Vec<ParsedRpcParameter>,
+}
+
+#[cfg(any(not(zallet_build = "merchant_terminal"), feature = "rpc-cli"))]
+struct ParsedRpcParameter {
+    name: String,
+    #[cfg_attr(zallet_build = "merchant_terminal", allow(dead_code))]
+    schema_ty: String,
+    required: Option<bool>,
+    #[cfg(feature = "rpc-cli")]
+    conversion: RpcCliConversion,
+}
+
+#[cfg(feature = "rpc-cli")]
+#[derive(Clone, Copy)]
+enum RpcCliConversion {
+    String,
+    NullableString,
+    Json,
+}
+
+#[cfg(any(not(zallet_build = "merchant_terminal"), feature = "rpc-cli"))]
+fn find_rpc_trait<'a>(methods_ast: &'a syn::File, name: &str) -> &'a syn::ItemTrait {
+    methods_ast
+        .items
+        .iter()
+        .find_map(|item| match item {
+            syn::Item::Trait(item_trait) if item_trait.ident == name => Some(item_trait),
+            _ => None,
+        })
+        .expect("present")
+}
+
+#[cfg(any(not(zallet_build = "merchant_terminal"), feature = "rpc-cli"))]
+fn parse_rpc_method(method: &syn::TraitItemFn) -> Option<ParsedRpcMethod<'_>> {
     use quote::ToTokens;
 
+    // Find methods via their `#[method(name = "command")]` attribute.
+    let mut command = None;
+    method
+        .attrs
+        .iter()
+        .find(|attr| attr.path().is_ident("method"))
+        .and_then(|attr| {
+            attr.parse_nested_meta(|meta| {
+                command = Some(meta.value()?.parse::<syn::LitStr>()?.value());
+                Ok(())
+            })
+            .ok()
+        });
+    let command = command?;
+
+    let module = match &method.sig.output {
+        syn::ReturnType::Type(_, ret) => match ret.as_ref() {
+            syn::Type::Path(type_path) => type_path.path.segments.first(),
+            _ => None,
+        },
+        _ => None,
+    }
+    .expect("required")
+    .ident
+    .to_string();
+
+    let params = method
+        .sig
+        .inputs
+        .iter()
+        .filter_map(|arg| match arg {
+            syn::FnArg::Receiver(_) => None,
+            syn::FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
+                syn::Pat::Ident(pat_ident) => {
+                    let name = pat_ident.ident.to_string();
+                    let rust_ty = pat_type.ty.as_ref();
+
+                    // If we can determine the parameter's optionality, do so.
+                    let (param_ty, required) = match rust_ty {
+                        syn::Type::Path(type_path) => {
+                            let is_standalone_ident = type_path.path.leading_colon.is_none()
+                                && type_path.path.segments.len() == 1;
+                            let first_segment = &type_path.path.segments[0];
+
+                            if first_segment.ident == "Option" && is_standalone_ident {
+                                // Strip the `Option<_>` for the schema and CLI types.
+                                let inner_ty = match &first_segment.arguments {
+                                    syn::PathArguments::AngleBracketed(args) => {
+                                        match args.args.first().expect("valid Option") {
+                                            syn::GenericArgument::Type(ty) => ty,
+                                            _ => panic!("Invalid Option"),
+                                        }
+                                    }
+                                    _ => panic!("Invalid Option"),
+                                };
+                                (inner_ty, Some(false))
+                            } else if first_segment.ident == "Vec" {
+                                // We don't know whether the vec may be empty.
+                                (rust_ty, None)
+                            } else {
+                                (rust_ty, Some(true))
+                            }
+                        }
+                        _ => (rust_ty, Some(true)),
+                    };
+
+                    let param_ty = param_ty.to_token_stream().to_string();
+                    let schema_ty = match param_ty.as_str() {
+                        "age :: secrecy :: SecretString" => "String".into(),
+                        _ => param_ty.clone(),
+                    };
+                    #[cfg(feature = "rpc-cli")]
+                    let optional = required == Some(false);
+                    #[cfg(feature = "rpc-cli")]
+                    let conversion = match (optional, param_ty.as_str()) {
+                        (false, "String" | "& str" | "age :: secrecy :: SecretString") => {
+                            RpcCliConversion::String
+                        }
+                        (true, "String" | "& str") => RpcCliConversion::NullableString,
+                        _ => RpcCliConversion::Json,
+                    };
+
+                    Some(ParsedRpcParameter {
+                        name,
+                        schema_ty,
+                        required,
+                        #[cfg(feature = "rpc-cli")]
+                        conversion,
+                    })
+                }
+                _ => None,
+            },
+        })
+        .collect();
+
+    Some(ParsedRpcMethod {
+        command,
+        module,
+        source: method,
+        params,
+    })
+}
+
+#[cfg(feature = "rpc-cli")]
+fn append_rpc_cli_methods(contents: &mut String, rpc_trait: &syn::ItemTrait) {
+    for method in rpc_trait.items.iter().filter_map(|item| match item {
+        syn::TraitItem::Fn(method) => parse_rpc_method(method),
+        _ => None,
+    }) {
+        let ParsedRpcMethod {
+            command,
+            module,
+            params,
+            ..
+        } = method;
+
+        contents.push_str(&format!("    {command:?} => Method::new(&[\n"));
+        for parameter in params {
+            let ParsedRpcParameter {
+                name,
+                required,
+                conversion,
+                ..
+            } = parameter;
+            let param_upper = name.to_uppercase();
+
+            contents.push_str(&format!("        Parameter::new({name:?}, "));
+            match required {
+                Some(required) => contents.push_str(&required.to_string()),
+                None => {
+                    contents.push_str("super::");
+                    contents.push_str(&module);
+                    contents.push_str("::PARAM_");
+                    contents.push_str(&param_upper);
+                    contents.push_str("_REQUIRED");
+                }
+            }
+            contents.push_str(", Conversion::");
+            contents.push_str(match conversion {
+                RpcCliConversion::String => "String",
+                RpcCliConversion::NullableString => "NullableString",
+                RpcCliConversion::Json => "Json",
+            });
+            contents.push_str("),\n");
+        }
+        contents.push_str("    ]),\n");
+    }
+}
+
+#[cfg(feature = "rpc-cli")]
+fn generate_rpc_cli_params(out_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let methods_rs = fs::read_to_string(JSON_RPC_METHODS_RS)?;
+    let methods_ast = syn::parse_file(&methods_rs)?;
+
+    let mut contents =
+        String::from("static METHODS: ::phf::Map<&str, Method> = ::phf::phf_map! {\n");
+    append_rpc_cli_methods(&mut contents, find_rpc_trait(&methods_ast, "Rpc"));
+    #[cfg(not(zallet_build = "merchant_terminal"))]
+    append_rpc_cli_methods(&mut contents, find_rpc_trait(&methods_ast, "WalletRpc"));
+    contents.push_str("};\n");
+
+    fs::write(out_dir.join("rpc_cli_params.rs"), contents)?;
+
+    Ok(())
+}
+
+#[cfg(not(zallet_build = "merchant_terminal"))]
+fn generate_rpc_openrpc(out_dir: &Path) -> Result<(), Box<dyn Error>> {
     // Parse the source file containing the `Rpc` trait.
     let methods_rs = fs::read_to_string(JSON_RPC_METHODS_RS)?;
     let methods_ast = syn::parse_file(&methods_rs)?;
 
-    let rpc_trait = methods_ast
-        .items
-        .iter()
-        .find_map(|item| match item {
-            syn::Item::Trait(item_trait) if item_trait.ident == "Rpc" => Some(item_trait),
-            _ => None,
-        })
-        .expect("present");
-    let wallet_rpc_trait = methods_ast
-        .items
-        .iter()
-        .find_map(|item| match item {
-            syn::Item::Trait(item_trait) if item_trait.ident == "WalletRpc" => Some(item_trait),
-            _ => None,
-        })
-        .expect("present");
+    let rpc_trait = find_rpc_trait(&methods_ast, "Rpc");
+    let wallet_rpc_trait = find_rpc_trait(&methods_ast, "WalletRpc");
 
     let mut contents = "#[allow(unused_qualifications)]
 pub(super) static METHODS: ::phf::Map<&str, RpcMethod> = ::phf::phf_map! {
 "
     .to_string();
 
-    for item in rpc_trait.items.iter().chain(&wallet_rpc_trait.items) {
-        if let syn::TraitItem::Fn(method) = item {
-            // Find methods via their `#[method(name = "command")]` attribute.
-            let mut command = None;
-            method
-                .attrs
-                .iter()
-                .find(|attr| attr.path().is_ident("method"))
-                .and_then(|attr| {
-                    attr.parse_nested_meta(|meta| {
-                        command = Some(meta.value()?.parse::<syn::LitStr>()?.value());
-                        Ok(())
-                    })
-                    .ok()
-                });
+    for method in rpc_trait
+        .items
+        .iter()
+        .chain(&wallet_rpc_trait.items)
+        .filter_map(|item| match item {
+            syn::TraitItem::Fn(method) => parse_rpc_method(method),
+            _ => None,
+        })
+    {
+        let ParsedRpcMethod {
+            command,
+            module,
+            source,
+            params,
+        } = method;
+        contents.push('"');
+        contents.push_str(&command);
+        contents.push_str("\" => RpcMethod {\n");
 
-            if let Some(command) = command {
-                let module = match &method.sig.output {
-                    syn::ReturnType::Type(_, ret) => match ret.as_ref() {
-                        syn::Type::Path(type_path) => type_path.path.segments.first(),
-                        _ => None,
-                    },
-                    _ => None,
-                }
-                .expect("required")
-                .ident
-                .to_string();
+        contents.push_str("    description: \"");
+        for attr in source
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("doc"))
+        {
+            if let syn::Meta::NameValue(doc_line) = &attr.meta
+                && let syn::Expr::Lit(docs) = &doc_line.value
+                && let syn::Lit::Str(s) = &docs.lit
+            {
+                // Trim the leading space from the doc comment line.
+                let line = s.value();
+                let trimmed_line = if line.is_empty() { &line } else { &line[1..] };
 
-                let params = method.sig.inputs.iter().filter_map(|arg| match arg {
-                    syn::FnArg::Receiver(_) => None,
-                    syn::FnArg::Typed(pat_type) => match pat_type.pat.as_ref() {
-                        syn::Pat::Ident(pat_ident) => {
-                            let parameter = pat_ident.ident.to_string();
-                            let rust_ty = pat_type.ty.as_ref();
+                let escaped = trimmed_line.escape_default().collect::<String>();
 
-                            // If we can determine the parameter's optionality, do so.
-                            let (param_ty, required) = match rust_ty {
-                                syn::Type::Path(type_path) => {
-                                    let is_standalone_ident =
-                                        type_path.path.leading_colon.is_none()
-                                            && type_path.path.segments.len() == 1;
-                                    let first_segment = &type_path.path.segments[0];
+                contents.push_str(&escaped);
+                contents.push_str("\\n");
+            }
+        }
+        contents.push_str("\",\n");
 
-                                    if first_segment.ident == "Option" && is_standalone_ident {
-                                        // Strip the `Option<_>` for the schema type.
-                                        let schema_ty = match &first_segment.arguments {
-                                            syn::PathArguments::AngleBracketed(args) => {
-                                                match args.args.first().expect("valid Option") {
-                                                    syn::GenericArgument::Type(ty) => ty,
-                                                    _ => panic!("Invalid Option"),
-                                                }
-                                            }
-                                            _ => panic!("Invalid Option"),
-                                        };
-                                        (schema_ty, Some(false))
-                                    } else if first_segment.ident == "Vec" {
-                                        // We don't know whether the vec may be empty.
-                                        (rust_ty, None)
-                                    } else {
-                                        (rust_ty, Some(true))
-                                    }
-                                }
-                                _ => (rust_ty, Some(true)),
-                            };
+        contents.push_str("    params: |_g| vec![\n");
+        for parameter in params {
+            let param_upper = parameter.name.to_uppercase();
 
-                            // Handle a few conversions we know we need.
-                            let param_ty = param_ty.to_token_stream().to_string();
-                            let schema_ty = match param_ty.as_str() {
-                                "age :: secrecy :: SecretString" => "String".into(),
-                                _ => param_ty,
-                            };
-
-                            Some((parameter, schema_ty, required))
-                        }
-                        _ => None,
-                    },
-                });
-
-                contents.push('"');
-                contents.push_str(&command);
-                contents.push_str("\" => RpcMethod {\n");
-
-                contents.push_str("    description: \"");
-                for attr in method
-                    .attrs
-                    .iter()
-                    .filter(|attr| attr.path().is_ident("doc"))
-                {
-                    if let syn::Meta::NameValue(doc_line) = &attr.meta
-                        && let syn::Expr::Lit(docs) = &doc_line.value
-                        && let syn::Lit::Str(s) = &docs.lit
-                    {
-                        // Trim the leading space from the doc comment line.
-                        let line = s.value();
-                        let trimmed_line = if line.is_empty() { &line } else { &line[1..] };
-
-                        let escaped = trimmed_line.escape_default().collect::<String>();
-
-                        contents.push_str(&escaped);
-                        contents.push_str("\\n");
-                    }
-                }
-                contents.push_str("\",\n");
-
-                contents.push_str("    params: |_g| vec![\n");
-                for (parameter, schema_ty, required) in params {
-                    let param_upper = parameter.to_uppercase();
-
-                    contents.push_str("        _g.param::<");
-                    contents.push_str(&schema_ty);
-                    contents.push_str(">(\"");
-                    contents.push_str(&parameter);
-                    contents.push_str("\", super::");
+            contents.push_str("        _g.param::<");
+            contents.push_str(&parameter.schema_ty);
+            contents.push_str(">(\"");
+            contents.push_str(&parameter.name);
+            contents.push_str("\", super::");
+            contents.push_str(&module);
+            contents.push_str("::PARAM_");
+            contents.push_str(&param_upper);
+            contents.push_str("_DESC, ");
+            match parameter.required {
+                Some(required) => contents.push_str(&required.to_string()),
+                None => {
+                    // Require a helper const to be present.
+                    contents.push_str("super::");
                     contents.push_str(&module);
                     contents.push_str("::PARAM_");
                     contents.push_str(&param_upper);
-                    contents.push_str("_DESC, ");
-                    match required {
-                        Some(required) => contents.push_str(&required.to_string()),
-                        None => {
-                            // Require a helper const to be present.
-                            contents.push_str("super::");
-                            contents.push_str(&module);
-                            contents.push_str("::PARAM_");
-                            contents.push_str(&param_upper);
-                            contents.push_str("_REQUIRED");
-                        }
-                    }
-                    contents.push_str("),\n");
+                    contents.push_str("_REQUIRED");
                 }
-                contents.push_str("    ],\n");
-
-                contents.push_str("    result: |g| g.result::<super::");
-                contents.push_str(&module);
-                contents.push_str("::ResultType>(\"");
-                contents.push_str(&command);
-                contents.push_str("_result\"),\n");
-
-                contents.push_str("    deprecated: ");
-                contents.push_str(
-                    &method
-                        .attrs
-                        .iter()
-                        .any(|attr| attr.path().is_ident("deprecated"))
-                        .to_string(),
-                );
-                contents.push_str(",\n");
-
-                contents.push_str("},\n");
             }
+            contents.push_str("),\n");
         }
+        contents.push_str("    ],\n");
+
+        contents.push_str("    result: |g| g.result::<super::");
+        contents.push_str(&module);
+        contents.push_str("::ResultType>(\"");
+        contents.push_str(&command);
+        contents.push_str("_result\"),\n");
+
+        contents.push_str("    deprecated: ");
+        contents.push_str(
+            &source
+                .attrs
+                .iter()
+                .any(|attr| attr.path().is_ident("deprecated"))
+                .to_string(),
+        );
+        contents.push_str(",\n");
+
+        contents.push_str("},\n");
     }
 
     contents.push_str("};");

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -622,10 +622,12 @@ err-rpc-convert-tex-not-p2pkh = Address is not a transparent p2pkh address
 ## RPC CLI errors
 
 err-rpc-cli-conn-failed = Failed to connect to the Zallet wallet's JSON-RPC port.
-err-rpc-cli-invalid-param = Invalid parameter '{$parameter}'
+err-rpc-cli-invalid-param = Parameter {$position} must be valid JSON.
+err-rpc-cli-invalid-named-param = Parameter {$position} ({$name}) must be valid JSON.
 err-rpc-cli-param-read-failed = Failed to read parameter from {$path}: {$error}
 err-rpc-cli-no-server = No JSON-RPC port is available.
 err-rpc-cli-request-failed = JSON-RPC request failed: {$error}
+err-rpc-cli-wrong-param-count = Wrong number of parameters for '{$method}': expected {$minimum} to {$maximum}, received {$provided}.
 
 ## zallet manpage
 

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -372,12 +372,16 @@ pub(crate) struct RpcCliCmd {
     /// Use `zallet rpc help` to get a list of RPC endpoints.
     pub(crate) command: String,
 
-    /// Any parameters for the command, as JSON values.
+    /// Any parameters for the command.
+    ///
+    /// For methods known to this Zallet binary, string parameters accept bare
+    /// or JSON-quoted values, while non-string parameters use JSON. Methods
+    /// unknown to this binary retain JSON-only parameter parsing.
     ///
     /// A parameter of the form `@PATH` is read from the first line of `PATH`
-    /// instead, and passed as a JSON string. Use this for secrets such as the
-    /// spending key given to `z_importkey`: command-line arguments are visible
-    /// to other processes and are recorded in shell history.
+    /// instead, and always passed as a JSON string. Use this for secrets such as
+    /// the spending key given to `z_importkey`: command-line arguments are
+    /// visible to other processes and are recorded in shell history.
     ///
     /// `@-` reads from standard input, prompting without echo if it is a
     /// terminal. `@/dev/fd/3` reads from a caller-supplied file descriptor.

--- a/zallet-core/src/commands/rpc_cli.rs
+++ b/zallet-core/src/commands/rpc_cli.rs
@@ -10,11 +10,16 @@ use hyper::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 use jsonrpsee::core::{client::ClientT, params::ArrayParams};
 use jsonrpsee_http_client::HttpClientBuilder;
 use secrecy::{ExposeSecret, SecretString};
+use serde_json::Value;
 use tracing::warn;
 
 use crate::{
-    cli::RpcCliCmd, commands::AsyncRunnable, components::json_rpc::server::cookie, error::Error,
-    fl, prelude::*,
+    cli::RpcCliCmd,
+    commands::AsyncRunnable,
+    components::json_rpc::{methods::rpc_cli, server::cookie},
+    error::Error,
+    fl,
+    prelude::*,
 };
 
 const DEFAULT_HTTP_CLIENT_TIMEOUT: u64 = 900;
@@ -42,26 +47,18 @@ macro_rules! wlnfl {
 
 impl AsyncRunnable for RpcCliCmd {
     async fn run(&self) -> Result<(), Error> {
+        let converted_params = convert_params(&self.command, &self.params)?;
         let config = APP.config();
 
         // `help` is generated from static method metadata, so answer it locally
         // instead of requiring a wallet with a running JSON-RPC server.
         #[cfg(zallet_build = "wallet")]
         if self.command == "help" {
-            let command = match self.params.as_slice() {
-                [] => None,
-                [command] => Some(
-                    serde_json::from_str::<String>(command).unwrap_or_else(|_| command.clone()),
-                ),
-                [_, param, ..] => {
-                    return Err(RpcCliError::InvalidParameter(param.clone()).into());
-                }
-            };
             print!(
                 "{}",
                 crate::components::json_rpc::methods::help::text(
                     config.consensus.network,
-                    command.as_deref(),
+                    help_command(&converted_params),
                 )
             );
             return Ok(());
@@ -125,31 +122,89 @@ impl AsyncRunnable for RpcCliCmd {
 
         // Construct the request.
         let mut params = ArrayParams::new();
-        for param in &self.params {
-            let value = match param.strip_prefix('@') {
-                Some(source) => serde_json::Value::String(read_indirect_param(source)?),
-                None => serde_json::from_str(param)
-                    .map_err(|_| RpcCliError::InvalidParameter(param.clone()))?,
-            };
+        for value in converted_params {
             params
                 .insert(value)
-                .map_err(|_| RpcCliError::InvalidParameter(param.clone()))?;
+                .expect("serde_json::Value always serializes");
         }
 
         // Make the request.
-        let response: serde_json::Value = client
+        let response: Value = client
             .request(&self.command, params)
             .await
             .map_err(|e| RpcCliError::RequestFailed(e.to_string()))?;
 
         // Print the response.
         match response {
-            serde_json::Value::String(s) => print!("{s}"),
+            Value::String(s) => print!("{s}"),
             _ => serde_json::to_writer_pretty(std::io::stdout(), &response)
                 .expect("response should be valid"),
         }
 
         Ok(())
+    }
+}
+
+fn convert_direct_param(
+    raw: &str,
+    position: usize,
+    parameter: Option<&rpc_cli::Parameter>,
+) -> Result<Value, RpcCliError> {
+    match parameter.map_or(rpc_cli::Conversion::Json, |parameter| {
+        parameter.conversion()
+    }) {
+        rpc_cli::Conversion::String => Ok(Value::String(
+            serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_owned()),
+        )),
+        rpc_cli::Conversion::NullableString if raw == "null" => Ok(Value::Null),
+        rpc_cli::Conversion::NullableString => Ok(Value::String(
+            serde_json::from_str::<String>(raw).unwrap_or_else(|_| raw.to_owned()),
+        )),
+        rpc_cli::Conversion::Json => {
+            serde_json::from_str(raw).map_err(|_| RpcCliError::InvalidJsonParameter {
+                position,
+                name: parameter.map(rpc_cli::Parameter::name),
+            })
+        }
+    }
+}
+
+fn convert_params(command: &str, raw_params: &[String]) -> Result<Vec<Value>, RpcCliError> {
+    let method = rpc_cli::get(command);
+    if let Some(method) = method {
+        let minimum = method.minimum_params();
+        let maximum = method.maximum_params();
+        let provided = raw_params.len();
+        if !(minimum..=maximum).contains(&provided) {
+            return Err(RpcCliError::WrongParameterCount {
+                command: command.to_owned(),
+                minimum,
+                maximum,
+                provided,
+            });
+        }
+    }
+
+    raw_params
+        .iter()
+        .enumerate()
+        .map(|(index, raw)| match raw.strip_prefix('@') {
+            Some(source) => read_indirect_param(source).map(Value::String),
+            None => convert_direct_param(
+                raw,
+                index + 1,
+                method.and_then(|method| method.params().get(index)),
+            ),
+        })
+        .collect()
+}
+
+#[cfg(zallet_build = "wallet")]
+fn help_command(params: &[Value]) -> Option<&str> {
+    match params {
+        [] | [Value::Null] => None,
+        [Value::String(command)] => Some(command),
+        _ => unreachable!("generated help metadata only yields a nullable string"),
     }
 }
 
@@ -210,7 +265,12 @@ pub enum RpcCliError {
     /// The wallet's JSON-RPC server could not be reached.
     FailedToConnect,
     /// A request parameter was not valid JSON.
-    InvalidParameter(String),
+    InvalidJsonParameter {
+        /// The one-based position of the invalid parameter.
+        position: usize,
+        /// The generated parameter name, when the method is known to this binary.
+        name: Option<&'static str>,
+    },
     /// An `@PATH` request parameter could not be read.
     ParamReadFailed {
         /// The `PATH` the parameter was to be read from.
@@ -222,14 +282,43 @@ pub enum RpcCliError {
     RequestFailed(String),
     /// The wallet is not running a JSON-RPC server.
     WalletHasNoRpcServer,
+    /// A known RPC method received the wrong number of parameters.
+    WrongParameterCount {
+        /// The RPC method name.
+        command: String,
+        /// The minimum accepted number of positional parameters.
+        minimum: usize,
+        /// The maximum accepted number of positional parameters.
+        maximum: usize,
+        /// The number of positional parameters provided.
+        provided: usize,
+    },
 }
 
 impl fmt::Display for RpcCliError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::FailedToConnect => wfl!(f, "err-rpc-cli-conn-failed"),
-            Self::InvalidParameter(param) => {
-                wfl!(f, "err-rpc-cli-invalid-param", parameter = param)
+            Self::InvalidJsonParameter {
+                position,
+                name: Some(name),
+            } => {
+                wfl!(
+                    f,
+                    "err-rpc-cli-invalid-named-param",
+                    position = position.to_string(),
+                    name = (*name).to_owned()
+                )
+            }
+            Self::InvalidJsonParameter {
+                position,
+                name: None,
+            } => {
+                wfl!(
+                    f,
+                    "err-rpc-cli-invalid-param",
+                    position = position.to_string()
+                )
             }
             Self::ParamReadFailed { source, error } => {
                 wfl!(
@@ -243,6 +332,21 @@ impl fmt::Display for RpcCliError {
                 wfl!(f, "err-rpc-cli-request-failed", error = e)
             }
             Self::WalletHasNoRpcServer => wfl!(f, "err-rpc-cli-no-server"),
+            Self::WrongParameterCount {
+                command,
+                minimum,
+                maximum,
+                provided,
+            } => {
+                wfl!(
+                    f,
+                    "err-rpc-cli-wrong-param-count",
+                    method = command.as_str().to_owned(),
+                    minimum = minimum.to_string(),
+                    maximum = maximum.to_string(),
+                    provided = provided.to_string()
+                )
+            }
         }
     }
 }
@@ -253,7 +357,23 @@ impl std::error::Error for RpcCliError {}
 mod tests {
     use std::io::Write as _;
 
-    use super::read_indirect_param;
+    use serde_json::{Value, json};
+
+    #[cfg(zallet_build = "wallet")]
+    use super::help_command;
+    use super::{RpcCliError, convert_params, read_indirect_param};
+
+    fn args(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| (*value).to_owned()).collect()
+    }
+
+    /// The language loader is process-global. A parallel test can reload its Fluent
+    /// bundles between `load_languages` disabling isolation and this test formatting a
+    /// message, transiently restoring the default directionality markers. Remove only
+    /// those presentation markers so the message text remains an exact assertion.
+    fn without_fluent_isolation_marks(message: &str) -> String {
+        message.replace(['\u{2068}', '\u{2069}'], "")
+    }
 
     /// Writes `contents` to a temporary file and returns its path.
     fn temp_file(contents: &[u8]) -> tempfile::TempPath {
@@ -283,7 +403,230 @@ mod tests {
     }
 
     #[test]
+    fn known_strings_accept_bare_and_json_quoted_values() {
+        for raw in ["alice", r#""alice""#] {
+            assert_eq!(
+                convert_params("z_getaccount", &args(&[raw])).expect("valid parameter"),
+                vec![json!("alice")],
+            );
+        }
+
+        assert_eq!(
+            convert_params("z_getaccount", &args(&["null"])).expect("valid string"),
+            vec![json!("null")],
+        );
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn nullable_strings_distinguish_null_from_the_string_null() {
+        assert_eq!(
+            convert_params("help", &args(&["null"])).expect("valid null"),
+            vec![Value::Null],
+        );
+        assert_eq!(
+            convert_params("help", &args(&[r#""null""#])).expect("valid string"),
+            vec![json!("null")],
+        );
+    }
+
+    #[test]
+    fn known_json_parameters_remain_strict_json() {
+        for raw in ["null", "true", "42", "[]", "{}", r#""alice""#] {
+            assert_eq!(
+                convert_params("z_getaddressforaccount", &args(&[raw]))
+                    .expect("valid JSON parameter"),
+                vec![serde_json::from_str::<Value>(raw).expect("test JSON")],
+            );
+        }
+    }
+
+    #[test]
+    fn invalid_json_names_the_position_without_echoing_contents() {
+        crate::i18n::load_languages(&[]);
+
+        let sensitive = "not-json-sensitive-address";
+        let error = convert_params("z_getaddressforaccount", &args(&[sensitive]))
+            .expect_err("JSON parameter must stay strict");
+
+        assert_eq!(
+            error,
+            RpcCliError::InvalidJsonParameter {
+                position: 1,
+                name: Some("account"),
+            },
+        );
+        let message = error.to_string();
+        assert_eq!(
+            without_fluent_isolation_marks(&message),
+            "Parameter 1 (account) must be valid JSON.",
+        );
+        assert!(!message.contains(sensitive));
+    }
+
+    #[test]
+    fn validates_known_method_arity() {
+        crate::i18n::load_languages(&[]);
+
+        let too_few = convert_params("z_getaccount", &[]).expect_err("one required parameter");
+        assert_eq!(
+            too_few,
+            RpcCliError::WrongParameterCount {
+                command: "z_getaccount".to_owned(),
+                minimum: 1,
+                maximum: 1,
+                provided: 0,
+            },
+        );
+        let message = too_few.to_string();
+        assert_eq!(
+            without_fluent_isolation_marks(&message),
+            "Wrong number of parameters for 'z_getaccount': expected 1 to 1, received 0.",
+        );
+        assert_eq!(
+            convert_params("z_getaccount", &args(&[r#""a""#, r#""b""#]))
+                .expect_err("one maximum parameter"),
+            RpcCliError::WrongParameterCount {
+                command: "z_getaccount".to_owned(),
+                minimum: 1,
+                maximum: 1,
+                provided: 2,
+            },
+        );
+    }
+
+    #[test]
+    fn required_vec_parameter_is_not_optional() {
+        assert!(matches!(
+            convert_params("pczt_combine", &[]),
+            Err(RpcCliError::WrongParameterCount { minimum: 1, .. })
+        ));
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn supports_optional_parameters_and_vecs() {
+        assert_eq!(convert_params("help", &[]), Ok(vec![]));
+        assert_eq!(convert_params("z_getoperationstatus", &[]), Ok(vec![]));
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn later_required_parameter_sets_the_minimum_position() {
+        let raw = args(&[
+            r#""account-id""#,
+            r#""orchard""#,
+            "[]",
+            "null",
+            "AllowRevealedAmounts",
+        ]);
+        assert_eq!(
+            convert_params("z_sendfromaccount", &raw).expect("explicit null placeholder"),
+            vec![
+                json!("account-id"),
+                json!("orchard"),
+                json!([]),
+                Value::Null,
+                json!("AllowRevealedAmounts"),
+            ],
+        );
+        assert!(matches!(
+            convert_params("z_sendfromaccount", &raw[..4]),
+            Err(RpcCliError::WrongParameterCount {
+                minimum: 5,
+                maximum: 5,
+                provided: 4,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn unknown_methods_keep_json_only_parsing_without_an_arity_limit() {
+        crate::i18n::load_languages(&[]);
+
+        assert_eq!(
+            convert_params("remote_only", &args(&["1", "true", "null", "[]", "{}"])),
+            Ok(vec![
+                json!(1),
+                json!(true),
+                Value::Null,
+                json!([]),
+                json!({}),
+            ]),
+        );
+
+        let sensitive = "bare-string";
+        let error = convert_params("remote_only", &args(&[sensitive]))
+            .expect_err("unknown methods remain JSON-only");
+        assert_eq!(
+            error,
+            RpcCliError::InvalidJsonParameter {
+                position: 1,
+                name: None,
+            },
+        );
+        let message = error.to_string();
+        assert_eq!(
+            without_fluent_isolation_marks(&message),
+            "Parameter 1 must be valid JSON.",
+        );
+        assert!(!message.contains(sensitive));
+    }
+
+    #[test]
+    fn indirect_parameters_are_strings_for_every_conversion() {
+        let path = temp_file(b"indirect-value\n");
+        let indirect = format!("@{}", path.display());
+
+        for command in ["z_getaccount", "z_getaddressforaccount"] {
+            assert_eq!(
+                convert_params(command, std::slice::from_ref(&indirect))
+                    .expect("reads indirect parameter"),
+                vec![json!("indirect-value")],
+            );
+        }
+
+        #[cfg(zallet_build = "wallet")]
+        assert_eq!(
+            convert_params("help", std::slice::from_ref(&indirect))
+                .expect("reads nullable indirect parameter"),
+            vec![json!("indirect-value")],
+        );
+    }
+
+    #[test]
+    fn arity_is_validated_before_indirect_io() {
+        let raw = args(&["@C:/definitely/not/a/zallet/parameter", r#""extra""#]);
+        assert!(matches!(
+            convert_params("z_getaccount", &raw),
+            Err(RpcCliError::WrongParameterCount {
+                minimum: 1,
+                maximum: 1,
+                provided: 2,
+                ..
+            })
+        ));
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn local_help_consumes_the_common_conversion() {
+        for raw in ["z_getaccount", r#""z_getaccount""#] {
+            let params = convert_params("help", &args(&[raw])).expect("valid help parameter");
+            assert_eq!(help_command(&params), Some("z_getaccount"));
+        }
+
+        assert_eq!(help_command(&[]), None);
+        let null = convert_params("help", &args(&["null"])).expect("valid null");
+        assert_eq!(help_command(&null), None);
+    }
+
+    #[test]
     fn missing_file_is_an_error() {
-        assert!(read_indirect_param("/nonexistent/zallet-rpc-param").is_err());
+        assert!(matches!(
+            read_indirect_param("/nonexistent/zallet-rpc-param"),
+            Err(RpcCliError::ParamReadFailed { .. })
+        ));
     }
 }

--- a/zallet-core/src/components/json_rpc/methods.rs
+++ b/zallet-core/src/components/json_rpc/methods.rs
@@ -72,6 +72,8 @@ mod list_unspent;
 mod lock_wallet;
 #[cfg(zallet_build = "wallet")]
 mod openrpc;
+#[cfg(feature = "rpc-cli")]
+pub(crate) mod rpc_cli;
 // PCZT methods. The stateless roles (combine, inspect, prove) and their shared
 // helpers are available in every build; create, sign, and extract (which
 // records the extracted transaction) require wallet state.

--- a/zallet-core/src/components/json_rpc/methods/rpc_cli.rs
+++ b/zallet-core/src/components/json_rpc/methods/rpc_cli.rs
@@ -1,0 +1,132 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Conversion {
+    String,
+    NullableString,
+    Json,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct Parameter {
+    name: &'static str,
+    required: bool,
+    conversion: Conversion,
+}
+
+impl Parameter {
+    pub(super) const fn new(name: &'static str, required: bool, conversion: Conversion) -> Self {
+        Self {
+            name,
+            required,
+            conversion,
+        }
+    }
+
+    pub(crate) fn name(&self) -> &'static str {
+        self.name
+    }
+
+    pub(crate) fn conversion(&self) -> Conversion {
+        self.conversion
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Method {
+    params: &'static [Parameter],
+}
+
+impl Method {
+    pub(super) const fn new(params: &'static [Parameter]) -> Self {
+        Self { params }
+    }
+
+    pub(crate) fn params(&self) -> &'static [Parameter] {
+        self.params
+    }
+
+    pub(crate) fn minimum_params(&self) -> usize {
+        self.params
+            .iter()
+            .rposition(|parameter| parameter.required)
+            .map_or(0, |index| index + 1)
+    }
+
+    pub(crate) fn maximum_params(&self) -> usize {
+        self.params.len()
+    }
+}
+
+include!(concat!(env!("OUT_DIR"), "/rpc_cli_params.rs"));
+
+pub(crate) fn get(name: &str) -> Option<&'static Method> {
+    METHODS.get(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Conversion, Parameter, get};
+
+    #[test]
+    fn generates_common_text_and_required_vec_metadata() {
+        assert_eq!(
+            get("z_getaccount").expect("generated method").params(),
+            &[Parameter::new("account_uuid", true, Conversion::String)],
+        );
+        assert_eq!(
+            get("pczt_combine").expect("generated method").params(),
+            &[Parameter::new("pczts", true, Conversion::Json)],
+        );
+        assert!(get("not_a_zallet_method").is_none());
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn generates_wallet_optional_metadata() {
+        assert_eq!(
+            get("help").expect("generated method").params(),
+            &[Parameter::new("command", false, Conversion::NullableString)],
+        );
+        assert_eq!(
+            get("z_getoperationstatus")
+                .expect("generated method")
+                .params(),
+            &[Parameter::new("operationid", false, Conversion::Json)],
+        );
+        assert_eq!(
+            get("walletpassphrase").expect("generated method").params(),
+            &[
+                Parameter::new("passphrase", true, Conversion::String),
+                Parameter::new("timeout", true, Conversion::Json),
+            ],
+        );
+        assert_eq!(
+            get("z_sendmany").expect("generated method").params()[4],
+            Parameter::new("privacy_policy", false, Conversion::NullableString),
+        );
+    }
+
+    #[cfg(zallet_build = "merchant_terminal")]
+    #[test]
+    fn omits_wallet_only_metadata() {
+        assert!(get("help").is_none());
+        assert!(get("walletpassphrase").is_none());
+    }
+
+    #[cfg(zallet_build = "wallet")]
+    #[test]
+    fn minimum_count_uses_the_last_required_position() {
+        let method = get("z_sendfromaccount").expect("generated method");
+        assert_eq!(
+            method.params(),
+            &[
+                Parameter::new("account", true, Conversion::Json),
+                Parameter::new("fund_source", true, Conversion::Json),
+                Parameter::new("recipients", true, Conversion::Json),
+                Parameter::new("minconf", false, Conversion::Json),
+                Parameter::new("privacy_policy", true, Conversion::String),
+            ],
+        );
+        assert_eq!(method.minimum_params(), 5);
+        assert_eq!(method.maximum_params(), 5);
+    }
+}


### PR DESCRIPTION
Closes #211.

## Motivation

`zallet rpc` currently requires every direct string argument to be encoded as JSON and then protected from the shell. This makes ordinary addresses, method names, and other textual values awkward to pass.

## What changed

- generate an ordered CLI parameter table from the existing `Rpc` and `WalletRpc` traits;
- accept bare or JSON-quoted values at known string positions;
- retain strict JSON for known non-string positions and methods unknown to this binary;
- validate known positional counts before indirect-file or network I/O; and
- report parameter position/name without echoing potentially sensitive contents.

`@PATH` continues to produce a JSON string. Same-named remote methods follow this binary's local Zallet metadata; the unknown-method fallback is not full compatibility with a divergent `zcashd` schema.

## Test plan

- `cargo test --workspace --features zcashd-import,rpc-cli,tokio-console`
- `cargo test --manifest-path backends/zebra/Cargo.toml --features zcashd-import,rpc-cli,tokio-console`
- `cargo test --manifest-path backends/zaino/Cargo.toml --features zcashd-import,rpc-cli,tokio-console`
- stable Clippy with `-D warnings` in all three workspaces
- beta Clippy in all three workspaces (no new warnings)
- merchant-terminal root-workspace tests with `rpc-cli`
- formatting checks in all three workspaces
- `utils/check-lockstep.sh` and lockfile-sync verification

## AI disclosure

OpenAI Codex assisted with design, implementation, tests, and review. The commit includes the required `Co-Authored-By` trailer; I reviewed the change and am responsible for it.