### PR TITLE
book: complete the list of what migrate-zcashd-wallet does not migrate

### DIFF
--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -95,10 +95,15 @@ directory of a source installation (via `--zcashd-install-dir`), or one on the
 system `$PATH`, are used otherwise.
 
 Some `zcashd` wallet contents cannot be represented in a Zallet wallet, and are
-reported (with counts) rather than migrated: Sprout spending keys (move any
-Sprout funds using `zcashd` before migrating), address book entries, watch-only
-entries recorded without their public keys or redeem scripts, and entries with
-uncompressed public keys.
+logged with a count rather than migrated: Sprout spending keys (move any Sprout
+funds using `zcashd` before migrating), address book entries, watch-only
+entries recorded without their public keys or redeem scripts, watch-only public
+keys that are uncompressed or malformed, watch-only redeem scripts other than
+multisig within the P2SH size limit, standalone copies of unified spending keys,
+and transactions that carry no raw data. Records the wallet parser does not
+recognise are discarded without any message. See
+[What is not migrated](../zcashd/README.md#what-is-not-migrated) for what each
+of these means for you.
 
 [ZeWIF]: https://github.com/zcash/zewif
 

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -86,14 +86,27 @@ you need.
 
 ## What is not migrated
 
-The migration reports these (with counts) instead of importing them:
+The migration logs each of these with a count instead of importing it, except the last,
+which is dropped silently:
 
 - **Sprout spending keys and funds.** Zallet does not support the Sprout pool. Move any
   Sprout funds (e.g. to Sapling, using `zcashd`'s migration or a Sprout-capable tool)
   *before* retiring `zcashd`.
-- Address book entries.
-- Watch-only entries recorded without their public key or redeem script, and entries
-  with uncompressed public keys.
+- **Address book entries.** Zallet has no store for them yet ([#774] tracks preserving
+  them); the labels exist only in `wallet.dat`.
+- **Watch-only entries recorded without their public key or redeem script**, and
+  watch-only public keys that are uncompressed or malformed.
+- **Watch-only redeem scripts the wallet cannot represent.** Only multisig scripts
+  within the P2SH size limit are imported; any other watched script is dropped.
+- **Standalone copies of unified spending keys.** The unified accounts themselves are
+  re-derived from the mnemonic, so this loses nothing.
+- **Transactions that carry no raw transaction data.** If such a transaction was mined,
+  the post-migration scan recovers it.
+- **Records of a kind the wallet parser does not recognise.** These are discarded with
+  no warning at all, so a `wallet.dat` written by an unusual `zcashd` build may lose
+  data without any sign of it in the log.
+
+[#774]: https://github.com/zcash/zallet/issues/774
 
 Not every skip is merely reported. A transparent *spending* key that cannot be imported
 (one whose public key is uncompressed, or whose address appears under none of the


### PR DESCRIPTION
Closes #837.

## Motivation

The migration drops more than the four items "What is not migrated" listed, each with only a log warning, and one class of record with no message at all.

## Solution

Rewrites the list in `book/src/zcashd/README.md` and the matching paragraph in `book/src/cli/migrate-zcashd-wallet.md` to cover, with the source of each:

- Sprout keys and address book entries (unchanged; `migrate_zcashd_wallet.rs:515-521`, `:1203-1209`, with #774 linked for the address book);
- watch-only entries without key material, and uncompressed or malformed watch-only public keys (`:747-753`);
- watch-only redeem scripts the wallet cannot represent (`:1179-1184`; the importer accepts only multisig within the P2SH size limit);
- standalone copies of unified spending keys (`:522-528`);
- transactions carrying no raw data (`:1197-1202`);
- records the parser does not recognise, discarded silently (`_unparsed_keys`, `:212`).

#816 will change the watch-only handling; the wording describes `main` today.

## Test evidence

Documentation only; `mdbook build book` succeeds.

Stacked on #843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1