### PR TITLE
sync: wake the data-requests task after blocks are applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ be considered breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- Wallet balances no longer stall part-way while the chain is idle. The
+  data-requests task was woken as soon as a new chain tip was observed, which
+  is before those blocks are scanned and before the transaction data requests
+  they generate exist, so it could wake, find nothing to do, and sleep again —
+  stranding that work until the next tip change. On a chain that was not
+  producing blocks it was never picked up, leaving RPCs such as
+  `z_gettotalbalance` and `z_listunspent` reporting a subset of the wallet's
+  transparent outputs. The task is now also woken once the blocks have been
+  applied and their requests queued.
+
 ## [0.1.0-beta.3] - 2026-08-24
 
 ### Added

--- a/zallet-core/src/components/sync.rs
+++ b/zallet-core/src/components/sync.rs
@@ -1028,6 +1028,15 @@ async fn steady_state_iteration<C: Chain>(
     // any) has been rescanned.
     status.set_fully_synced(db_data.block_fully_scanned()?.map(|m| m.block_height()));
     status.mark_tip_reached();
+
+    // Wake the data-requests task now that those blocks are applied. The notification
+    // above fires as soon as a new tip is *observed*, which is before the blocks have
+    // been scanned and before the requests they generate exist; a task woken by it can
+    // find nothing to do and go back to sleep, stranding that work until the next tip
+    // change. While the chain is idle there is no next tip change, so the wallet's
+    // transparent balance can sit part-way through the outputs it owns. Signalling
+    // again here means there is always a wakeup after the work is actually queued.
+    tip_change_signal.notify_one();
     // TODO(zcash/zallet#195): when this actually clears an in-progress recovery (i.e. on
     // the `Recovering` → synced edge, not on every tip-reached), trigger an online backup
     // so the recovered state is durably captured before any subsequent failure.


### PR DESCRIPTION
Refs #817.

## The race

`tip_change_signal.notify_one()` fires as soon as a new chain tip is **observed** — before those blocks are scanned, and before the transaction data requests they generate exist.

A data-requests pass woken by that signal can find nothing it can act on and go back to waiting. The work queued moments later by the scan then waits for the *next* tip change, and while the chain is idle there is no next tip change.

`decrypt_and_store_transaction` writes `transparent_received_outputs` — the table `get_wallet_summary` sums — and runs only in that task. So the wallet can be fully scanned while `z_gettotalbalance` and `z_listunspent` report a subset of the transparent outputs it owns, and stay that way indefinitely.

## Why this is not usually seen

The task normally never catches up: there is a standing backlog, so any pass has enough to do that the new block's requests show up before it finishes. That masking is incidental, and it disappears precisely when the queue gets close to drained.

Measured on a local run of `zcash/integration-tests` `wallet.py`, counting what the task saw on the pass after the final block was mined:

| | queue found | enhanced |
|---|---|---|
| `main` (backlog present) | 44 | 4 |
| a build that drains the queue | 10 | **0** |

With the backlog gone, the pass runs before the block is scanned, finds only entries it cannot clear, and sleeps — the new coinbase is never picked up and the balance stops growing. Same race, just no longer hidden.

## The change

One `notify_one()` after the apply loop, where the blocks are scanned and their requests are queued, so there is always a wakeup after the work actually exists. The existing signal is left alone; an extra wakeup is harmless, as the task simply finds an empty queue and waits again.

## Testing

`wallet.py` from zcash/integration-tests, zebra backend, same harness throughout:

| build | result | txs enhanced |
|---|---|---|
| `main` | 3/3 pass | 101 |
| **this branch** | **3/3 pass** | **102** |

The extra enhanced transaction is the coinbase from the block mined at the end of the test — the one the race can lose.

Note the failure this addresses does **not** reproduce on a normal workstation; `main` passes locally every time. It reproduces on CI runners, so these runs show this change is not harmful rather than proving it helps. The interop run this PR triggers exercises it on the hardware where the problem actually appears.

I previously tried fixing this by draining the queue (#819) and closed it — three variants all regressed the local test, because removing the backlog removes the masking without addressing the race itself. This targets the ordering instead.