### PR TITLE
book: route zcashd users to the migration guide from the quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ contacting us in the `#wallet-dev` channel of the
 ## Usage
 
 See the [user guide](https://zcash.github.io/zallet/) for information on how to set up a Zallet wallet.
+If you are migrating from `zcashd`, start with the
+[migration guide](https://zcash.github.io/zallet/zcashd/index.html).
 
 ## Reproducible Builds
 

--- a/book/src/README.md
+++ b/book/src/README.md
@@ -1,7 +1,8 @@
 # Introduction
 
 Zallet is a full-node Zcash wallet written in Rust. It is being built as a replacement for
-the [`zcashd`] wallet.
+the [`zcashd`] wallet. If you run a `zcashd` wallet today, start with
+[Migrating from `zcashd`](zcashd/README.md).
 
 [`zcashd`]: https://github.com/zcash/zcash
 

--- a/book/src/guide/first-wallet.md
+++ b/book/src/guide/first-wallet.md
@@ -4,6 +4,10 @@ This tutorial continues from [Wallet setup](setup.md): it assumes `zallet
 start` is running and you have generated a mnemonic. You will create an
 account, receive funds, and send them onward.
 
+If your wallet came from a [`zcashd` migration](../zcashd/README.md), it
+already has accounts: skip step 2 and pick one from the output of
+`zallet rpc z_listaccounts` instead.
+
 All commands below use [`zallet rpc`](../cli/rpc.md). Remember its quoting
 rule: parameters must be valid JSON, so strings need shell-quoted double
 quotes (`'"like this"'`).

--- a/book/src/guide/setup.md
+++ b/book/src/guide/setup.md
@@ -3,6 +3,11 @@
 > WARNING: This process is currently unstable, very manual, and subject to change as we
 > make Zallet easier to use.
 
+> **Migrating from `zcashd`?** Follow [Migrating from `zcashd`](../zcashd/README.md)
+> instead of this page. It covers the same setup in the right order for an existing
+> wallet; in particular, do **not** generate a new mnemonic (below) for a wallet you
+> intend to import.
+
 ## Create a config file
 
 Zallet by default uses `$HOME/.zallet` as its data directory. You can override
@@ -177,6 +182,11 @@ $ zallet -d /path/to/zallet/datadir init-wallet-encryption
 > [Reference](../cli/init-wallet-encryption.md)
 
 ## Generate a mnemonic phrase
+
+Skip this step if you are importing a `zcashd` wallet:
+[`zallet migrate-zcashd-wallet`](../cli/migrate-zcashd-wallet.md) brings the wallet's
+own mnemonic across, and generating one here would add an unrelated second root of
+spend authority.
 
 ```
 $ zallet -d /path/to/zallet/datadir generate-mnemonic


### PR DESCRIPTION
Closes #829.

## Motivation

Nothing on the quickstart path (`guide/setup.md`, `guide/first-wallet.md`, the book intro, the repository README) links to `zcashd/README.md`, so a migrating user following the docs in order generates a new mnemonic instead of importing their wallet.

## Solution

- `guide/setup.md`: a note at the top sending `zcashd` users to the migration guide, and a sentence at "Generate a mnemonic phrase" saying to skip it when migrating.
- `guide/first-wallet.md`: the intro says a migrated wallet already has accounts, so step 2 can be replaced by `z_listaccounts`.
- `book/src/README.md` and the repository `README.md`: a link to the migration guide next to the existing mention of `zcashd`.

This PR is based on `main` and does not touch the runbook pages.

## Test evidence

Documentation only; `mdbook build book` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bxtXYNVkMSE8RkZZGC9H1