### PR TITLE
book: correct stale statements in the zcashd migration docs and help text

### DIFF
--- a/book/src/cli/migrate-zcash-conf.md
+++ b/book/src/cli/migrate-zcash-conf.md
@@ -5,11 +5,12 @@
 `zallet migrate-zcash-conf` migrates a [`zcashd`] configuration file (`zcash.conf`) to an
 equivalent Zallet [configuration file] (`zallet.toml`).
 
-The command requires at least one of the following two flag:
+The configuration file is located with two flags, neither of which is required:
 
-- `--path`: A path to a `zcashd` configuration file.
-- `--zcashd-datadir`: A path to a `zcashd` datadir. If this is provided, then `--path` can
-  be relative (or omitted, in which case the default filename `zcash.conf` will be used).
+- `--conf`: A path to a `zcashd` configuration file. Defaults to `zcash.conf`.
+- `--zcashd-datadir`: A path to a `zcashd` datadir, against which a relative `--conf` is
+  resolved. If omitted, the platform's default `zcashd` datadir is used (`~/.zcash` on
+  Linux, the XDG data home's `Zcash` directory on macOS, `%APPDATA%\Zcash` on Windows).
 
 > For the Zallet beta releases, the command also currently takes another required flag
 > `--this-is-beta-code-and-you-will-need-to-redo-the-migration-later`.

--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -32,11 +32,12 @@ normally do not need to provide one yourself. If that vendored utility is unavai
 Zallet falls back to a `db_dump` found on the system `$PATH`; you can also point Zallet
 at a specific `zcashd` installation's `db_dump` with `--zcashd-install-dir` (see below).
 
-The command requires at least one of the following two flag:
+The wallet file is located with two flags, neither of which is required:
 
-- `--path`: A path to a `zcashd` wallet file.
-- `--zcashd-datadir`: A path to a `zcashd` datadir. If this is provided, then `--path` can
-  be relative (or omitted, in which case the default filename `wallet.dat` will be used).
+- `--path`: A path to a `zcashd` wallet file. Defaults to `wallet.dat`.
+- `--zcashd-datadir`: A path to a `zcashd` datadir, against which a relative `--path` is
+  resolved. If omitted, the platform's default `zcashd` datadir is used (`~/.zcash` on
+  Linux, the XDG data home's `Zcash` directory on macOS, `%APPDATA%\Zcash` on Windows).
 
 Additional CLI arguments:
 - `--zcashd-install-dir`: A path to a local `zcashd` installation directory, for

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -135,7 +135,7 @@ Notes:
 
 If you have an existing `zcash.conf`, you can use it as a starting point:
 ```
-$ zallet migrate-zcash-conf --datadir /path/to/zcashd/datadir -o /path/to/zallet/datadir/zallet.toml
+$ zallet migrate-zcash-conf --zcashd-datadir /path/to/zcashd/datadir -o /path/to/zallet/datadir/zallet.toml
 ```
 
 > [Reference](../cli/migrate-zcash-conf.md)

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -85,7 +85,6 @@ The migration reports these (with counts) instead of importing them:
 - Address book entries.
 - Watch-only entries recorded without their public key or redeem script, and entries
   with uncompressed public keys.
-- Regtest wallets (not currently supported).
 
 ## Back up the migrated wallet
 

--- a/book/src/zcashd/rpc_status.md
+++ b/book/src/zcashd/rpc_status.md
@@ -48,11 +48,11 @@ Statuses:
 | `sendmany` | Not planned | Use `z_sendmany`, or `z_sendfromaccount` once implemented ([#66](https://github.com/zcash/zallet/issues/66), [#217](https://github.com/zcash/zallet/issues/217)) |
 | `sendtoaddress` | Not planned | Use `z_sendfromaccount` once implemented ([#217](https://github.com/zcash/zallet/issues/217)); `z_sendmany` covers most uses today ([#67](https://github.com/zcash/zallet/issues/67)) |
 | `settxfee` | Omitted | [ZIP 317](https://zips.z.cash/zip-0317) fees are always used |
-| `signmessage` | Not yet implemented | [#68](https://github.com/zcash/zallet/issues/68) |
+| `signmessage` | Implemented | Transparent P2PKH addresses only; signing with an ephemeral (ZIP 320) address is refused |
 | `walletconfirmbackup` | Not planned | Internal `zcashd` method not intended to be called directly; use the [`zallet confirm-backup`](../cli/confirm-backup.md) command instead |
 | `z_converttex` | Implemented | |
 | `z_exportkey` | Implemented | |
-| `z_exportviewingkey` | Not yet implemented | Planned as UFVK/UIVK export ([#70](https://github.com/zcash/zallet/issues/70)) |
+| `z_exportviewingkey` | Implemented (altered) | [Changes](json_rpc.md#z_exportviewingkey) |
 | `z_exportwallet` | Not yet implemented | Planned as a [ZeWIF](https://github.com/zcash/zewif) export, likely a CLI operation rather than an RPC ([#71](https://github.com/zcash/zallet/issues/71)) |
 | `z_getaddressforaccount` | Implemented (altered) | [Changes](json_rpc.md#z_getaddressforaccount) |
 | `z_getbalance` | Omitted | Use `z_getbalanceforaccount` |
@@ -66,7 +66,7 @@ Statuses:
 | `z_getoperationstatus` | Implemented | |
 | `z_gettotalbalance` | Implemented (deprecated) | `include_watchonly = false` is not yet honored; use the account-scoped `z_getbalanceforaccount` / `z_getbalances` instead ([#324](https://github.com/zcash/zallet/issues/324)) |
 | `z_importkey` | Implemented (altered) | Sapling extended spending keys only |
-| `z_importviewingkey` | Not yet implemented | Planned for Sapling keys, UFVKs, and UIVKs ([#80](https://github.com/zcash/zallet/issues/80)) |
+| `z_importviewingkey` | Implemented (altered) | Sapling extended full viewing keys only; the key becomes its own view-only account |
 | `z_importwallet` | Omitted | Use `z_importkey` per key, or [`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md); reconsideration tracked in [#81](https://github.com/zcash/zallet/issues/81) |
 | `z_listaccounts` | Implemented (altered) | [Changes](json_rpc.md#z_listaccounts) |
 | `z_listaddresses` | Omitted | Use `listaddresses` |

--- a/zallet-core/i18n/en-US/zallet_core.ftl
+++ b/zallet-core/i18n/en-US/zallet_core.ftl
@@ -462,10 +462,6 @@ err-migrate-wallet-db-dump-not-found =
     is available on the system `$PATH`.
 err-migrate-wallet-db-dump =
     An error occurred in extracting wallet data from '{$path}': '{$err}'
-err-migrate-wallet-seed-absent =
-    The {-zcashd} wallet file did not contain HD seed information. Wallets from
-    prior to the Sapling network upgrade are not supported by this migration
-    tool.
 err-migrate-wallet-invalid-mnemonic =
     The {-zcashd} wallet file contained invalid mnemonic seed phrase data and
     may be corrupt: '{$err}'

--- a/zallet-core/src/cli.rs
+++ b/zallet-core/src/cli.rs
@@ -197,11 +197,12 @@ pub(crate) struct MigrateZcashdWalletCmd {
     #[arg(long)]
     pub(crate) allow_multiple_wallet_imports: bool,
 
-    /// Specify the path to the zcashd installation directory.
+    /// Specify the path to a local `zcashd` installation directory.
     ///
-    /// This is required for locating the `db_dump` command used to extract data from the
-    /// `wallet.dat` file. Wallet migration without a local `zcashd` installation is not yet
-    /// supported.
+    /// When set, the `db_dump` utility from that installation's `zcutil/bin` directory is
+    /// used to extract data from the `wallet.dat` file. By default the Berkeley DB 6.2
+    /// `db_dump` vendored with Zallet is used, falling back to one on the system `PATH`,
+    /// so a local `zcashd` installation is not required.
     #[arg(long)]
     pub(crate) zcashd_install_dir: Option<PathBuf>,
 


### PR DESCRIPTION
Closes #775.

## Motivation

Seven statements in the migration docs and help text no longer match the code, each able to derail a user mid-migration (wrong flag names, "not yet implemented" rows for shipped methods, regtest listed as unsupported).

## Solution

- `migrate-zcash-conf` reference: `--path` → `--conf`; both reference pages: neither locating flag is required, and the platform default `zcashd` datadir fallback is described (`migrate_zcashd_wallet.rs:110-120`, `migrate_zcash_conf.rs:193-211`).
- Setup guide: `--datadir` → `--zcashd-datadir`.
- Method status matrix: `signmessage`, `z_exportviewingkey`, `z_importviewingkey` marked implemented, with their actual scope.
- Migration guide: dropped the regtest line from "What is not migrated".
- `--zcashd-install-dir` help text describes the vendored `db_dump` default.
- Removed the orphaned `err-migrate-wallet-seed-absent` string.

## Test evidence

Documentation and help-text only; `mdbook build book` succeeds. No changelog entry per the doc-only rule.

Base of the migration-docs stack (#182); the remaining PRs build on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1