### PR TITLE
deps: bump librustzcash to include transparent output persistence fix (#2986)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1339,7 +1339,7 @@ checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1374,7 +1374,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3138,7 +3138,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -5857,7 +5857,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -5870,7 +5870,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -5923,7 +5923,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -5985,7 +5985,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6031,7 +6031,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6052,7 +6052,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6082,7 +6082,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6104,7 +6104,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "corez",
  "document-features",
@@ -6142,7 +6142,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bip32",
  "bs58",
@@ -6321,7 +6321,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,20 +182,23 @@ debug = "line-tables-only"
 # the fix for reading back a stored unmined transaction with a zero expiry height
 # (zcash/librustzcash#2975, fixed by zcash/librustzcash#2983), which
 # `zallet migrate-zcashd-wallet` needs in order to re-read the transactions it
-# imports from a zcashd wallet before any chain scan. The full in-repo dependency
+# imports from a zcashd wallet before any chain scan. Also carries the fix for
+# block scanning discarding transparent outputs (zcash/librustzcash#2984, fixed
+# by zcash/librustzcash#2986), which caused z_gettotalbalance to report stale
+# transparent balances after scan completion. The full in-repo dependency
 # closure of the two client crates is patched to the same rev so the whole cohort
-# resolves from a single source. Repoint at crates.io once the fix lands in a
+# resolves from a single source. Repoint at crates.io once the fixes land in a
 # release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }

--- a/backends/zaino/Cargo.lock
+++ b/backends/zaino/Cargo.lock
@@ -1522,7 +1522,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1558,7 +1558,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3651,7 +3651,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -7024,7 +7024,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -7037,7 +7037,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -7090,7 +7090,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7163,7 +7163,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -7209,7 +7209,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -7230,7 +7230,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -7260,7 +7260,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -7282,7 +7282,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "corez",
  "document-features",
@@ -7320,7 +7320,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bip32",
  "bs58",
@@ -7774,7 +7774,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zaino/Cargo.toml
+++ b/backends/zaino/Cargo.toml
@@ -84,19 +84,19 @@ librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev
 # closure of the two client crates is patched to the same rev so the whole cohort
 # resolves from a single source. Repoint at crates.io once the fix lands in a
 # release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
 
 # TEMPORARY: pin the zaino crates to the zodl-inc/zaino branch
 # `update/librustzcash-0.24.0-rc.4`, which bumps zaino to the librustzcash

--- a/backends/zebra/Cargo.lock
+++ b/backends/zebra/Cargo.lock
@@ -1429,7 +1429,7 @@ dependencies = [
 [[package]]
 name = "equihash"
 version = "0.3.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -1465,7 +1465,7 @@ dependencies = [
 [[package]]
 name = "f4jumble"
 version = "0.1.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
 ]
@@ -3482,7 +3482,7 @@ dependencies = [
 [[package]]
 name = "pczt"
 version = "0.9.3"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "bls12_381",
@@ -6636,7 +6636,7 @@ dependencies = [
 [[package]]
 name = "zcash_address"
 version = "0.13.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bs58",
@@ -6649,7 +6649,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_backend"
 version = "0.24.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "base64 0.22.1",
  "bech32 0.11.1",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "zcash_client_sqlite"
 version = "0.22.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6775,7 +6775,7 @@ dependencies = [
 [[package]]
 name = "zcash_keys"
 version = "0.16.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bech32 0.11.1",
  "bip0039",
@@ -6821,7 +6821,7 @@ dependencies = [
 [[package]]
 name = "zcash_pool_migration"
 version = "0.1.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "corez",
@@ -6842,7 +6842,7 @@ dependencies = [
 [[package]]
 name = "zcash_primitives"
 version = "0.30.1"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "blake2b_simd",
  "block-buffer 0.11.0-rc.3",
@@ -6872,7 +6872,7 @@ dependencies = [
 [[package]]
 name = "zcash_proofs"
 version = "0.30.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bellman",
  "blake2b_simd",
@@ -6894,7 +6894,7 @@ dependencies = [
 [[package]]
 name = "zcash_protocol"
 version = "0.10.5"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "corez",
  "document-features",
@@ -6932,7 +6932,7 @@ dependencies = [
 [[package]]
 name = "zcash_transparent"
 version = "0.10.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "bip32",
  "bs58",
@@ -7386,7 +7386,7 @@ dependencies = [
 [[package]]
 name = "zip321"
 version = "0.9.0"
-source = "git+https://github.com/zcash/librustzcash.git?rev=1f6bb2072e7fcb142b0d90ff7b267a8699a84818#1f6bb2072e7fcb142b0d90ff7b267a8699a84818"
+source = "git+https://github.com/zcash/librustzcash.git?rev=d475e5244d48b84ac0675c71b1d0b11ba73b12a6#d475e5244d48b84ac0675c71b1d0b11ba73b12a6"
 dependencies = [
  "base64 0.22.1",
  "nom 7.1.3",

--- a/backends/zebra/Cargo.toml
+++ b/backends/zebra/Cargo.toml
@@ -87,19 +87,19 @@ librocksdb-sys = { git = "https://github.com/rust-rocksdb/rust-rocksdb.git", rev
 # closure of the two client crates is patched to the same rev so the whole cohort
 # resolves from a single source. Repoint at crates.io once the fix lands in a
 # release.
-equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
-zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "1f6bb2072e7fcb142b0d90ff7b267a8699a84818" }
+equihash = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+f4jumble = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+pczt = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_address = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_client_backend = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_client_sqlite = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_keys = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_pool_migration = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_primitives = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_proofs = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_protocol = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zcash_transparent = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
+zip321 = { git = "https://github.com/zcash/librustzcash.git", rev = "d475e5244d48b84ac0675c71b1d0b11ba73b12a6" }
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(tokio_unstable)',


### PR DESCRIPTION
Bumps the pinned librustzcash rev from `1f6bb207` to `d475e524` (merge commit of #2986).

Block scanning was silently discarding transparent outputs detected during full-block scans (#2984). Only the enhancement path populated transparent UTXOs, so `z_gettotalbalance` reported stale transparent balances after scan completion. This caused the integration-tests `wallet.py` flake (#198, zcash/integration-tests#199) where the balance summary froze 4-14 blocks behind the scan tip.

Related:
* https://github.com/zcash/librustzcash/pull/2986