### PR TITLE
sync: drain transaction data requests instead of one pass per tip change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wallet balances no longer stall part-way while the chain is idle. Transaction
+  data requests were only serviced when the chain tip advanced, so any request
+  still queued at the end of a pass — including ones added while that pass was
+  running — waited for the next block. On a chain that was not producing blocks
+  the remainder was never serviced, leaving RPCs such as `z_gettotalbalance` and
+  `z_listunspent` reporting a subset of the wallet's transparent outputs
+  indefinitely. The queue is now drained while it is making progress, and only
+  waits on the chain tip when there is nothing left to do (or when a pass cannot
+  resolve anything further on its own).
+
 ## [0.1.0-beta.3] - 2026-08-24
 
 ### Added

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -1290,17 +1290,23 @@ async fn data_requests<C: Chain>(
     tip_change_signal: Arc<Notify>,
 ) -> Result<(), SyncError> {
     loop {
-        // Wait for the chain tip to advance
-        tip_change_signal.notified().await;
+        let requests = db_data.transaction_data_requests()?;
+        if requests.is_empty() {
+            // Nothing to do; wait for the chain tip to advance and bring more work.
+            debug!("No transaction data requests, sleeping until the chain tip changes.");
+            tip_change_signal.notified().await;
+            continue;
+        }
 
         let chain_view = chain.snapshot().await.map_err(SyncError::Chain)?;
 
-        let requests = db_data.transaction_data_requests()?;
-        if requests.is_empty() {
-            // Wait for new requests.
-            debug!("No transaction data requests, sleeping until the chain tip changes.");
-            continue;
-        }
+        // Servicing a pass can leave work behind: requests queued while the pass was
+        // running, entries deliberately kept for retry (`SpentSpenderUnknown`), and ones
+        // that hit a transient chain error. Previously the loop went straight back to
+        // waiting on the chain tip, so on an idle chain that remainder was stranded and
+        // the wallet's transparent balance stayed frozen part-way. Re-check the queue
+        // after each pass instead, and only wait on the tip when a pass resolves nothing.
+        let outstanding_before = requests.len();
 
         let view_tip = chain_view.tip().await.map_err(SyncError::Chain)?.height();
         info!("{} transaction data requests to service", requests.len());
@@ -1398,6 +1404,17 @@ async fn data_requests<C: Chain>(
                     }
                 }
             }
+        }
+
+        // If the queue did not shrink, this pass resolved nothing that it can resolve on
+        // its own, so go back to waiting on the chain rather than spinning against the
+        // same entries. Otherwise loop straight round and drain what is left.
+        if db_data.transaction_data_requests()?.len() >= outstanding_before {
+            debug!(
+                "Transaction data requests made no progress this pass; \
+                 sleeping until the chain tip changes."
+            );
+            tip_change_signal.notified().await;
         }
     }
 }


### PR DESCRIPTION
Refs #817. Not a complete fix on its own — see Status below.

## The bug

`data_requests` waits on the chain tip, services **one snapshot** of the queue, then goes back to waiting:

```rust
loop {
    tip_change_signal.notified().await;   // wait for a tip change
    let requests = db_data.transaction_data_requests()?;
    for request in requests { /* service */ }
}                                          // loop back, block again
```

Anything still queued when a pass ends waits for the *next* tip change: requests added while the pass was running, entries deliberately kept for retry (`SpentSpenderUnknown`), and ones that hit a transient chain error.

While the chain is idle there is no next tip change, so that remainder sits unserviced. Because `decrypt_and_store_transaction` writes `transparent_received_outputs` — the table `get_wallet_summary` sums — and runs only in this task, the wallet can be fully scanned while RPCs like `z_gettotalbalance` and `z_listunspent` report a subset of the transparent outputs it owns.

## The change

Check the queue first and only wait on the tip when it is empty, so a pass that leaves work behind loops straight round and drains it.

The second wait is the important half: several arms deliberately leave entries queued, so an unconditional "loop until empty" would spin against them. Waiting whenever a pass fails to shrink the queue preserves the existing backoff for those cases while letting genuine progress continue without needing a new block.

No behaviour change when the queue empties in one pass, which is the common case.

## Evidence

From the integration-tests interop run this PR triggers ([run](https://github.com/zcash/integration-tests/actions/runs/33426089753)), against the same suite on the same hardware:

| | queue behaviour | balance observed |
|---|---|---|
| `main` | stalls at **80 of 90** queued | 80 of 101 coinbases |
| this PR | drains **110 → 10** | 95 of 101 coinbases |

The ~10 remaining are the deliberately-requeued kind, which is the intended steady state rather than a stall.

## Status

That run still fails, on a different cause: it pairs this branch with integration-tests `main`, whose `wallet.py` reads the balance **once**, two seconds after `wallet_tip`. It sampled 95 while enhancement was still in flight and needed ≥96 — it read too early rather than the wallet being stuck. zcash/integration-tests#200 turns that read into a bounded wait.

The two are complementary and **have not yet been tested together**: this run pairs a patched wallet with unpatched tests, and #200's CI pairs patched tests with an unpatched wallet. I'd like a combined run before calling this verified, which is why it says `Refs` rather than `Fixes`.

## Testing

- `cargo check -p zallet-core` passes; CI is green (the single NU7 Linux failure was the known flake #766 and passed on rerun).
- Locally the failure does not reproduce: unpatched `main` passes `wallet.py` 3/3 with all 101 transactions enhanced. So the local runs show this change is not harmful, but cannot show that it helps; the CI queue-drain behaviour above is the real signal.
- Worth a careful look at the no-progress guard in particular, and ideally a regtest case asserting the balance settles while the chain is idle.