### PR TITLE
book: document migrating a passphrase-encrypted wallet.dat

### DIFF
--- a/book/src/cli/migrate-zcashd-wallet.md
+++ b/book/src/cli/migrate-zcashd-wallet.md
@@ -101,6 +101,24 @@ recommended choice; a `zcashd`-provided `db_dump` from the `zcutil/bin`
 directory of a source installation (via `--zcashd-install-dir`), or one on the
 system `$PATH`, are used otherwise.
 
+## Encrypted wallets
+
+A `wallet.dat` whose key material was encrypted with `zcashd`'s `encryptwallet`
+can be migrated as-is; nothing needs to be done in `zcashd` first. When the
+command finds encrypted key material it prompts on the terminal:
+
+```
+Enter the passphrase for the encrypted zcashd wallet:
+```
+
+This is the `zcashd` wallet passphrase (the one `walletpassphrase` took), not
+the passphrase of your age encryption identity. A wrong passphrase is reported
+and the prompt repeats; after three wrong attempts the command fails without
+having written anything. Because the prompt is interactive, run this step in a
+terminal rather than under a service manager. The decrypted keys are used only
+for the duration of the migration and are stored in Zallet's keystore
+encrypted to your age identity.
+
 ## How the wallet birthday is chosen
 
 Every imported account gets the same birthday, and the post-migration scan

--- a/book/src/zcashd/README.md
+++ b/book/src/zcashd/README.md
@@ -55,6 +55,9 @@ you need.
    This imports the wallet's key material and creates corresponding Zallet accounts. If
    you have several `wallet.dat` files, run it once per file (subsequent runs need
    `--allow-multiple-wallet-imports`); each wallet becomes a distinct set of accounts.
+   If the wallet's key material is encrypted, the command prompts for the `zcashd`
+   wallet passphrase; see
+   [Encrypted wallets](../cli/migrate-zcashd-wallet.md#encrypted-wallets).
 
    **Decide before the first run whether to pass `--allow-partial-import`.** Without it,
    the migration fails if any account or transparent spending key could not be imported,


### PR DESCRIPTION
Closes #827.

## Motivation

The interactive passphrase prompt for encrypted `wallet.dat` files (`migrate_zcashd_wallet.rs:184-211`) is documented only in the 0.1.0-beta.1 CHANGELOG entry.

## Solution

Adds an "Encrypted wallets" section to `book/src/cli/migrate-zcashd-wallet.md`: the prompt appears only when the wallet's key material is encrypted, three attempts are allowed before the command fails, nothing needs to be done in `zcashd` first, and the passphrase is the `zcashd` wallet passphrase rather than the age identity passphrase. A short pointer is added to step 5 of the guide.

## Test evidence

Documentation only; `mdbook build book` succeeds.

Stacked on #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1