### PR TITLE
book: Correct two unimplemented defenses in the threat model

### DIFF
--- a/book/src/security/threat-model.md
+++ b/book/src/security/threat-model.md
@@ -31,8 +31,16 @@ with an encryption of their own key material is detected at the point of use,
 because the recomputed fingerprint does not match the row that selected it.
 
 These per-read re-derive checks were landed in #643 and cover mnemonic seeds,
-standalone Sapling extended spending keys, standalone transparent secret keys,
-and seed-derived account UFVKs at spend time.
+standalone Sapling extended spending keys, and standalone transparent secret
+keys. The same release also re-derives a built transaction's transparent
+outputs from the seed-derived account key before broadcast, so a substituted
+transparent change address is rejected.
+
+The account's own recorded viewing key (`accounts.ufvk`) is **not** validated
+against the seed. Spending authority is unaffected, because signing derives
+from the seed rather than from that record, but receive-address derivation
+reads it as-is. See [Full filesystem compromise](#full-filesystem-compromise)
+below.
 
 ### RPC channel hygiene
 
@@ -119,7 +127,7 @@ recover keys from memory regardless of the wallet software in use.
 | Spend funds | **Yes** | The spending key is age-encrypted; the attacker cannot decrypt it without the identity file. |
 | Substitute a keystore ciphertext with their own key | No | Per-read re-derive check: the recomputed fingerprint does not match the row key. |
 | Substitute a cached transparent change address | No | Per-read re-derive check: change outputs are re-derived from the USK before broadcast. |
-| Forge a UFVK signature over a swapped UFVK | No | Computationally infeasible without the spending key (the signature is produced at import time by the USK). |
+| Substitute the account's recorded UFVK (`accounts.ufvk`) | No | Not currently caught. Newly derived receive addresses follow the substituted key. Transparent change is caught, because it is re-derived from the seed before broadcast; shielded change is not. |
 | Append an age recipient to silently receive future ciphertexts | No | Not caught by per-read checks. The operator's defense is encrypting backups and verifying restored DB provenance. |
 
 [age]: https://age-encryption.org/


### PR DESCRIPTION
## Summary

The threat model page added in #786 states two defenses Zallet does not implement. This corrects both to describe shipped behaviour.

This surfaced while assembling the remediation report for Least Authority: the threat model is the page an auditor reads first when verifying our Issue A/B disposition, so a claim there that the code does not back is worse than the finding it was meant to answer.

## The two corrections

**1. A UFVK signature scheme that does not exist.** The capability table listed:

> | Forge a UFVK signature over a swapped UFVK | No | Computationally infeasible without the spending key (the signature is produced at import time by the USK). |

`git grep` for `sign_ufvk`, `verify_ufvk`, `ufvk_signature` and `UFVKSignature` returns nothing, and there is no column or migration to hold such a signature (the keystore migrations are `initial_setup` and `mnemonic_backup_confirmation`). That scheme is the *proposed* remediation for audit Issue B, which was closed as out of scope under this same page's filesystem-compromise exclusion — so the row described intended work as though it had shipped.

Replaced with the capability that actually exists, substituting `accounts.ufvk`, and its real coverage. Receive-address derivation reads the record without validating it: `get_next_available_address` and `get_address_for_index` (`connection.rs:694`, `:702`) pass straight through. Transparent change *is* caught, because `check_transparent_outputs` re-derives it from the seed-derived key before broadcast; shielded change is not.

**2. "Per-read integrity" overstated the same coverage.** It claimed the #643 checks reach "seed-derived account UFVKs at spend time". That rests entirely on `check_transparent_outputs`, whose own doc comment scopes it to "transparent change and ephemeral (ZIP 320) output"; the only other pre-broadcast check in `payments.rs` is `check_shielded_action_limits`, a count cap rather than output verification. Split the sentence so the transparent-output check is stated for what it is, and added an explicit line that `accounts.ufvk` is not validated against the seed — noting that spending authority is unaffected, since signing derives from the seed rather than that record.

## Scope

Documentation only. No code changes, no behaviour change.

## Interaction with #735

#735 wires `validate_seed` before signing, which closes the shielded-change half of the substitution row. It is not merged, so this PR describes the tree as it stands. When #735 lands, that row should be revisited — noted in #807 so it is not lost.

## Testing

- `mdbook build book` succeeds.
- The `#full-filesystem-compromise` anchor added in the per-read section resolves to the existing `### Full filesystem compromise` heading (line 78).

Closes #807

Co-Authored-By: Claude <noreply@anthropic.com>
