### PR TITLE
migrate-zcashd-wallet: Fix standalone P2SH support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,13 @@ be considered breaking changes.
   see. As in `zcashd`, and as for any address imported with `zallet
   import-address`, funds they receive are reported but cannot be spent without
   importing the corresponding key material.
+- `migrate-zcashd-wallet` no longer aborts when a `zcashd` wallet's watch-only
+  pubkeys (from `importpubkey`) include one whose address the Zallet wallet already
+  tracks. Every such pubkey was registered regardless, and the wallet rejects an
+  import of key material another account holds, so migrating a second `zcashd`
+  wallet that shared a watched key failed with a database error *after* the import
+  had committed. Such an address now keeps the registration and the exposure it
+  already had, as the watch-only address registration does for its own candidates.
 - `migrate-zcashd-wallet` prints the backup reminder before reporting an
   error from the post-import registration and verification steps.
 - The `__cookie__` JSON-RPC username is now actually reserved. It is documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,15 @@ be considered breaking changes.
   did. Addresses that are also seed-derived receivers of an imported account
   are excluded — both here and in the watch-only pubkey registration — so
   they keep the gap-limit-inferred exposure that seed recovery depends on.
+- `migrate-zcashd-wallet` now records the P2SH addresses of the redeem scripts it
+  imports (from zcashd's `importaddress <redeemscript>` and
+  `addmultisigaddress`) as exposed. Such an address was in use outside the wallet
+  before it was imported, but it has no derivation, so it was reached by neither
+  the exposures recorded in the migrated wallet nor the gap-limit inference that
+  covers derived receivers; one that had never appeared in a wallet transaction
+  was left with no exposure height at all. One consequence is that
+  `listaddresses`, which reports only exposed addresses, did not surface it where
+  `zcashd` did.
 - `migrate-zcashd-wallet` prints the backup reminder before reporting an
   error from the post-import registration and verification steps.
 - The `__cookie__` JSON-RPC username is now actually reserved. It is documented

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,15 @@ be considered breaking changes.
   was left with no exposure height at all. One consequence is that
   `listaddresses`, which reports only exposed addresses, did not surface it where
   `zcashd` did.
+- `migrate-zcashd-wallet` now migrates the transparent addresses that `zcashd`
+  watched without holding any key material for them, as watch-only addresses.
+  These are the addresses imported with `importaddress <address>`, and the P2SH
+  addresses of redeem scripts that the Zallet wallet cannot represent
+  (non-multisig, or beyond the 520-byte P2SH limit); both were previously dropped
+  with a warning, leaving the migrated wallet blind to funds that `zcashd` could
+  see. As in `zcashd`, and as for any address imported with `zallet
+  import-address`, funds they receive are reported but cannot be spent without
+  importing the corresponding key material.
 - `migrate-zcashd-wallet` prints the backup reminder before reporting an
   error from the post-import registration and verification steps.
 - The `__cookie__` JSON-RPC username is now actually reserved. It is documented

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -982,10 +982,17 @@ struct WatchedAddress {
 ///
 /// An address the document records an exposure height for takes that height, as the
 /// import would have done had it recognized the address; the rest take
-/// `exposure_height`. The result is sorted, so that a migration run registers
-/// addresses in a deterministic order, and an address recorded by more than one
-/// account is registered once, under the first account that records it: the wallet
-/// rejects an import of the same address into a second account.
+/// `exposure_height`. No converter records one today — `zewif-zcashd` never sets the
+/// field, and neither does [`enriched_document`] — so every address currently takes
+/// `exposure_height`. The branch is here because the ZeWIF importer has the same one
+/// over the same field, and an address this step registers should not end up with a
+/// worse exposure than the import would have given it had the wallet been able to
+/// hold the address; a document that does record heights must not silently lose them.
+///
+/// The result is sorted, so that a migration run registers addresses in a
+/// deterministic order, and an address recorded by more than one account is registered
+/// once, under the first account that records it: the wallet rejects an import of the
+/// same address into a second account.
 ///
 /// Returns the selected addresses along with the number of address strings that could
 /// not be decoded for this network, which the caller warns about.
@@ -2182,6 +2189,9 @@ mod tests {
     /// applied had it recognized the address. The rest take the migration's own
     /// exposure height; the disclosure that put such an address into a zcashd wallet
     /// happened before the migration either way.
+    ///
+    /// No converter records an exposure height yet, so this pins a branch that a
+    /// zcashd wallet cannot currently reach, against the day one does.
     #[test]
     fn watched_addresses_take_the_documents_exposure_height_where_it_records_one() {
         use transparent::address::TransparentAddress;

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -719,6 +719,22 @@ fn collect_transparent_receivers(
     Ok(receivers)
 }
 
+/// Marks `to_expose` as exposed, doing nothing when there is nothing to mark.
+///
+/// Every caller assembles its addresses conditionally and several can end up with
+/// none, which `mark_transparent_addresses_exposed` should not be troubled with.
+fn mark_addresses_exposed(
+    db_data: &mut DbHandle,
+    to_expose: &[(TransparentAddress, BlockHeight)],
+) -> Result<(), MigrateError> {
+    if to_expose.is_empty() {
+        return Ok(());
+    }
+    db_data
+        .mark_transparent_addresses_exposed(to_expose)
+        .map_err(MigrateError::Database)
+}
+
 /// Registers watch-only transparent pubkeys (from zcashd's `importpubkey`) with the
 /// accounts whose address lists carry them, exposing their addresses as of
 /// `exposure_height`.
@@ -767,11 +783,7 @@ fn register_watch_pubkeys(
             db_data
                 .import_standalone_transparent_pubkeys(account_uuid, watch_pubkeys.into_iter())
                 .map_err(MigrateError::Database)?;
-            if !to_expose.is_empty() {
-                db_data
-                    .mark_transparent_addresses_exposed(&to_expose)
-                    .map_err(MigrateError::Database)?;
-            }
+            mark_addresses_exposed(db_data, &to_expose)?;
         }
     }
     if skipped_uncompressed_watch_pubkeys > 0 {
@@ -886,9 +898,7 @@ fn expose_spending_key_addresses(
         "Marking {} imported transparent spending-key addresses as exposed",
         to_expose.len(),
     );
-    db_data
-        .mark_transparent_addresses_exposed(&to_expose)
-        .map_err(MigrateError::Database)
+    mark_addresses_exposed(db_data, &to_expose)
 }
 
 /// A transparent address that zcashd watched and that the document records without
@@ -1014,9 +1024,7 @@ fn register_watch_addresses(
             .map_err(MigrateError::Database)?;
         to_expose.push((watched.address, watched.exposure_height));
     }
-    db_data
-        .mark_transparent_addresses_exposed(&to_expose)
-        .map_err(MigrateError::Database)
+    mark_addresses_exposed(db_data, &to_expose)
 }
 
 /// Selects the P2SH addresses among `receivers` that the wallet does not already
@@ -1091,9 +1099,7 @@ fn expose_registered_script_addresses(
         "Marking {} imported P2SH redeem script addresses as exposed",
         to_expose.len(),
     );
-    db_data
-        .mark_transparent_addresses_exposed(&to_expose)
-        .map_err(MigrateError::Database)
+    mark_addresses_exposed(db_data, &to_expose)
 }
 
 /// Best-effort removal of a provisionally stored mnemonic from the keystore, after

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -1042,7 +1042,9 @@ fn watched_addresses_to_import<P: Parameters>(
 /// spent from, which is what it was in zcashd as well.
 ///
 /// This runs after the registration steps that precede it, so that the receivers read
-/// back here account for everything they added.
+/// back here account for everything they added. The registrations and the exposures
+/// they call for are applied as one database transaction, so a failure partway leaves
+/// the wallet as it was rather than watching addresses it does not report.
 fn register_watch_addresses(
     db_data: &mut DbHandle,
     document: &zewif::Zewif,
@@ -1067,14 +1069,15 @@ fn register_watch_addresses(
         "Registering {} watch-only transparent addresses that carry no key material",
         to_import.len(),
     );
-    let mut to_expose = Vec::with_capacity(to_import.len());
-    for watched in to_import {
-        db_data
-            .import_standalone_transparent_address(watched.account_uuid, watched.address)
-            .map_err(MigrateError::Database)?;
-        to_expose.push((watched.address, watched.exposure_height));
-    }
-    mark_addresses_exposed(db_data, &to_expose)
+    db_data
+        .import_standalone_transparent_addresses(to_import.into_iter().map(|watched| {
+            (
+                watched.account_uuid,
+                watched.address,
+                watched.exposure_height,
+            )
+        }))
+        .map_err(MigrateError::Database)
 }
 
 /// Selects the P2SH addresses among `receivers` that the wallet does not already

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -5,7 +5,7 @@ use abscissa_core::Runnable;
 
 use bip0039::{Count, English, Mnemonic};
 use rand::{RngCore, rngs::OsRng};
-use secp256k1::PublicKey;
+use secp256k1::{PublicKey, constants::PUBLIC_KEY_SIZE};
 use secrecy::{SecretVec, Zeroize};
 use transparent::address::TransparentAddress;
 use zcash_client_backend::data_api::{
@@ -763,9 +763,12 @@ fn register_watch_pubkeys(
                 // P2PKH address from the compressed pubkey serialization, so an
                 // uncompressed pubkey would be tracked under a different
                 // address than zcashd had on-chain.
-                match PublicKey::from_slice(pubkey.as_slice()) {
-                    Ok(pk) if pubkey.as_slice().len() == 33 => watch_pubkeys.push(pk),
-                    _ => skipped_uncompressed_watch_pubkeys += 1,
+                if pubkey.as_slice().len() == PUBLIC_KEY_SIZE
+                    && let Ok(pk) = PublicKey::from_slice(pubkey.as_slice())
+                {
+                    watch_pubkeys.push(pk);
+                } else {
+                    skipped_uncompressed_watch_pubkeys += 1;
                 }
             }
         }

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -11,6 +11,7 @@ use transparent::address::TransparentAddress;
 use zcash_client_backend::data_api::{
     Account as _, AccountSource, WalletRead, WalletWrite as _, chain::ChainState,
 };
+use zcash_client_backend::wallet::TransparentAddressMetadata;
 use zcash_client_sqlite::error::SqliteClientError;
 use zcash_client_sqlite::zewif::{
     AccountSkipReason, DiscardSecrets, SecretSink, SkippedAccount, SkippedTransparentKey,
@@ -583,11 +584,11 @@ impl MigrateZcashdWalletCmd {
             .or(no_scan_birthday_estimate)
             .unwrap_or(sapling_activation);
         // The import has committed: register watch-only transparent pubkeys, expose
-        // the imported standalone spending keys' addresses, then evaluate the import
-        // report. All of these must happen after the imported accounts are fully set
-        // up, so that a failure here never leaves committed accounts half-configured.
-        // The backup reminder is printed before propagating any error from these
-        // steps, as the minted-seed notice above refers to it.
+        // the addresses of the imported standalone spending keys and redeem scripts,
+        // then evaluate the import report. All of these must happen after the imported
+        // accounts are fully set up, so that a failure here never leaves committed
+        // accounts half-configured. The backup reminder is printed before propagating
+        // any error from these steps, as the minted-seed notice above refers to it.
         let post_import = derived_transparent_receivers(&mut db_data, &report)
             .and_then(|derived| {
                 register_watch_pubkeys(
@@ -603,7 +604,8 @@ impl MigrateZcashdWalletCmd {
                     &report,
                     exposure_height,
                     &derived,
-                )
+                )?;
+                expose_registered_script_addresses(&mut db_data, &report, exposure_height)
             })
             .and_then(|()| {
                 let document_account_count = document
@@ -826,6 +828,77 @@ fn expose_spending_key_addresses(
     }
     info!(
         "Marking {} imported transparent spending-key addresses as exposed",
+        to_expose.len(),
+    );
+    db_data
+        .mark_transparent_addresses_exposed(&to_expose)
+        .map_err(MigrateError::Database)
+}
+
+/// Selects the P2SH addresses among `receivers` that the wallet does not already
+/// consider exposed.
+///
+/// A P2SH address registered from a redeem script carries no derivation, so the
+/// child-index inference that the ZeWIF importer uses to fill in the exposures the
+/// document does not record directly cannot reach it. Any such address that the
+/// document's transactions did not already reveal is therefore left unexposed by the
+/// import, and needs marking here.
+///
+/// The result is sorted, so that a migration run marks exposures in a deterministic
+/// order regardless of the iteration order of the wallet's receiver map.
+fn unexposed_script_addresses(
+    receivers: impl IntoIterator<Item = (TransparentAddress, TransparentAddressMetadata)>,
+) -> Vec<TransparentAddress> {
+    // TODO: `receivers` is not examined yet, which is why the addresses of the
+    // imported redeem scripts are still left unexposed. See the failing test below.
+    let _ = receivers;
+    vec![]
+}
+
+/// Marks the P2SH addresses of the imported standalone redeem scripts (from zcashd's
+/// `importaddress <redeemscript>` and `addmultisigaddress`) as exposed as of
+/// `exposure_height`.
+///
+/// A redeem script reaches a zcashd wallet only because its P2SH address was already
+/// in use outside that wallet, so the address has been disclosed by the time it is
+/// migrated and the wallet's exposure metadata should say so. The ZeWIF importer
+/// cannot establish that on its own: it marks an address exposed only where the
+/// document accounts for an exposure of it, and the child-index inference that fills
+/// in the derived receivers the document does not mention cannot reach an address with
+/// no derivation. A P2SH address that never appeared in a migrated transaction is
+/// therefore left with no exposure height at all.
+///
+/// One consequence today is that the address goes unreported: `listaddresses` is built
+/// on `list_addresses`, which returns only exposed addresses, so an imported-but-never-
+/// funded P2SH address is invisible where zcashd always listed it. zcash/zallet#782
+/// proposes to report standalone imports from `get_transparent_receivers` instead,
+/// which applies no exposure filter; the exposure record needs to be right either way.
+///
+/// The registered scripts are read back from the wallet rather than recomputed from
+/// the document: the importer skips the redeem scripts the wallet cannot represent,
+/// and the standalone-script receivers of the accounts this import created are exactly
+/// the scripts it registered.
+fn expose_registered_script_addresses(
+    db_data: &mut DbHandle,
+    report: &ZewifImportReport,
+    exposure_height: BlockHeight,
+) -> Result<(), MigrateError> {
+    let mut to_expose = Vec::new();
+    for account in &report.imported_accounts {
+        let receivers = db_data
+            .get_transparent_receivers(account.account_uuid, true, true)
+            .map_err(MigrateError::Database)?;
+        to_expose.extend(
+            unexposed_script_addresses(receivers)
+                .into_iter()
+                .map(|address| (address, exposure_height)),
+        );
+    }
+    if to_expose.is_empty() {
+        return Ok(());
+    }
+    info!(
+        "Marking {} imported P2SH redeem script addresses as exposed",
         to_expose.len(),
     );
     db_data
@@ -1544,6 +1617,105 @@ mod tests {
                 &derived_receivers,
             ),
             vec![TransparentAddress::from_pubkey(&registered)],
+        );
+    }
+
+    /// Exposure marking after a migration covers exactly the P2SH addresses the
+    /// importer registered a redeem script for and did not already expose: a
+    /// standalone pubkey, a bare imported address and a derived receiver each belong
+    /// to another step, an address the import exposed keeps the height its
+    /// transactions established, and one the wallet cannot judge is marked, because
+    /// the migration knows what the wallet does not. The selection is returned in
+    /// address order, so a run does not depend on the iteration order of the wallet's
+    /// receiver map.
+    #[test]
+    fn unexposed_script_addresses_selects_only_unexposed_p2sh() {
+        use transparent::{
+            address::TransparentAddress,
+            keys::{NonHardenedChildIndex, TransparentKeyScope},
+        };
+        use zcash_client_backend::wallet::{Exposure, GapMetadata, TransparentAddressMetadata};
+        use zcash_script::script::{Code, Redeem};
+
+        // A P2PKH-shaped redeem script, with its hash varied per address so that no
+        // two registered scripts are identical.
+        let redeem = |byte: u8| {
+            let mut script = hex::decode("76a91411695b6cd891484c2d49ec5aa738ec2b2f89777788ac")
+                .expect("valid hex");
+            script[3] = byte;
+            Redeem::parse(&Code(script)).expect("valid redeem script")
+        };
+        let exposed = Exposure::Exposed {
+            at_height: BlockHeight::from_u32(100),
+            gap_metadata: GapMetadata::DerivationUnknown,
+        };
+        let pubkey = secp256k1::SecretKey::from_slice(&[0x01; 32])
+            .expect("valid secret key")
+            .public_key(&secp256k1::Secp256k1::new());
+
+        let unexposed_high = TransparentAddress::ScriptHash([0x0b; 20]);
+        let unexposed_low = TransparentAddress::ScriptHash([0x0a; 20]);
+        let unknowable = TransparentAddress::ScriptHash([0x0f; 20]);
+
+        let receivers = vec![
+            (
+                unexposed_high,
+                TransparentAddressMetadata::standalone_script(
+                    redeem(0x0b),
+                    Exposure::Unknown,
+                    None,
+                ),
+            ),
+            (
+                unexposed_low,
+                TransparentAddressMetadata::standalone_script(
+                    redeem(0x0a),
+                    Exposure::Unknown,
+                    None,
+                ),
+            ),
+            // Already exposed by the import, at the height its transactions revealed.
+            (
+                TransparentAddress::ScriptHash([0x0c; 20]),
+                TransparentAddressMetadata::standalone_script(redeem(0x0c), exposed, None),
+            ),
+            // The wallet cannot tell whether this one was exposed; the migration can.
+            // A redeem script reached the zcashd wallet only because its address was
+            // already in use outside it.
+            (
+                unknowable,
+                TransparentAddressMetadata::standalone_script(
+                    redeem(0x0f),
+                    Exposure::CannotKnow,
+                    None,
+                ),
+            ),
+            // Handled by `register_watch_pubkeys` / `expose_spending_key_addresses`.
+            (
+                TransparentAddress::from_pubkey(&pubkey),
+                TransparentAddressMetadata::standalone_p2pkh(pubkey, Exposure::Unknown, None),
+            ),
+            // A P2SH address imported without its redeem script: nothing to spend
+            // with, and not something this migration path registers.
+            (
+                TransparentAddress::ScriptHash([0x0d; 20]),
+                TransparentAddressMetadata::standalone_address(Exposure::Unknown, None),
+            ),
+            // Derived receivers keep the importer's gap-inferred exposure.
+            (
+                TransparentAddress::PublicKeyHash([0x0e; 20]),
+                TransparentAddressMetadata::derived(
+                    TransparentKeyScope::EXTERNAL,
+                    NonHardenedChildIndex::ZERO,
+                    Exposure::Unknown,
+                    None,
+                ),
+            ),
+        ];
+
+        assert_eq!(
+            super::unexposed_script_addresses(receivers),
+            vec![unexposed_low, unexposed_high, unknowable],
         );
     }
 

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -618,8 +618,9 @@ fn finish_import(
     exposure_height: BlockHeight,
     allow_partial_import: bool,
 ) -> Result<(), MigrateError> {
+    let tracked = tracked_transparent_receivers(db_data)?;
     let derived = derived_transparent_receivers(db_data, report)?;
-    register_watch_pubkeys(db_data, document, report, exposure_height, &derived)?;
+    register_watch_pubkeys(db_data, document, report, exposure_height, &tracked)?;
     expose_spending_key_addresses(db_data, document, report, exposure_height, &derived)?;
     register_watch_addresses(db_data, document, report, exposure_height)?;
     expose_registered_script_addresses(db_data, report, exposure_height)?;
@@ -689,12 +690,15 @@ fn derived_transparent_receivers(
 /// Collects the transparent receivers of every account in the wallet, standalone
 /// imports included.
 ///
-/// Watch-only address registration is checked against the whole wallet rather than
-/// the accounts this run imported. A migration can run against a wallet that already
-/// holds accounts, and the wallet rejects an import of an address another account has
-/// already imported; an address that is a derived receiver of another account must
-/// also keep the exposure its own derivation gives it, rather than be force-exposed
-/// as an import.
+/// Both watch-only registration steps check their candidates against this rather than
+/// against the accounts this run imported. A migration can run against a wallet that
+/// already holds accounts, and the wallet rejects an import of material another
+/// account has already imported; an address that is a derived receiver of another
+/// account must also keep the exposure its own derivation gives it, rather than be
+/// force-exposed as an import.
+///
+/// Each step reads its own set, as the steps before it register material that belongs
+/// in the sets after them.
 fn tracked_transparent_receivers(
     db_data: &mut DbHandle,
 ) -> Result<HashSet<TransparentAddress>, MigrateError> {
@@ -741,63 +745,89 @@ fn mark_addresses_exposed(
         .map_err(MigrateError::Database)
 }
 
+/// Selects the watch-only transparent pubkeys `account` records that the wallet does
+/// not already track, with the number of them declined for their serialization:
+/// uncompressed first, then unparsable.
+///
+/// zcashd recorded a watch-only pubkey (`importpubkey`) against the address it
+/// controls and no spend authority. An entry carrying a spend authority is the
+/// importer's to register, and one carrying neither is
+/// [`watched_addresses_to_import`]'s.
+fn account_watch_pubkeys(
+    account: &zewif::Account,
+    tracked: &HashSet<TransparentAddress>,
+) -> (Vec<PublicKey>, usize, usize) {
+    let mut to_import = Vec::new();
+    let mut uncompressed = 0usize;
+    let mut malformed = 0usize;
+    for address in account.addresses() {
+        if let zewif::ProtocolAddress::Transparent(t) = address.address()
+            && t.spend_authority().is_none()
+            && let Some(pubkey) = t.pubkey()
+        {
+            match pubkey.as_slice() {
+                bytes if bytes.len() == PUBLIC_KEY_SIZE => match PublicKey::from_slice(bytes) {
+                    Ok(pk) => to_import.push(pk),
+                    Err(_) => malformed += 1,
+                },
+                // `import_standalone_transparent_pubkeys` derives the stored P2PKH
+                // address from the compressed pubkey serialization, so an uncompressed
+                // pubkey would be tracked under a different address than zcashd had
+                // on-chain.
+                bytes if bytes.len() == UNCOMPRESSED_PUBLIC_KEY_SIZE => uncompressed += 1,
+                _ => malformed += 1,
+            }
+        }
+    }
+    to_import.retain(|pubkey| !tracked.contains(&TransparentAddress::from_pubkey(pubkey)));
+    (to_import, uncompressed, malformed)
+}
+
 /// Registers watch-only transparent pubkeys (from zcashd's `importpubkey`) with the
 /// accounts whose address lists carry them, exposing their addresses as of
 /// `exposure_height`.
 ///
 /// The ZeWIF importer registers spendable transparent keys from the secret store
 /// and P2SH redeem scripts, but has no path for pubkey-only (watch) addresses.
+///
+/// A pubkey whose address `tracked` already names is left alone, as in
+/// [`register_watch_addresses`]. The wallet rejects an import of a pubkey another
+/// account holds, which would fail a migration that has already committed; one this
+/// account holds is a no-op; and one held as a derived receiver — zcashd also stored
+/// seed-derived keys as watch entries — must keep the importer's gap-inferred
+/// exposure, as force-exposing it beyond the gap could hide funded addresses from
+/// seed recovery. An address the wallet tracks is not this step's to expose either:
+/// whatever exposure it carries was established by whatever registered it.
 fn register_watch_pubkeys(
     db_data: &mut DbHandle,
     document: &zewif::Zewif,
     report: &ZewifImportReport,
     exposure_height: BlockHeight,
-    derived_receivers: &HashSet<TransparentAddress>,
+    tracked: &HashSet<TransparentAddress>,
 ) -> Result<(), MigrateError> {
     let mut skipped_uncompressed_watch_pubkeys = 0usize;
     let mut skipped_malformed_watch_pubkeys = 0usize;
     for (account_uuid, account) in imported_document_accounts(document, report) {
-        let mut watch_pubkeys = Vec::new();
-        for address in account.addresses() {
-            if let zewif::ProtocolAddress::Transparent(t) = address.address()
-                && t.spend_authority().is_none()
-                && let Some(pubkey) = t.pubkey()
-            {
-                match pubkey.as_slice() {
-                    bytes if bytes.len() == PUBLIC_KEY_SIZE => match PublicKey::from_slice(bytes) {
-                        Ok(pk) => watch_pubkeys.push(pk),
-                        Err(_) => skipped_malformed_watch_pubkeys += 1,
-                    },
-                    // `import_standalone_transparent_pubkeys` derives the stored P2PKH
-                    // address from the compressed pubkey serialization, so an
-                    // uncompressed pubkey would be tracked under a different address
-                    // than zcashd had on-chain.
-                    bytes if bytes.len() == UNCOMPRESSED_PUBLIC_KEY_SIZE => {
-                        skipped_uncompressed_watch_pubkeys += 1
-                    }
-                    _ => skipped_malformed_watch_pubkeys += 1,
-                }
-            }
+        let (watch_pubkeys, uncompressed, malformed) = account_watch_pubkeys(account, tracked);
+        skipped_uncompressed_watch_pubkeys += uncompressed;
+        skipped_malformed_watch_pubkeys += malformed;
+        if watch_pubkeys.is_empty() {
+            continue;
         }
-        if !watch_pubkeys.is_empty() {
-            info!(
-                "Registering {} watch-only transparent pubkeys with account '{}'",
-                watch_pubkeys.len(),
-                account.name(),
-            );
-            // A watched pubkey may coincide with one of the wallet's own derived
-            // receivers; those keep the importer's gap-inferred exposure.
-            let to_expose: Vec<(TransparentAddress, BlockHeight)> = watch_pubkeys
-                .iter()
-                .map(TransparentAddress::from_pubkey)
-                .filter(|address| !derived_receivers.contains(address))
-                .map(|address| (address, exposure_height))
-                .collect();
-            db_data
-                .import_standalone_transparent_pubkeys(account_uuid, watch_pubkeys.into_iter())
-                .map_err(MigrateError::Database)?;
-            mark_addresses_exposed(db_data, &to_expose)?;
-        }
+        info!(
+            "Registering {} watch-only transparent pubkeys with account '{}'",
+            watch_pubkeys.len(),
+            account.name(),
+        );
+        let to_expose: Vec<(TransparentAddress, BlockHeight)> = watch_pubkeys
+            .iter()
+            .map(TransparentAddress::from_pubkey)
+            .map(|address| (address, exposure_height))
+            .collect();
+        db_data
+            .import_standalone_transparent_pubkeys(account_uuid, watch_pubkeys.into_iter())
+            .map_err(MigrateError::Database)?;
+        mark_addresses_exposed(db_data, &to_expose)?;
     }
     if skipped_uncompressed_watch_pubkeys > 0 {
         warn!(
@@ -1995,6 +2025,67 @@ mod tests {
             });
         }
         report
+    }
+
+    /// A watched pubkey whose address the wallet already tracks is not this step's to
+    /// register: the wallet rejects an import of a pubkey another account holds, which
+    /// would fail a migration that has already committed, and an address held as a
+    /// derived receiver must keep the exposure its derivation gives it. An entry with a
+    /// spend authority belongs to the importer and one with no key material at all to
+    /// `register_watch_addresses`, while a pubkey zcashd stored uncompressed is counted
+    /// rather than tracked under an address zcashd never used.
+    #[test]
+    fn watch_pubkeys_exclude_what_the_wallet_already_tracks() {
+        use transparent::address::TransparentAddress;
+
+        let secp = secp256k1::Secp256k1::new();
+        let key = |byte: u8| {
+            secp256k1::SecretKey::from_slice(&[byte; 32])
+                .expect("valid secret key")
+                .public_key(&secp)
+        };
+        let fresh = key(0x01);
+        let already_tracked = key(0x02);
+        let uncompressed = key(0x03);
+        let spendable = key(0x04);
+
+        let pubkey_entry = |pubkey: &secp256k1::PublicKey, bytes: Vec<u8>| {
+            let mut entry = watched_taddr(TransparentAddress::from_pubkey(pubkey));
+            entry.set_pubkey(
+                zewif::transparent::TransparentPubKey::from_bytes(bytes)
+                    .expect("valid pubkey bytes"),
+            );
+            entry
+        };
+
+        let mut spendable_entry = pubkey_entry(&spendable, spendable.serialize().to_vec());
+        spendable_entry
+            .set_spend_authority(zewif::transparent::TransparentSpendAuthority::Imported);
+
+        let account = account_with(
+            "Legacy",
+            vec![
+                document_address(pubkey_entry(&fresh, fresh.serialize().to_vec())),
+                document_address(pubkey_entry(
+                    &already_tracked,
+                    already_tracked.serialize().to_vec(),
+                )),
+                document_address(pubkey_entry(
+                    &uncompressed,
+                    uncompressed.serialize_uncompressed().to_vec(),
+                )),
+                document_address(spendable_entry),
+                document_address(watched_taddr(TransparentAddress::ScriptHash([0x05; 20]))),
+            ],
+        );
+
+        assert_eq!(
+            super::account_watch_pubkeys(
+                &account,
+                &HashSet::from([TransparentAddress::from_pubkey(&already_tracked)]),
+            ),
+            (vec![fresh], 1, 0),
+        );
     }
 
     /// The addresses registered as bare watch-only imports are the ones the import

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -5,7 +5,10 @@ use abscissa_core::Runnable;
 
 use bip0039::{Count, English, Mnemonic};
 use rand::{RngCore, rngs::OsRng};
-use secp256k1::{PublicKey, constants::PUBLIC_KEY_SIZE};
+use secp256k1::{
+    PublicKey,
+    constants::{PUBLIC_KEY_SIZE, UNCOMPRESSED_PUBLIC_KEY_SIZE},
+};
 use secrecy::{SecretVec, Zeroize};
 use transparent::address::TransparentAddress;
 use zcash_client_backend::data_api::{
@@ -752,6 +755,7 @@ fn register_watch_pubkeys(
     derived_receivers: &HashSet<TransparentAddress>,
 ) -> Result<(), MigrateError> {
     let mut skipped_uncompressed_watch_pubkeys = 0usize;
+    let mut skipped_malformed_watch_pubkeys = 0usize;
     for (account_uuid, account) in imported_document_accounts(document, report) {
         let mut watch_pubkeys = Vec::new();
         for address in account.addresses() {
@@ -759,16 +763,19 @@ fn register_watch_pubkeys(
                 && t.spend_authority().is_none()
                 && let Some(pubkey) = t.pubkey()
             {
-                // `import_standalone_transparent_pubkeys` derives the stored
-                // P2PKH address from the compressed pubkey serialization, so an
-                // uncompressed pubkey would be tracked under a different
-                // address than zcashd had on-chain.
-                if pubkey.as_slice().len() == PUBLIC_KEY_SIZE
-                    && let Ok(pk) = PublicKey::from_slice(pubkey.as_slice())
-                {
-                    watch_pubkeys.push(pk);
-                } else {
-                    skipped_uncompressed_watch_pubkeys += 1;
+                match pubkey.as_slice() {
+                    bytes if bytes.len() == PUBLIC_KEY_SIZE => match PublicKey::from_slice(bytes) {
+                        Ok(pk) => watch_pubkeys.push(pk),
+                        Err(_) => skipped_malformed_watch_pubkeys += 1,
+                    },
+                    // `import_standalone_transparent_pubkeys` derives the stored P2PKH
+                    // address from the compressed pubkey serialization, so an
+                    // uncompressed pubkey would be tracked under a different address
+                    // than zcashd had on-chain.
+                    bytes if bytes.len() == UNCOMPRESSED_PUBLIC_KEY_SIZE => {
+                        skipped_uncompressed_watch_pubkeys += 1
+                    }
+                    _ => skipped_malformed_watch_pubkeys += 1,
                 }
             }
         }
@@ -794,9 +801,15 @@ fn register_watch_pubkeys(
     }
     if skipped_uncompressed_watch_pubkeys > 0 {
         warn!(
-            "Skipped {} watch-only entries with uncompressed or malformed public \
-             keys; Zallet only supports compressed-form pubkey imports.",
+            "Skipped {} watch-only entries whose public keys zcashd stored in \
+             uncompressed form; Zallet only supports compressed-form pubkey imports.",
             skipped_uncompressed_watch_pubkeys,
+        );
+    }
+    if skipped_malformed_watch_pubkeys > 0 {
+        warn!(
+            "Skipped {} watch-only entries whose public keys could not be parsed.",
+            skipped_malformed_watch_pubkeys,
         );
     }
     Ok(())

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -11,7 +11,9 @@ use transparent::address::TransparentAddress;
 use zcash_client_backend::data_api::{
     Account as _, AccountSource, WalletRead, WalletWrite as _, chain::ChainState,
 };
-use zcash_client_backend::wallet::TransparentAddressMetadata;
+use zcash_client_backend::wallet::{
+    Exposure, TransparentAddressMetadata, TransparentAddressSource,
+};
 use zcash_client_sqlite::error::SqliteClientError;
 use zcash_client_sqlite::zewif::{
     AccountSkipReason, DiscardSecrets, SecretSink, SkippedAccount, SkippedTransparentKey,
@@ -849,10 +851,16 @@ fn expose_spending_key_addresses(
 fn unexposed_script_addresses(
     receivers: impl IntoIterator<Item = (TransparentAddress, TransparentAddressMetadata)>,
 ) -> Vec<TransparentAddress> {
-    // TODO: `receivers` is not examined yet, which is why the addresses of the
-    // imported redeem scripts are still left unexposed. See the failing test below.
-    let _ = receivers;
-    vec![]
+    let mut addresses = receivers
+        .into_iter()
+        .filter(|(_, meta)| {
+            matches!(meta.source(), TransparentAddressSource::StandaloneScript(_))
+                && !matches!(meta.exposure(), Exposure::Exposed { .. })
+        })
+        .map(|(address, _)| address)
+        .collect::<Vec<_>>();
+    addresses.sort();
+    addresses
 }
 
 /// Marks the P2SH addresses of the imported standalone redeem scripts (from zcashd's

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -585,12 +585,13 @@ impl MigrateZcashdWalletCmd {
             .map(|cs| BlockHeight::from_u32(u32::from(cs.height()) + 1))
             .or(no_scan_birthday_estimate)
             .unwrap_or(sapling_activation);
-        // The import has committed: register watch-only transparent pubkeys, expose
-        // the addresses of the imported standalone spending keys and redeem scripts,
-        // then evaluate the import report. All of these must happen after the imported
-        // accounts are fully set up, so that a failure here never leaves committed
-        // accounts half-configured. The backup reminder is printed before propagating
-        // any error from these steps, as the minted-seed notice above refers to it.
+        // The import has committed: register the watch-only transparent material the
+        // importer has no path for, expose the addresses of the imported standalone
+        // spending keys and redeem scripts, then evaluate the import report. All of
+        // these must happen after the imported accounts are fully set up, so that a
+        // failure here never leaves committed accounts half-configured. The backup
+        // reminder is printed before propagating any error from these steps, as the
+        // minted-seed notice above refers to it.
         let post_import = derived_transparent_receivers(&mut db_data, &report)
             .and_then(|derived| {
                 register_watch_pubkeys(
@@ -607,6 +608,7 @@ impl MigrateZcashdWalletCmd {
                     exposure_height,
                     &derived,
                 )?;
+                register_watch_addresses(&mut db_data, &document, &report, exposure_height)?;
                 expose_registered_script_addresses(&mut db_data, &report, exposure_height)
             })
             .and_then(|()| {
@@ -681,6 +683,30 @@ fn derived_transparent_receivers(
         );
     }
     Ok(derived)
+}
+
+/// Collects the transparent receivers of every account in the wallet, standalone
+/// imports included.
+///
+/// Watch-only address registration is checked against the whole wallet rather than
+/// the accounts this run imported. A migration can run against a wallet that already
+/// holds accounts, and the wallet rejects an import of an address another account has
+/// already imported; an address that is a derived receiver of another account must
+/// also keep the exposure its own derivation gives it, rather than be force-exposed
+/// as an import.
+fn tracked_transparent_receivers(
+    db_data: &mut DbHandle,
+) -> Result<HashSet<TransparentAddress>, MigrateError> {
+    let mut tracked = HashSet::new();
+    for account_id in db_data.get_account_ids().map_err(MigrateError::Database)? {
+        tracked.extend(
+            db_data
+                .get_transparent_receivers(account_id, true, true)
+                .map_err(MigrateError::Database)?
+                .into_keys(),
+        );
+    }
+    Ok(tracked)
 }
 
 /// Registers watch-only transparent pubkeys (from zcashd's `importpubkey`) with the
@@ -832,6 +858,109 @@ fn expose_spending_key_addresses(
         "Marking {} imported transparent spending-key addresses as exposed",
         to_expose.len(),
     );
+    db_data
+        .mark_transparent_addresses_exposed(&to_expose)
+        .map_err(MigrateError::Database)
+}
+
+/// A transparent address that zcashd watched and that the document records without
+/// key material Zallet can import, together with the account that records it and the
+/// height at which it is known to have been disclosed.
+struct WatchedAddress {
+    account_uuid: zcash_client_sqlite::AccountUuid,
+    address: TransparentAddress,
+    exposure_height: BlockHeight,
+}
+
+/// Selects the watch-only transparent addresses of the imported accounts that the
+/// wallet does not track after the import, and so must be registered as bare
+/// addresses for the migration not to lose them.
+///
+/// A candidate is an address the document records with neither a spend authority nor
+/// a public key: zcashd's `importaddress <address>` records exactly that, and so does
+/// `importaddress <redeemscript>` for the script's P2SH address. Key material the
+/// import deliberately declined keeps that treatment, because the address still
+/// carries the material: an uncompressed public key is excluded here as it is in
+/// [`register_watch_pubkeys`], which warns rather than track the address zcashd never
+/// used.
+///
+/// `tracked` names the receivers the wallet holds once the import and the
+/// registration steps before this one have run, and removing them is what leaves only
+/// the addresses that need registering. Deciding that here instead — by mirroring the
+/// rules the wallet applies to a redeem script — would let the two drift apart: a
+/// script the wallet can represent is tracked under its P2SH address already, and one
+/// it cannot (non-multisig, or beyond the 520-byte P2SH limit) is not tracked at all,
+/// and is reached by this step precisely because the wallet dropped it.
+///
+/// An address the document records an exposure height for takes that height, as the
+/// import would have done had it recognized the address; the rest take
+/// `exposure_height`. The result is sorted, so that a migration run registers
+/// addresses in a deterministic order, and an address recorded by more than one
+/// account is registered once, under the first account that records it: the wallet
+/// rejects an import of the same address into a second account.
+///
+/// Returns the selected addresses along with the number of address strings that could
+/// not be decoded for this network, which the caller warns about.
+fn watched_addresses_to_import<P: Parameters>(
+    document: &zewif::Zewif,
+    report: &ZewifImportReport,
+    tracked: &HashSet<TransparentAddress>,
+    params: &P,
+    exposure_height: BlockHeight,
+) -> (Vec<WatchedAddress>, usize) {
+    // TODO: the document is not examined yet, which is why the addresses zcashd
+    // watched without key material are still dropped. See the failing tests below.
+    let _ = (document, report, tracked, params, exposure_height);
+    (vec![], 0)
+}
+
+/// Registers the transparent addresses that zcashd watched but for which no key
+/// material reached the wallet (from zcashd's `importaddress <address>`, and from the
+/// redeem scripts the wallet cannot represent) as bare watch-only addresses, exposing
+/// each as of the height at which it was disclosed.
+///
+/// zcashd watched such an address, so a migration that dropped it would stop
+/// reporting funds the source wallet could see. The ZeWIF importer has no path for
+/// one: it registers spendable transparent keys and representable P2SH redeem
+/// scripts, and counts every other address the document records in
+/// `addresses_not_recognized`. The Zallet wallet can hold a bare transparent address
+/// — `zallet import-address` takes one — so the migration registers it here rather
+/// than warning that it was skipped. Without key material such an address cannot be
+/// spent from, which is what it was in zcashd as well.
+///
+/// This runs after the registration steps that precede it, so that the receivers read
+/// back here account for everything they added.
+fn register_watch_addresses(
+    db_data: &mut DbHandle,
+    document: &zewif::Zewif,
+    report: &ZewifImportReport,
+    exposure_height: BlockHeight,
+) -> Result<(), MigrateError> {
+    let tracked = tracked_transparent_receivers(db_data)?;
+    let params = *db_data.params();
+    let (to_import, undecodable) =
+        watched_addresses_to_import(document, report, &tracked, &params, exposure_height);
+    if undecodable > 0 {
+        warn!(
+            "Skipped {} watch-only transparent addresses that could not be decoded for \
+             this network.",
+            undecodable,
+        );
+    }
+    if to_import.is_empty() {
+        return Ok(());
+    }
+    info!(
+        "Registering {} watch-only transparent addresses that carry no key material",
+        to_import.len(),
+    );
+    let mut to_expose = Vec::with_capacity(to_import.len());
+    for watched in to_import {
+        db_data
+            .import_standalone_transparent_address(watched.account_uuid, watched.address)
+            .map_err(MigrateError::Database)?;
+        to_expose.push((watched.address, watched.exposure_height));
+    }
     db_data
         .mark_transparent_addresses_exposed(&to_expose)
         .map_err(MigrateError::Database)
@@ -1520,9 +1649,9 @@ mod tests {
     use zcash_protocol::consensus::{BlockHeight, NetworkType};
 
     use super::{
-        BlockHash, HashMap, MigrateError, MigrateZcashdWalletCmd, ZCASHD_LEGACY_ACCOUNT_INDEX,
-        ZCASHD_LEGACY_SOURCE, backfill_mined_heights, check_import_report,
-        derive_regtest_activations, describe_skipped_items, enriched_document,
+        BlockHash, HashMap, HashSet, MigrateError, MigrateZcashdWalletCmd,
+        ZCASHD_LEGACY_ACCOUNT_INDEX, ZCASHD_LEGACY_SOURCE, backfill_mined_heights,
+        check_import_report, derive_regtest_activations, describe_skipped_items, enriched_document,
         has_seedless_legacy_account, mint_legacy_mnemonic, to_zewif_frontier,
     };
 
@@ -1614,8 +1743,7 @@ mod tests {
             reason: TransparentKeySkipReason::UncompressedPubKey,
         });
 
-        let derived_receivers =
-            std::collections::HashSet::from([TransparentAddress::from_pubkey(&derived)]);
+        let derived_receivers = HashSet::from([TransparentAddress::from_pubkey(&derived)]);
 
         assert_eq!(
             super::registered_spending_key_addresses(
@@ -1703,8 +1831,8 @@ mod tests {
                 TransparentAddress::from_pubkey(&pubkey),
                 TransparentAddressMetadata::standalone_p2pkh(pubkey, Exposure::Unknown, None),
             ),
-            // A P2SH address imported without its redeem script: nothing to spend
-            // with, and not something this migration path registers.
+            // A P2SH address held without its redeem script belongs to
+            // `register_watch_addresses`, which exposes what it registers.
             (
                 TransparentAddress::ScriptHash([0x0d; 20]),
                 TransparentAddressMetadata::standalone_address(Exposure::Unknown, None),
@@ -1724,6 +1852,241 @@ mod tests {
         assert_eq!(
             super::unexposed_script_addresses(receivers),
             vec![unexposed_low, unexposed_high, unknowable],
+        );
+    }
+
+    /// A document address entry for `address`, as zcashd's `importaddress <address>`
+    /// records one: watched, with no key material of any kind.
+    fn watched_taddr(
+        address: transparent::address::TransparentAddress,
+    ) -> zewif::transparent::Address {
+        use zcash_keys::encoding::AddressCodec;
+        use zcash_protocol::consensus::MAIN_NETWORK;
+
+        zewif::transparent::Address::new(address.encode(&MAIN_NETWORK))
+    }
+
+    /// Wraps a transparent address entry as the document records it on an account.
+    fn document_address(taddr: zewif::transparent::Address) -> zewif::Address {
+        zewif::Address::new(zewif::ProtocolAddress::Transparent(taddr))
+    }
+
+    /// A redeem script recorded on a document address. Its contents do not matter to
+    /// the selection, only whether the address carries one and whether the wallet
+    /// ended up tracking the address it hashes to.
+    fn recorded_redeem_script() -> zewif::Script {
+        zewif::Script::from(zewif::Data::from_vec(vec![0x51]))
+    }
+
+    /// A document account named `name`, recording `addresses`.
+    fn account_with(name: &str, addresses: Vec<zewif::Address>) -> zewif::Account {
+        let mut account = zewif::Account::new(zewif::AccountViewingKey::TransparentAddressSet);
+        account.set_name(name);
+        for address in addresses {
+            account.add_address(address);
+        }
+        account
+    }
+
+    /// A single-wallet document holding `accounts`, in the order given.
+    fn document_with(accounts: Vec<zewif::Account>) -> zewif::Zewif {
+        let mut wallet = zewif::ZewifWallet::new(zewif::Network::Mainnet);
+        for account in accounts {
+            wallet.add_account(account);
+        }
+        let mut document = zewif::Zewif::new(
+            zewif::BlockHeight::from_u32(2_000_000),
+            zewif::BlockHash::from_bytes([9u8; 32]),
+        );
+        document.add_wallet(wallet);
+        document
+    }
+
+    /// An import report naming the accounts a migration run created.
+    fn report_with(accounts: &[(&str, AccountUuid)]) -> ZewifImportReport {
+        let mut report = ZewifImportReport::default();
+        for (name, account_uuid) in accounts {
+            report.imported_accounts.push(ImportedAccount {
+                name: (*name).into(),
+                account_uuid: *account_uuid,
+                birthday_basis: BirthdayBasis::ChainState,
+            });
+        }
+        report
+    }
+
+    /// The addresses registered as bare watch-only imports are the ones the import
+    /// left untracked: zcashd's `importaddress <address>` records no key material at
+    /// all, and a redeem script the wallet cannot represent leaves its P2SH address
+    /// with none the wallet could keep. Material the import did handle is tracked
+    /// already, material it declined keeps that treatment, and an address recorded by
+    /// an account this run did not import has no account to be registered against.
+    #[test]
+    fn watched_addresses_cover_only_what_the_import_left_untracked() {
+        use transparent::address::TransparentAddress;
+        use zcash_protocol::consensus::MAIN_NETWORK;
+
+        let pubkey = secp256k1::SecretKey::from_slice(&[0x01; 32])
+            .expect("valid secret key")
+            .public_key(&secp256k1::Secp256k1::new());
+
+        let bare_p2pkh = TransparentAddress::PublicKeyHash([0x01; 20]);
+        let bare_p2sh = TransparentAddress::ScriptHash([0x02; 20]);
+        let script_registered = TransparentAddress::ScriptHash([0x03; 20]);
+        let script_dropped = TransparentAddress::ScriptHash([0x04; 20]);
+        let spendable = TransparentAddress::PublicKeyHash([0x05; 20]);
+        let unowned = TransparentAddress::ScriptHash([0x06; 20]);
+
+        // A redeem script the wallet could represent: registered by the import, and
+        // so tracked under its P2SH address by the time this step runs.
+        let mut registered_entry = watched_taddr(script_registered);
+        registered_entry.set_redeem_script(recorded_redeem_script());
+        // One it could not (non-multisig, or beyond the P2SH size limit): dropped by
+        // the import, leaving the address tracked by nothing.
+        let mut dropped_entry = watched_taddr(script_dropped);
+        dropped_entry.set_redeem_script(recorded_redeem_script());
+        // A watched pubkey belongs to `register_watch_pubkeys`, which registers the
+        // key itself and so tracks the address as spendable-shaped material.
+        let mut pubkey_entry = watched_taddr(TransparentAddress::from_pubkey(&pubkey));
+        pubkey_entry.set_pubkey(
+            zewif::transparent::TransparentPubKey::from_bytes(pubkey.serialize().to_vec())
+                .expect("valid pubkey bytes"),
+        );
+        // An address the wallet holds a spending key for belongs to the import and to
+        // `expose_spending_key_addresses`.
+        let mut spendable_entry = watched_taddr(spendable);
+        spendable_entry
+            .set_spend_authority(zewif::transparent::TransparentSpendAuthority::Imported);
+
+        let document = document_with(vec![
+            account_with(
+                "Legacy",
+                vec![
+                    document_address(watched_taddr(bare_p2sh)),
+                    document_address(watched_taddr(bare_p2pkh)),
+                    document_address(registered_entry),
+                    document_address(dropped_entry),
+                    document_address(pubkey_entry),
+                    document_address(spendable_entry),
+                ],
+            ),
+            account_with(
+                "Not imported",
+                vec![document_address(watched_taddr(unowned))],
+            ),
+        ]);
+
+        let account_uuid = AccountUuid::from_uuid(uuid::Uuid::from_bytes([0x0a; 16]));
+        let tracked = HashSet::from([script_registered]);
+
+        let (to_import, undecodable) = super::watched_addresses_to_import(
+            &document,
+            &report_with(&[("Legacy", account_uuid)]),
+            &tracked,
+            &MAIN_NETWORK,
+            BlockHeight::from_u32(500),
+        );
+
+        assert_eq!(undecodable, 0);
+        assert_eq!(
+            to_import
+                .into_iter()
+                .map(|watched| (watched.account_uuid, watched.address))
+                .collect::<Vec<_>>(),
+            vec![
+                (account_uuid, bare_p2pkh),
+                (account_uuid, bare_p2sh),
+                (account_uuid, script_dropped),
+            ],
+        );
+    }
+
+    /// An address the document records an exposure height for takes that height: it
+    /// is the height at which the address was seen, and is what the import would have
+    /// applied had it recognized the address. The rest take the migration's own
+    /// exposure height; the disclosure that put such an address into a zcashd wallet
+    /// happened before the migration either way.
+    #[test]
+    fn watched_addresses_take_the_documents_exposure_height_where_it_records_one() {
+        use transparent::address::TransparentAddress;
+        use zcash_protocol::consensus::MAIN_NETWORK;
+
+        let recorded = TransparentAddress::ScriptHash([0x01; 20]);
+        let unrecorded = TransparentAddress::ScriptHash([0x02; 20]);
+
+        let mut recorded_entry = document_address(watched_taddr(recorded));
+        recorded_entry.set_exposed_at_height(zewif::BlockHeight::from_u32(123));
+
+        let document = document_with(vec![account_with(
+            "Legacy",
+            vec![recorded_entry, document_address(watched_taddr(unrecorded))],
+        )]);
+        let account_uuid = AccountUuid::from_uuid(uuid::Uuid::from_bytes([0x0a; 16]));
+
+        let (to_import, _) = super::watched_addresses_to_import(
+            &document,
+            &report_with(&[("Legacy", account_uuid)]),
+            &HashSet::new(),
+            &MAIN_NETWORK,
+            BlockHeight::from_u32(500),
+        );
+
+        assert_eq!(
+            to_import
+                .into_iter()
+                .map(|watched| (watched.address, watched.exposure_height))
+                .collect::<Vec<_>>(),
+            vec![
+                (recorded, BlockHeight::from_u32(123)),
+                (unrecorded, BlockHeight::from_u32(500)),
+            ],
+        );
+    }
+
+    /// The wallet rejects an import of an address that another account already holds,
+    /// so an address recorded by two accounts is registered once, under the first that
+    /// records it. An address string the wallet cannot decode for its own network is
+    /// counted for the caller to warn about: no account can hold it, and one such
+    /// entry is not worth failing a migration that has already committed.
+    #[test]
+    fn watched_addresses_are_registered_once_and_undecodable_strings_counted() {
+        use transparent::address::TransparentAddress;
+        use zcash_keys::encoding::AddressCodec;
+        use zcash_protocol::consensus::{MAIN_NETWORK, TEST_NETWORK};
+
+        let shared = TransparentAddress::ScriptHash([0x01; 20]);
+        let first = AccountUuid::from_uuid(uuid::Uuid::from_bytes([0x0a; 16]));
+        let second = AccountUuid::from_uuid(uuid::Uuid::from_bytes([0x0b; 16]));
+
+        let document = document_with(vec![
+            account_with(
+                "First",
+                vec![
+                    document_address(watched_taddr(shared)),
+                    document_address(zewif::transparent::Address::new("not an address")),
+                    document_address(zewif::transparent::Address::new(
+                        TransparentAddress::ScriptHash([0x02; 20]).encode(&TEST_NETWORK),
+                    )),
+                ],
+            ),
+            account_with("Second", vec![document_address(watched_taddr(shared))]),
+        ]);
+
+        let (to_import, undecodable) = super::watched_addresses_to_import(
+            &document,
+            &report_with(&[("First", first), ("Second", second)]),
+            &HashSet::new(),
+            &MAIN_NETWORK,
+            BlockHeight::from_u32(500),
+        );
+
+        assert_eq!(undecodable, 2);
+        assert_eq!(
+            to_import
+                .into_iter()
+                .map(|watched| (watched.account_uuid, watched.address))
+                .collect::<Vec<_>>(),
+            vec![(first, shared)],
         );
     }
 

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -732,55 +732,45 @@ fn register_watch_pubkeys(
     exposure_height: BlockHeight,
     derived_receivers: &HashSet<TransparentAddress>,
 ) -> Result<(), MigrateError> {
-    let accounts_by_name: HashMap<&str, zcash_client_sqlite::AccountUuid> = report
-        .imported_accounts
-        .iter()
-        .map(|a| (a.name.as_str(), a.account_uuid))
-        .collect();
     let mut skipped_uncompressed_watch_pubkeys = 0usize;
-    for wallet in document.wallets() {
-        for account in wallet.accounts() {
-            let Some(account_uuid) = accounts_by_name.get(account.name()) else {
-                continue;
-            };
-            let mut watch_pubkeys = Vec::new();
-            for address in account.addresses() {
-                if let zewif::ProtocolAddress::Transparent(t) = address.address()
-                    && t.spend_authority().is_none()
-                    && let Some(pubkey) = t.pubkey()
-                {
-                    // `import_standalone_transparent_pubkeys` derives the stored
-                    // P2PKH address from the compressed pubkey serialization, so an
-                    // uncompressed pubkey would be tracked under a different
-                    // address than zcashd had on-chain.
-                    match PublicKey::from_slice(pubkey.as_slice()) {
-                        Ok(pk) if pubkey.as_slice().len() == 33 => watch_pubkeys.push(pk),
-                        _ => skipped_uncompressed_watch_pubkeys += 1,
-                    }
+    for (account_uuid, account) in imported_document_accounts(document, report) {
+        let mut watch_pubkeys = Vec::new();
+        for address in account.addresses() {
+            if let zewif::ProtocolAddress::Transparent(t) = address.address()
+                && t.spend_authority().is_none()
+                && let Some(pubkey) = t.pubkey()
+            {
+                // `import_standalone_transparent_pubkeys` derives the stored
+                // P2PKH address from the compressed pubkey serialization, so an
+                // uncompressed pubkey would be tracked under a different
+                // address than zcashd had on-chain.
+                match PublicKey::from_slice(pubkey.as_slice()) {
+                    Ok(pk) if pubkey.as_slice().len() == 33 => watch_pubkeys.push(pk),
+                    _ => skipped_uncompressed_watch_pubkeys += 1,
                 }
             }
-            if !watch_pubkeys.is_empty() {
-                info!(
-                    "Registering {} watch-only transparent pubkeys with account '{}'",
-                    watch_pubkeys.len(),
-                    account.name(),
-                );
-                // A watched pubkey may coincide with one of the wallet's own derived
-                // receivers; those keep the importer's gap-inferred exposure.
-                let to_expose: Vec<(TransparentAddress, BlockHeight)> = watch_pubkeys
-                    .iter()
-                    .map(TransparentAddress::from_pubkey)
-                    .filter(|address| !derived_receivers.contains(address))
-                    .map(|address| (address, exposure_height))
-                    .collect();
+        }
+        if !watch_pubkeys.is_empty() {
+            info!(
+                "Registering {} watch-only transparent pubkeys with account '{}'",
+                watch_pubkeys.len(),
+                account.name(),
+            );
+            // A watched pubkey may coincide with one of the wallet's own derived
+            // receivers; those keep the importer's gap-inferred exposure.
+            let to_expose: Vec<(TransparentAddress, BlockHeight)> = watch_pubkeys
+                .iter()
+                .map(TransparentAddress::from_pubkey)
+                .filter(|address| !derived_receivers.contains(address))
+                .map(|address| (address, exposure_height))
+                .collect();
+            db_data
+                .import_standalone_transparent_pubkeys(account_uuid, watch_pubkeys.into_iter())
+                .map_err(MigrateError::Database)?;
+            if !to_expose.is_empty() {
                 db_data
-                    .import_standalone_transparent_pubkeys(*account_uuid, watch_pubkeys.into_iter())
+                    .mark_transparent_addresses_exposed(&to_expose)
                     .map_err(MigrateError::Database)?;
-                if !to_expose.is_empty() {
-                    db_data
-                        .mark_transparent_addresses_exposed(&to_expose)
-                        .map_err(MigrateError::Database)?;
-                }
             }
         }
     }
@@ -792,6 +782,34 @@ fn register_watch_pubkeys(
         );
     }
     Ok(())
+}
+
+/// Pairs each of the document's accounts that the import created a wallet account
+/// for with the UUID of that wallet account.
+///
+/// The document names accounts and the import report records the UUID each was
+/// created as, so matching the two by name is what lets a step that reads the
+/// document address the wallet rows it produced. An account the import did not
+/// create — one it skipped — is left out, as there is nothing to register against.
+fn imported_document_accounts<'a>(
+    document: &'a zewif::Zewif,
+    report: &ZewifImportReport,
+) -> Vec<(zcash_client_sqlite::AccountUuid, &'a zewif::Account)> {
+    let accounts_by_name: HashMap<&str, zcash_client_sqlite::AccountUuid> = report
+        .imported_accounts
+        .iter()
+        .map(|a| (a.name.as_str(), a.account_uuid))
+        .collect();
+    document
+        .wallets()
+        .iter()
+        .flat_map(|wallet| wallet.accounts())
+        .filter_map(|account| {
+            accounts_by_name
+                .get(account.name())
+                .map(|account_uuid| (*account_uuid, account))
+        })
+        .collect()
 }
 
 /// Computes the P2PKH addresses of the standalone transparent spending keys that
@@ -918,41 +936,31 @@ fn watched_addresses_to_import<P: Parameters>(
     params: &P,
     exposure_height: BlockHeight,
 ) -> (Vec<WatchedAddress>, usize) {
-    let accounts_by_name: HashMap<&str, zcash_client_sqlite::AccountUuid> = report
-        .imported_accounts
-        .iter()
-        .map(|a| (a.name.as_str(), a.account_uuid))
-        .collect();
     let mut undecodable = 0usize;
     let mut seen = HashSet::new();
     let mut to_import = Vec::new();
-    for wallet in document.wallets() {
-        for account in wallet.accounts() {
-            let Some(account_uuid) = accounts_by_name.get(account.name()) else {
+    for (account_uuid, account) in imported_document_accounts(document, report) {
+        for address in account.addresses() {
+            let zewif::ProtocolAddress::Transparent(taddr) = address.address() else {
                 continue;
             };
-            for address in account.addresses() {
-                let zewif::ProtocolAddress::Transparent(taddr) = address.address() else {
-                    continue;
-                };
-                if taddr.spend_authority().is_some() || taddr.pubkey().is_some() {
-                    continue;
-                }
-                let Ok(decoded) = TransparentAddress::decode(params, taddr.address()) else {
-                    undecodable += 1;
-                    continue;
-                };
-                if tracked.contains(&decoded) || !seen.insert(decoded) {
-                    continue;
-                }
-                to_import.push(WatchedAddress {
-                    account_uuid: *account_uuid,
-                    address: decoded,
-                    exposure_height: address
-                        .exposed_at_height()
-                        .map_or(exposure_height, |h| BlockHeight::from(u32::from(h))),
-                });
+            if taddr.spend_authority().is_some() || taddr.pubkey().is_some() {
+                continue;
             }
+            let Ok(decoded) = TransparentAddress::decode(params, taddr.address()) else {
+                undecodable += 1;
+                continue;
+            };
+            if tracked.contains(&decoded) || !seen.insert(decoded) {
+                continue;
+            }
+            to_import.push(WatchedAddress {
+                account_uuid,
+                address: decoded,
+                exposure_height: address
+                    .exposed_at_height()
+                    .map_or(exposure_height, |h| BlockHeight::from(u32::from(h))),
+            });
         }
     }
     to_import.sort_by_key(|watched| watched.address);

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -908,10 +908,45 @@ fn watched_addresses_to_import<P: Parameters>(
     params: &P,
     exposure_height: BlockHeight,
 ) -> (Vec<WatchedAddress>, usize) {
-    // TODO: the document is not examined yet, which is why the addresses zcashd
-    // watched without key material are still dropped. See the failing tests below.
-    let _ = (document, report, tracked, params, exposure_height);
-    (vec![], 0)
+    let accounts_by_name: HashMap<&str, zcash_client_sqlite::AccountUuid> = report
+        .imported_accounts
+        .iter()
+        .map(|a| (a.name.as_str(), a.account_uuid))
+        .collect();
+    let mut undecodable = 0usize;
+    let mut seen = HashSet::new();
+    let mut to_import = Vec::new();
+    for wallet in document.wallets() {
+        for account in wallet.accounts() {
+            let Some(account_uuid) = accounts_by_name.get(account.name()) else {
+                continue;
+            };
+            for address in account.addresses() {
+                let zewif::ProtocolAddress::Transparent(taddr) = address.address() else {
+                    continue;
+                };
+                if taddr.spend_authority().is_some() || taddr.pubkey().is_some() {
+                    continue;
+                }
+                let Ok(decoded) = TransparentAddress::decode(params, taddr.address()) else {
+                    undecodable += 1;
+                    continue;
+                };
+                if tracked.contains(&decoded) || !seen.insert(decoded) {
+                    continue;
+                }
+                to_import.push(WatchedAddress {
+                    account_uuid: *account_uuid,
+                    address: decoded,
+                    exposure_height: address
+                        .exposed_at_height()
+                        .map_or(exposure_height, |h| BlockHeight::from(u32::from(h))),
+                });
+            }
+        }
+    }
+    to_import.sort_by_key(|watched| watched.address);
+    (to_import, undecodable)
 }
 
 /// Registers the transparent addresses that zcashd watched but for which no key
@@ -1388,7 +1423,10 @@ fn log_import_report(report: &ZewifImportReport) {
     }
     if report.redeem_scripts_not_representable > 0 {
         warn!(
-            "Skipped {} watch-only redeem scripts that the wallet cannot represent",
+            "Skipped {} watch-only redeem scripts that the wallet cannot represent; \
+             their P2SH addresses are registered as watch-only addresses, so funds \
+             they receive remain visible, but the scripts must be re-imported into a \
+             wallet that can hold them to be spent from.",
             report.redeem_scripts_not_representable,
         );
     }

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -866,8 +866,9 @@ fn registered_spending_key_addresses<P: Parameters>(
         if derived_receivers.contains(&address) {
             continue;
         }
-        let encoded = address.encode(params);
-        if !skipped.contains(encoded.as_str()) && seen.insert(encoded) {
+        // Encoding is only needed to test against the report's skipped addresses,
+        // which name theirs as strings.
+        if seen.insert(address) && !skipped.contains(address.encode(params).as_str()) {
             addresses.push(address);
         }
     }

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -585,45 +585,48 @@ impl MigrateZcashdWalletCmd {
             .map(|cs| BlockHeight::from_u32(u32::from(cs.height()) + 1))
             .or(no_scan_birthday_estimate)
             .unwrap_or(sapling_activation);
-        // The import has committed: register the watch-only transparent material the
-        // importer has no path for, expose the addresses of the imported standalone
-        // spending keys and redeem scripts, then evaluate the import report. All of
-        // these must happen after the imported accounts are fully set up, so that a
-        // failure here never leaves committed accounts half-configured. The backup
-        // reminder is printed before propagating any error from these steps, as the
-        // minted-seed notice above refers to it.
-        let post_import = derived_transparent_receivers(&mut db_data, &report)
-            .and_then(|derived| {
-                register_watch_pubkeys(
-                    &mut db_data,
-                    &document,
-                    &report,
-                    exposure_height,
-                    &derived,
-                )?;
-                expose_spending_key_addresses(
-                    &mut db_data,
-                    &document,
-                    &report,
-                    exposure_height,
-                    &derived,
-                )?;
-                register_watch_addresses(&mut db_data, &document, &report, exposure_height)?;
-                expose_registered_script_addresses(&mut db_data, &report, exposure_height)
-            })
-            .and_then(|()| {
-                let document_account_count = document
-                    .wallets()
-                    .iter()
-                    .map(|wallet| wallet.accounts().len())
-                    .sum();
-                check_import_report(&report, document_account_count, allow_partial_import)
-            });
+        // The backup reminder is printed before propagating any error from the
+        // post-import steps, as the minted-seed notice above refers to it.
+        let post_import = finish_import(
+            &mut db_data,
+            &document,
+            &report,
+            exposure_height,
+            allow_partial_import,
+        );
         print_backup_reminder();
         post_import?;
 
         Ok(())
     }
+}
+
+/// Completes a committed import: registers the watch-only transparent material the
+/// ZeWIF importer has no path for, exposes the addresses of the imported standalone
+/// spending keys and redeem scripts, then evaluates the import report.
+///
+/// All of this must happen after the imported accounts are fully set up, so that a
+/// failure here never leaves committed accounts half-configured. The steps run in
+/// order because each reads back what the ones before it registered.
+fn finish_import(
+    db_data: &mut DbHandle,
+    document: &zewif::Zewif,
+    report: &ZewifImportReport,
+    exposure_height: BlockHeight,
+    allow_partial_import: bool,
+) -> Result<(), MigrateError> {
+    let derived = derived_transparent_receivers(db_data, report)?;
+    register_watch_pubkeys(db_data, document, report, exposure_height, &derived)?;
+    expose_spending_key_addresses(db_data, document, report, exposure_height, &derived)?;
+    register_watch_addresses(db_data, document, report, exposure_height)?;
+    expose_registered_script_addresses(db_data, report, exposure_height)?;
+
+    let document_account_count = document
+        .wallets()
+        .iter()
+        .map(|wallet| wallet.accounts().len())
+        .sum();
+    check_import_report(report, document_account_count, allow_partial_import)
 }
 
 /// Derives the ZeWIF document's regtest activation schedule from the configured

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -673,16 +673,11 @@ fn derived_transparent_receivers(
     db_data: &mut DbHandle,
     report: &ZewifImportReport,
 ) -> Result<HashSet<TransparentAddress>, MigrateError> {
-    let mut derived = HashSet::new();
-    for account in &report.imported_accounts {
-        derived.extend(
-            db_data
-                .get_transparent_receivers(account.account_uuid, true, false)
-                .map_err(MigrateError::Database)?
-                .into_keys(),
-        );
-    }
-    Ok(derived)
+    collect_transparent_receivers(
+        db_data,
+        report.imported_accounts.iter().map(|a| a.account_uuid),
+        false,
+    )
 }
 
 /// Collects the transparent receivers of every account in the wallet, standalone
@@ -697,16 +692,31 @@ fn derived_transparent_receivers(
 fn tracked_transparent_receivers(
     db_data: &mut DbHandle,
 ) -> Result<HashSet<TransparentAddress>, MigrateError> {
-    let mut tracked = HashSet::new();
-    for account_id in db_data.get_account_ids().map_err(MigrateError::Database)? {
-        tracked.extend(
+    let accounts = db_data.get_account_ids().map_err(MigrateError::Database)?;
+    collect_transparent_receivers(db_data, accounts, true)
+}
+
+/// Collects the transparent receivers of `accounts` into a set, change addresses
+/// included.
+///
+/// `include_standalone` selects whether imported standalone addresses count as
+/// receivers of the account that holds them; the two callers differ on that, and on
+/// which accounts they ask about, but not otherwise.
+fn collect_transparent_receivers(
+    db_data: &mut DbHandle,
+    accounts: impl IntoIterator<Item = zcash_client_sqlite::AccountUuid>,
+    include_standalone: bool,
+) -> Result<HashSet<TransparentAddress>, MigrateError> {
+    let mut receivers = HashSet::new();
+    for account_uuid in accounts {
+        receivers.extend(
             db_data
-                .get_transparent_receivers(account_id, true, true)
+                .get_transparent_receivers(account_uuid, true, include_standalone)
                 .map_err(MigrateError::Database)?
                 .into_keys(),
         );
     }
-    Ok(tracked)
+    Ok(receivers)
 }
 
 /// Registers watch-only transparent pubkeys (from zcashd's `importpubkey`) with the

--- a/zallet-core/src/components/database/connection.rs
+++ b/zallet-core/src/components/database/connection.rs
@@ -215,6 +215,42 @@ impl DbConnection {
             })
         })
     }
+
+    /// Imports the given transparent addresses into their accounts as watch-only
+    /// addresses carrying no key material, marking each exposed as of the height given
+    /// alongside it.
+    ///
+    /// This creates a single database transaction for the whole batch, so a failure
+    /// partway through leaves the wallet as it was, rather than with some of the
+    /// addresses registered and none of them marked exposed. Registration and exposure
+    /// travel together for the same reason: an address the wallet watches without
+    /// recording that it has been disclosed is one that `listaddresses` will not
+    /// report.
+    ///
+    /// The imported addresses will contribute to the balance of their accounts, but
+    /// the wallet holds neither the public key (P2PKH) nor the redeem script (P2SH)
+    /// from which each was derived, so funds they receive cannot be spent until that
+    /// material is imported. See
+    /// [`WalletWrite::import_standalone_transparent_address`].
+    #[cfg(feature = "zcashd-import")]
+    pub(crate) fn import_standalone_transparent_addresses(
+        &mut self,
+        addresses: impl IntoIterator<Item = (AccountUuid, TransparentAddress, BlockHeight)>,
+    ) -> Result<
+        (),
+        <WalletDb<rusqlite::Connection, Network, SystemClock, OsRng> as WalletRead>::Error,
+    > {
+        self.with_mut(|mut db_data| {
+            db_data.transactionally(|wdb| {
+                let mut to_expose = Vec::new();
+                for (account, address, exposure_height) in addresses {
+                    wdb.import_standalone_transparent_address(account, address)?;
+                    to_expose.push((address, exposure_height));
+                }
+                wdb.mark_transparent_addresses_exposed(&to_expose)
+            })
+        })
+    }
 }
 
 impl WalletRead for DbConnection {


### PR DESCRIPTION
Closes #572.

## Motivation

#571 removed the `cscripts()` walk from `migrate-zcashd-wallet` on the basis that the
ZeWIF importer covers standalone P2SH, and [noted](https://github.com/zcash/zallet/pull/571#discussion_r3554335918)
that it "was removed and not replaced". The importer covers it two-thirds of the way:

- `zewif-zcashd` emits one legacy-account address entry per `cscript`, keyed by the P2SH
  address, carrying the redeem script and no spend authority or pubkey.
- `zcash_client_sqlite::zewif` registers those via `import_standalone_transparent_script`,
  but accepts only multisig within the 520-byte P2SH limit. Everything else is counted in
  `redeem_scripts_not_representable` and **dropped**, leaving the migrated wallet blind to
  funds `zcashd` could see.
- Its exposure pass marks an address only where the document accounts for one, and its
  child-index inference cannot reach an address with no derivation — so even the *accepted*
  P2SH addresses ended up with no exposure height, and `listaddresses` (which reports only
  exposed addresses) did not surface them where `zcashd` did.

## Solution

`finish_import` gains two steps after the existing ones:

- `register_watch_addresses` registers, as bare watch-only addresses, the transparent
  addresses `zcashd` watched but for which no key material reached the wallet — both
  `importaddress <address>` and the redeem scripts the wallet cannot represent. Membership
  is decided by reading back what the wallet tracks rather than by re-deriving the
  representability rules, so the two cannot drift apart.
- `expose_registered_script_addresses` marks the P2SH addresses of the registered redeem
  scripts exposed. A redeem script reaches a `zcashd` wallet only because its address was
  already in use outside it.

The preceding commits are the refactors that make those two expressible, each a stated
no-op. The last four address review findings on the branch: an unparsable watch pubkey is
now reported separately from an uncompressed one; `register_watch_pubkeys` no longer
imports a pubkey whose address the wallet already tracks (which reached
`StandaloneImportConflict` and failed a migration *after* it had committed, when migrating
a second `zcashd` wallet that shared an `importpubkey` entry); the watched-address
registration and its exposures now share one database transaction; and the dormant
document-exposure-height branch is documented as dormant.

## Test evidence

`cargo fmt --all -- --check`, `cargo clippy --all-targets --features
zcashd-import,rpc-cli,tokio-console -- -D warnings`, and `cargo test --features
zcashd-import,rpc-cli,tokio-console` all pass locally — 426 tests.

Unit tests cover each selection: which addresses are registered and which are left to the
importer, exposure-height precedence, per-address deduplication and undecodable strings,
which P2SH addresses need exposing, and which watch pubkeys survive the tracked-receiver
filter. Each was checked to fail against the behaviour it pins.

Not covered: the database-touching wrappers themselves have no integration test, as the
crate has no `migrate-zcashd-wallet` harness. The ordering and conflict-avoidance claims
are argued in doc comments rather than asserted by a test.

### Unrelated flaky test

`components::sync::tests::wallet_sync_error_shuts_down_the_spawned_batch_decryptor` fails
intermittently. It reproduces on this branch *without* these commits (1 failure in 4
full-suite runs at the pre-existing tip), so it is not introduced here. Its assertion
admits three outcomes and handles two: after a failed `WalletSync::spawn`, `reload_keys()`
returning `Some` whose future resolves `Ok` — the engine serving the reload before it shuts
down — trips the assert. Filed as #818.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
