### PR TITLE
book: say that a partial-import failure is post-commit and not retryable

### DIFF
--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -60,6 +60,16 @@ Additional CLI arguments:
   accessible only via the original `wallet.dat` file. Without this flag, such
   a migration fails with an error enumerating what was left behind. A
   migration that imports nothing at all is an error regardless of this flag.
+  Note that the check runs *after* the importable accounts and their key
+  material have been written to the wallet database and keystore, so a
+  failed migration cannot simply be re-run against the same wallet database:
+  the re-run is refused as a duplicate import. Decide on this flag before the
+  first run. To accept a partial import after a failure, start again with a
+  fresh wallet database (delete `wallet.db` and re-run
+  [`zallet init-wallet-encryption`]) and pass the flag. The items that can
+  trigger it in a `zcashd` wallet are transparent spending keys with
+  uncompressed public keys, and transparent spending keys whose address is
+  not listed under any imported account.
 - `--no-scan`: Do not connect to the chain backend. Keys, accounts and
   transactions are still imported, but nothing is resolved from the chain: no
   transaction gains a mined height (all are stored as unmined until the next

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -49,6 +49,15 @@ you need.
    you have several `wallet.dat` files, run it once per file (subsequent runs need
    `--allow-multiple-wallet-imports`); each wallet becomes a distinct set of accounts.
 
+   **Decide before the first run whether to pass `--allow-partial-import`.** Without it,
+   the migration fails if any account or transparent spending key could not be imported,
+   listing what was left behind. That failure happens *after* the importable accounts
+   have been written, and a second run against the same wallet database is refused as a
+   duplicate import, so recovering from it means starting over: delete `wallet.db`,
+   re-run `zallet init-wallet-encryption` (the identity file can stay), and migrate
+   again with the flag. Anything the flag lets the migration skip remains accessible
+   only through the original `wallet.dat`.
+
    > [Reference](../cli/migrate-zcashd-wallet.md)
 
 6. **Start Zallet and let it sync:**
@@ -85,6 +94,11 @@ The migration reports these (with counts) instead of importing them:
 - Address book entries.
 - Watch-only entries recorded without their public key or redeem script, and entries
   with uncompressed public keys.
+
+Not every skip is merely reported. A transparent *spending* key that cannot be imported
+(one whose public key is uncompressed, or whose address appears under none of the
+imported accounts) fails the migration unless `--allow-partial-import` is passed; see
+step 5 above for why that decision has to be made before the first run.
 
 ## Back up the migrated wallet
 


### PR DESCRIPTION
Closes #832.

## Motivation

`check_import_report` runs after `import_wallet` has committed (`migrate_zcashd_wallet.rs:543-551`, `:608-617`), and a re-run is refused by the multi-import / duplicate-import checks (`:394-404`). The docs presented skipped material as merely "reported", so an operator hitting the partial-import error had no documented way forward.

## Solution

- Runbook step 5: decide on `--allow-partial-import` before the first run; how to start over (delete `wallet.db`, re-run `init-wallet-encryption`, migrate again with the flag). Recipients live in the keystore inside `wallet.db` (`init_wallet_encryption.rs:64-65`), which is why `init-wallet-encryption` must be repeated while the identity file can stay.
- "What is not migrated": a paragraph separating the skips that fail the migration (transparent spending keys with uncompressed pubkeys or no owning account, `zallet_core.ftl:553-558`) from those that are only reported.
- Reference page: the `--allow-partial-import` entry says the same.

## Test evidence

Documentation only; `mdbook build book` succeeds.

Stacked on #842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1