### PR TITLE
 migrate-zcashd-wallet: stop defaulting the birthday to Sapling activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ be considered breaking changes.
   the wallet's addresses were in use around its expiry height, so history near
   such a transaction is no longer at risk of being skipped by the post-import
   scan.
+- `migrate-zcashd-wallet` no longer raises the wallet birthday to the Sapling
+  activation height. A zcashd wallet may predate Sapling, so evidence of
+  earlier activity now sets the birthday directly, and a wallet with no usable
+  evidence at all falls back to the genesis height instead of Sapling
+  activation.
 - Fixed a race that could leave wallet data requests unprocessed. The sync task
   now signals data-request processing after new blocks are stored. It also
   signals after each mempool transaction is stored.

--- a/zallet-core/src/commands/migrate_zcashd_wallet.rs
+++ b/zallet-core/src/commands/migrate_zcashd_wallet.rs
@@ -18,7 +18,7 @@ use zcash_client_sqlite::zewif::{
 };
 use zcash_keys::encoding::AddressCodec;
 use zcash_primitives::block::BlockHash;
-use zcash_protocol::consensus::{BlockHeight, NetworkType, NetworkUpgrade, Parameters};
+use zcash_protocol::consensus::{BlockHeight, H0, NetworkType, NetworkUpgrade, Parameters};
 use zewif_zcashd::{
     BDBDump, EncryptedKeyPolicy, ParseOptions, ZcashdDump, ZcashdParser, ZcashdWallet,
 };
@@ -261,10 +261,6 @@ impl MigrateZcashdWalletCmd {
             info!("No-scan mode: skipping chain scanning");
             (None, None)
         };
-        let sapling_activation = network_params
-            .activation_height(NetworkUpgrade::Sapling)
-            .expect("Sapling activation height is defined.");
-
         // The export height records the chain tip at export time. Without a chain
         // backend, approximate it with the wallet's maximum transaction expiry height
         // (expiry heights are near the height at which a transaction was created).
@@ -278,7 +274,7 @@ impl MigrateZcashdWalletCmd {
                     .max()
                     .map(BlockHeight::from_u32)
             })
-            .unwrap_or(sapling_activation);
+            .unwrap_or(H0);
 
         // Export the parsed wallet to a ZeWIF document. Everything below operates on
         // the document alone.
@@ -431,12 +427,14 @@ impl MigrateZcashdWalletCmd {
             );
 
             // The estimate never exceeds the tip, which also stands in for it when
-            // the wallet records no transactions at all.
+            // the wallet records no transactions at all. A zcashd wallet may predate
+            // Sapling, so an estimate below Sapling activation stands as-is, and
+            // with no evidence at all the birthday falls back to genesis.
             let birthday_height = earliest_activity_estimate(&document)
                 .into_iter()
                 .chain(chain_tip)
                 .min()
-                .map_or(sapling_activation, |h| std::cmp::max(h, sapling_activation));
+                .unwrap_or(H0);
 
             // Fetch the tree state corresponding to the last block prior to the
             // wallet's birthday height.
@@ -454,10 +452,7 @@ impl MigrateZcashdWalletCmd {
             (None, None)
         };
         let no_scan_birthday_estimate = if chain_view.is_none() {
-            Some(
-                earliest_activity_estimate(&document)
-                    .map_or(sapling_activation, |h| std::cmp::max(h, sapling_activation)),
-            )
+            Some(earliest_activity_estimate(&document).unwrap_or(H0))
         } else {
             None
         };
@@ -572,7 +567,7 @@ impl MigrateZcashdWalletCmd {
             .as_ref()
             .map(|cs| BlockHeight::from_u32(u32::from(cs.height()) + 1))
             .or(no_scan_birthday_estimate)
-            .unwrap_or(sapling_activation);
+            .unwrap_or(H0);
         // The import has committed: register watch-only transparent pubkeys, expose
         // the imported standalone spending keys' addresses, then evaluate the import
         // report. All of these must happen after the imported accounts are fully set


### PR DESCRIPTION
Stacked on https://github.com/zcash/zallet/pull/823 

Closes #574.
Closes [COR-1534](https://linear.app/zodl/issue/COR-1534).

Built on the `nc/birthday-unmined-txs` PR (#573's fix), which
reworks the same expressions; only the last commit is new here.

The migration clamped every birthday up to Sapling activation and used it as
the fallback wherever no evidence existed (birthday, export height, exposure
height). A zcashd wallet may predate Sapling, so the clamp could raise the
birthday above genuine pre-Sapling activity and cut that history out of the
post-import scan.

Evidence of activity now sets the birthday directly, and with no evidence at
all the fallback is the genesis height (`consensus::H0`). Nothing downstream
requires a post-Sapling birthday: `ChainView::tree_state_as_of` legitimately
returns empty frontiers below a pool's activation (both backends test this),
and the ZeWIF importer seeds its chain view from the export height precisely
for birthdays at or below Sapling activation.

Trade-off: a wallet whose evidence (or lack of it) puts the birthday below
Sapling activation will scan the pre-Sapling range too. That range holds no
shielded notes but can hold the wallet's transparent history, which is the
point of the issue. Wallets with post-Sapling evidence are unaffected.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>