### PR TITLE
book: document the migrate-zcashd-wallet --no-scan flag

### DIFF
--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -60,6 +60,14 @@ Additional CLI arguments:
   accessible only via the original `wallet.dat` file. Without this flag, such
   a migration fails with an error enumerating what was left behind. A
   migration that imports nothing at all is an error regardless of this flag.
+- `--no-scan`: Do not connect to the chain backend. Keys, accounts and
+  transactions are still imported, but nothing is resolved from the chain: no
+  transaction gains a mined height (all are stored as unmined until the next
+  scan re-encounters them), and each account's birthday is estimated from the
+  wallet's transaction expiry heights instead (the lowest one minus 1000
+  blocks, never below Sapling activation). The next `zallet start` rescans
+  from that estimate. Use it when the chain backend is not reachable yet; the
+  cost is a conservative birthday and therefore a longer first sync.
 
 > For the Zallet beta releases, the command also currently takes another required flag
 > `--this-is-beta-code-and-you-will-need-to-redo-the-migration-later`.


### PR DESCRIPTION
Closes #825.

## Motivation

`--no-scan` (`cli.rs:223-227`) has shipped since 0.1.0-alpha.4 but is absent from the flag list in `book/src/cli/migrate-zcashd-wallet.md`.

## Solution

Adds the flag to the list, describing what it skips and what the migration does instead, traced from `migrate_zcashd_wallet.rs:73-78` (no backend), `:454-472` (expiry-based birthday estimate) and `:1135-1145` (transactions stored as unmined until the scan re-encounters them).

## Test evidence

Documentation only; `mdbook build book` succeeds.

Stacked on #841.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1