### PR TITLE
book: require a synced zebrad before migrating, and explain the birthday

### DIFF
--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -94,6 +94,35 @@ recommended choice; a `zcashd`-provided `db_dump` from the `zcutil/bin`
 directory of a source installation (via `--zcashd-install-dir`), or one on the
 system `$PATH`, are used otherwise.
 
+## How the wallet birthday is chosen
+
+Every imported account gets the same birthday, and the post-migration scan
+starts there, so a birthday later than the wallet's real history means funds
+the scan never finds.
+
+- **With a chain backend** (the default), the migration looks up every block
+  hash recorded on the wallet's transactions and takes the lowest main-chain
+  height it finds, never below Sapling activation. Hashes the backend does not
+  know are ignored. If none resolve, the birthday falls back to the current
+  chain tip, and so does the height up to which the wallet considers itself
+  recovered. The note commitment tree state as of the block before the
+  birthday is then fetched from the backend and stored with the accounts.
+- **With `--no-scan`**, no lookups happen: the birthday is the lowest
+  transaction expiry height in the wallet minus 1000 blocks, never below
+  Sapling activation, and the wallet rescans from there on the next start.
+
+Two failure modes follow from the first case, and both are avoided by letting
+`zebrad` sync to the chain tip before migrating. If `zebrad` has not yet
+reached the blocks the wallet's transactions are in, those hashes do not
+resolve and the birthday lands too late, with nothing in the output to say so.
+If it has reached some of them but the backend cannot supply the tree state
+for the block before the earliest, the migration fails with
+`missing tree state for height N`. (A wallet with no transactions at all also
+gets the chain tip as its birthday, which is correct for it.) The
+Sapling-activation floor is tracked in [#574].
+
+[#574]: https://github.com/zcash/zallet/issues/574
+
 Some `zcashd` wallet contents cannot be represented in a Zallet wallet, and are
 logged with a count rather than migrated: Sprout spending keys (move any Sprout
 funds using `zcashd` before migrating), address book entries, watch-only

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -14,9 +14,16 @@ you need.
 
 ## Migration steps
 
-1. **Run a `zebrad` node.** Zallet reads chain data from `zebrad` via one of its two
+1. **Run a `zebrad` node, and let it sync to the chain tip.** Zallet reads chain data
+   from `zebrad` via one of its two
    [chain backends](../guide/installation/README.md#choosing-a-chain-backend); the
    backend you choose determines how `zebrad` needs to be built and configured.
+
+   Do not run the wallet migration (step 5) until `zebrad` has caught up: the migration
+   sets each account's birthday from the blocks the node can already resolve, so an
+   unsynced node silently produces a birthday later than your wallet's history, and
+   the scan then never finds the earlier funds. See
+   [How the wallet birthday is chosen](../cli/migrate-zcashd-wallet.md#how-the-wallet-birthday-is-chosen).
 
 2. **Install Zallet.** See [Installation](../guide/installation/README.md).
 


### PR DESCRIPTION
Closes #834.

## Motivation

The birthday computation (`migrate_zcashd_wallet.rs:413-450`) ignores block hashes the backend cannot resolve and falls back to the chain tip when none resolve, so a migration run against a partially synced `zebrad` yields a silently late birthday, or fails on the tree-state lookup (`:439-447`). Step 1 of the guide did not mention syncing.

## Solution

- Runbook step 1: let `zebrad` sync to the chain tip before running the migration, and why.
- Reference page: a "How the wallet birthday is chosen" section covering the chain-backed case, the `--no-scan` estimate (`:454-472`), the two symptoms of an unsynced node, and a pointer to #574 for the Sapling-activation floor.

## Test evidence

Documentation only; `mdbook build book` succeeds.

Stacked on #844.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1