### PR TITLE
book: describe the migration as importing transactions, not recovering them

### DIFF
--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -87,8 +87,15 @@ in-memory [ZeWIF] (Zcash Wallet Interchange Format) document, connect to the
 backing full node (to obtain necessary chain information for setting up wallet
 birthdays), and import the document: Zallet accounts are created corresponding
 to the structure of the `zcashd` wallet, spending key material is stored in the
-Zallet keystore, and the account birthdays carry the note commitment tree state
-needed for recovery. Parsing is performed using the `db_dump` command-line
+Zallet keystore, the account birthdays carry the note commitment tree state
+needed for recovery, and every transaction in the `zcashd` wallet is stored
+directly. Transactions whose block the chain backend can resolve are stored
+with their mined height; the rest (never-mined sends, transactions on a
+non-main-chain block, and everything when `--no-scan` is used) are stored as
+unmined, and the post-migration scan fills in the height of any that were in
+fact mined. The scan is what establishes the note commitment tree positions
+that make notes spendable, so balances are complete only once it has run past
+the wallet's history. Parsing is performed using the `db_dump` command-line
 utility. By default Zallet uses the copy it vendors and builds, which is the
 recommended choice; a `zcashd`-provided `db_dump` from the `zcutil/bin`
 directory of a source installation (via `--zcashd-install-dir`), or one on the

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -73,8 +73,12 @@ you need.
    $ zallet start
    ```
 
-   Transaction history is recovered by scanning the chain, so the wallet needs to sync
-   before balances are complete. Use `zallet rpc getwalletstatus` to observe sync
+   Your transaction history is already present: the migration imports every transaction
+   from `wallet.dat` directly, including sends that were never mined and transactions
+   that ended up on a non-main-chain block, which a chain scan alone could not recover.
+   What the scan adds is the note commitment tree positions of your notes (and the
+   mined heights of any transactions the migration could not place), and balances are
+   not spendable until it has done so. Use `zallet rpc getwalletstatus` to observe sync
    progress, then verify your balances against `zcashd` before decommissioning it.
 
 7. **Update your RPC clients.** Zallet implements a subset of the `zcashd` wallet


### PR DESCRIPTION
Closes #835.

## Motivation

Step 6 of the guide describes the pre-beta.2 behaviour ("Transaction history is recovered by scanning the chain"). Since 0.1.0-beta.2 the migration imports every `wallet.dat` transaction directly (`migrate_zcashd_wallet.rs:1135-1145`), backfills mined heights for those in main-chain blocks (`:1017-1051`), and leaves the scan to supply note positions.

## Solution

- Runbook step 6: says what is present immediately (the full transaction list, including unmined and conflicted sends) and what still waits for the scan (mined heights it could not resolve, note positions, and therefore spendable balances).
- Reference page: the "When run" paragraph now includes the transaction import in its description of the pipeline.

## Test evidence

Documentation only; `mdbook build book` succeeds.

Stacked on #845.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1